### PR TITLE
feat: highlight default namespace in red

### DIFF
--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -57,7 +57,7 @@
     {{- else }}
         {{- .Kind | cyan | bold }}/{{ .Name | cyan }}
     {{- end }}
-    {{- with .Namespace }} -n {{ . }}{{ end }}
+    {{- with .Namespace }} -n {{ if eq . "default" }}{{ . | red }}{{ else }}{{ . }}{{ end }}{{ end }}
     {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- if .Metadata.ownerReferences }} by {{ range $index, $ownerReference := .Metadata.ownerReferences }}
         {{- if $index }},{{ end }}{{ $ownerReference.kind | bold }}/{{ $ownerReference.name }}


### PR DESCRIPTION
## Summary

- Highlights the "default" namespace in red in the status summary line
- Uses the existing `red` template function with an `eq` conditional
- Template-only change (1 line in `common.tmpl`)
- All existing template tests pass

Closes #338

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./pkg/plugin/ -run Template` passes
- [ ] Verify visually that resources in "default" namespace show the namespace in red
- [ ] Resources in other namespaces display normally (no color change)