### PR TITLE
Enable shell completion for positional arguments (resource types and names)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Initialize all known client auth plugins.
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/completion"
 
 	"github.com/bergerx/kubectl-status/pkg/plugin"
 )
@@ -94,6 +95,7 @@ func RootCmd() *cobra.Command {
 	configFlags := initFlags(cmd)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	f := cmdutil.NewFactory(configFlags)
+	cmd.ValidArgsFunction = completion.ResourceTypeAndNameCompletionFunc(f)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		klog.V(5).InfoS("running the cobra.Command ...")
 		var err error


### PR DESCRIPTION
## Summary

- Registers `completion.ResourceTypeAndNameCompletionFunc` from `k8s.io/kubectl/pkg/util/completion` as `ValidArgsFunction` on the root command
- Enables tab completion for positional arguments, matching the behaviour of `kubectl get`:
  - `kubectl status <TAB>` → all resource types
  - `kubectl status pods <TAB>` → pod names in the current namespace
  - `kubectl status pod/my-p<TAB>` → `<type>/<name>` form
  - Multiple resources on the same line (already-used names are excluded)
- Flag completion was already working; this adds the missing positional argument completion
- Works for any binary name (e.g. a manual `kubectl-st` symlink) since cobra's `__complete` protocol is binary-name-agnostic

Closes #296

## Test plan

- [ ] Build binary and symlink/install as `kubectl-status` in PATH
- [ ] Verify `kubectl status <TAB>` returns resource types
- [ ] Verify `kubectl status pods <TAB>` returns pod names
- [ ] Verify `kubectl status pod/<TAB>` completes resource names in `type/name` form
- [ ] Verify a `kubectl-st` symlink also gets completions (`kubectl st <TAB>`)
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)