### PR TITLE
Fix HPA template: nil lastScaleTime crash + autoscaling/v2 rewrite

### DIFF
--- a/pkg/plugin/templates/HorizontalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/HorizontalPodAutoscaler.tmpl
@@ -1,11 +1,86 @@
 {{- define "HorizontalPodAutoscaler" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "status_summary_line" . }} last scale was {{ .Status.lastScaleTime | colorAgo }}{{ agoSuffix }}
+    {{- /* GVK: autoscaling/v2, Kind=HorizontalPodAutoscaler */ -}}
+    {{- template "status_summary_line" . }}{{- with .Status.lastScaleTime }}, last scaled {{ . | colorAgo }}{{ agoSuffix }}{{- end }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
-    {{- "current" | bold | nindent 2 }} replicas:{{ .Status.currentReplicas }}/({{ .Spec.minReplicas | default "1" }}-{{ .Spec.maxReplicas }})
-    {{- if .Status.currentCPUUtilizationPercentage }} CPUUtilisation: {{ .Status.currentCPUUtilizationPercentage | toString | redIf (ge .Status.currentCPUUtilizationPercentage .Spec.targetCPUUtilizationPercentage) }}%/{{ .Spec.targetCPUUtilizationPercentage }}%{{ end }}
-    {{- if (ne .Status.currentReplicas .Status.desiredReplicas) }}, {{ "desired" | red | bold}}: {{ .Status.currentReplicas }} --> {{ .Status.desiredReplicas }}{{ end }}
+    {{- template "observed_generation_summary" . }}
+    {{- with .Spec.scaleTargetRef }}
+        {{- if $.Config.GetBool "deep" }}
+            {{- $obj := $.KubeGetFirst $.Namespace (.kind | default "Deployment") .name }}
+            {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
+        {{- else }}
+            {{- "Scales" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "namespace" $.Namespace) }}
+        {{- end }}
+    {{- end }}
+    {{- $minReplicas := 1 }}{{- if hasKey .Spec "minReplicas" }}{{- $minReplicas = .Spec.minReplicas | int }}{{- end }}
+    {{- $current := .Status.currentReplicas | default 0 | int }}
+    {{- $desired := .Status.desiredReplicas | default 0 | int }}
+    {{- "Replicas" | bold | nindent 2 }}: {{ printf "%d" $current | redBoldIf (ne $current $desired) }}/{{ printf "%d-%d" $minReplicas (.Spec.maxReplicas | int) }}
+    {{- if ne $current $desired }}, {{ "desired" | yellow | bold }}: {{ printf "%d" $desired | yellow }}{{ end }}
+    {{- with .Spec.metrics }}
+        {{- "Metrics" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- $spec := . }}
+            {{- $cur := dict }}
+            {{- range $.Status.currentMetrics }}
+                {{- if eq .type $spec.type }}
+                    {{- if eq .type "Resource" }}{{ if eq .resource.name $spec.resource.name }}{{ $cur = . }}{{ end }}{{ end }}
+                    {{- if eq .type "ContainerResource" }}{{ if and (eq .containerResource.name $spec.containerResource.name) (eq .containerResource.container $spec.containerResource.container) }}{{ $cur = . }}{{ end }}{{ end }}
+                    {{- if eq .type "Pods" }}{{ if eq .pods.metric.name $spec.pods.metric.name }}{{ $cur = . }}{{ end }}{{ end }}
+                    {{- if eq .type "Object" }}{{ if eq .object.metric.name $spec.object.metric.name }}{{ $cur = . }}{{ end }}{{ end }}
+                    {{- if eq .type "External" }}{{ if eq .external.metric.name $spec.external.metric.name }}{{ $cur = . }}{{ end }}{{ end }}
+                {{- end }}
+            {{- end }}
+            {{- if eq .type "Resource" }}
+                {{- $target := .resource.target }}
+                {{- .resource.name | nindent 4 }}:
+                {{- if eq $target.type "Utilization" }}
+                    {{- $targetUtil := $target.averageUtilization | int }}
+                    {{- if hasKey ($cur.resource.current | default dict) "averageUtilization" }}
+                        {{- $curUtil := $cur.resource.current.averageUtilization | int }}
+                        {{- $curUtil | toString | redIf (ge $curUtil $targetUtil) }}%/
+                    {{- end }}{{ $targetUtil | toString }}%
+                {{- else if eq $target.type "AverageValue" }}
+                    {{- with ($cur.resource.current | default dict).averageValue }}{{ . | cyan }}/{{ end }}{{ $target.averageValue | cyan }}
+                {{- else }}
+                    {{- with ($cur.resource.current | default dict).value }}{{ . | cyan }}/{{ end }}{{ $target.value | cyan }}
+                {{- end }}
+            {{- else if eq .type "ContainerResource" }}
+                {{- $target := .containerResource.target }}
+                {{- printf "%s[%s]" .containerResource.name .containerResource.container | nindent 4 }}:
+                {{- if eq $target.type "Utilization" }}
+                    {{- $targetUtil := $target.averageUtilization | int }}
+                    {{- if hasKey ($cur.containerResource.current | default dict) "averageUtilization" }}
+                        {{- $curUtil := $cur.containerResource.current.averageUtilization | int }}
+                        {{- $curUtil | toString | redIf (ge $curUtil $targetUtil) }}%/
+                    {{- end }}{{ $targetUtil | toString }}%
+                {{- else if eq $target.type "AverageValue" }}
+                    {{- with ($cur.containerResource.current | default dict).averageValue }}{{ . | cyan }}/{{ end }}{{ $target.averageValue | cyan }}
+                {{- else }}
+                    {{- with ($cur.containerResource.current | default dict).value }}{{ . | cyan }}/{{ end }}{{ $target.value | cyan }}
+                {{- end }}
+            {{- else if eq .type "Pods" }}
+                {{- .pods.metric.name | nindent 4 }}:
+                {{- with ($cur.pods.current | default dict).averageValue }}{{ . | cyan }}/{{ end }}{{ .pods.target.averageValue | cyan }} avg/pod
+            {{- else if eq .type "Object" }}
+                {{- printf "%s/%s %s" .object.describedObject.kind .object.describedObject.name .object.metric.name | nindent 4 }}:
+                {{- if eq (.object.target.type | default "Value") "AverageValue" }}
+                    {{- with ($cur.object.current | default dict).averageValue }}{{ . | cyan }}/{{ end }}{{ .object.target.averageValue | cyan }} avg
+                {{- else }}
+                    {{- with ($cur.object.current | default dict).value }}{{ . | cyan }}/{{ end }}{{ .object.target.value | cyan }}
+                {{- end }}
+            {{- else if eq .type "External" }}
+                {{- .external.metric.name | nindent 4 }}:
+                {{- if eq (.external.target.type | default "Value") "AverageValue" }}
+                    {{- with ($cur.external.current | default dict).averageValue }}{{ . | cyan }}/{{ end }}{{ .external.target.averageValue | cyan }} avg
+                {{- else }}
+                    {{- with ($cur.external.current | default dict).value }}{{ . | cyan }}/{{ end }}{{ .external.target.value | cyan }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
     {{- template "application_details" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -125,6 +125,86 @@ func TestSuspendTemplate(t *testing.T) {
 	}
 }
 
+func TestHorizontalPodAutoscalerTemplate(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]interface{}
+		want string
+	}{
+		{
+			name: "no lastScaleTime should not crash (issue #548)",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":              "my-hpa",
+					"creationTimestamp": "2024-01-01T00:00:00Z",
+				},
+				"spec": map[string]interface{}{
+					"maxReplicas": 10,
+					"scaleTargetRef": map[string]interface{}{
+						"kind": "Deployment",
+						"name": "my-app",
+					},
+				},
+				"status": map[string]interface{}{
+					"currentReplicas": 3,
+					"desiredReplicas": 3,
+				},
+			},
+			want: "Replicas",
+		},
+		{
+			name: "resource metric with utilization",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":              "my-hpa",
+					"creationTimestamp": "2024-01-01T00:00:00Z",
+				},
+				"spec": map[string]interface{}{
+					"maxReplicas": 10,
+					"scaleTargetRef": map[string]interface{}{
+						"kind": "Deployment",
+						"name": "my-app",
+					},
+					"metrics": []interface{}{
+						map[string]interface{}{
+							"type": "Resource",
+							"resource": map[string]interface{}{
+								"name": "cpu",
+								"target": map[string]interface{}{
+									"type":               "Utilization",
+									"averageUtilization": 80,
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]interface{}{
+					"currentReplicas": 3,
+					"desiredReplicas": 3,
+					"currentMetrics": []interface{}{
+						map[string]interface{}{
+							"type": "Resource",
+							"resource": map[string]interface{}{
+								"name": "cpu",
+								"current": map[string]interface{}{
+									"averageUtilization": 45,
+									"averageValue":       "450m",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "cpu",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkTemplate(t, "HorizontalPodAutoscaler", tt.obj, tt.want, true)
+		})
+	}
+}
+
 func TestOwnersTemplate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/tests/artifacts/hpa-at-max-replicas.out
+++ b/tests/artifacts/hpa-at-max-replicas.out
@@ -1,0 +1,9 @@
+
+HorizontalPodAutoscaler/my-app -n default, created 1m ago, last scaled 1m ago
+  Current: Resource is current
+  Scales: Deployment/my-app -n default
+  Replicas: 10/2-10
+  Metrics:
+    cpu:88%/70%
+  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited TooManyReplicas, the desired replica count is more than the maximum replica count for 1m

--- a/tests/artifacts/hpa-at-max-replicas.yaml
+++ b/tests/artifacts/hpa-at-max-replicas.yaml
@@ -1,0 +1,45 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: "2024-01-01T00:00:00Z"
+  name: my-app
+  namespace: default
+  resourceVersion: "55555"
+  uid: c3d4e5f6-a7b8-9012-cdef-123456789012
+spec:
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+status:
+  currentReplicas: 10
+  desiredReplicas: 10
+  lastScaleTime: "2024-01-01T02:00:00Z"
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 88
+        averageValue: 880m
+  conditions:
+  - lastTransitionTime: "2024-01-01T02:00:00Z"
+    message: the HPA was able to successfully calculate a replica count
+    reason: ValidMetricFound
+    status: "True"
+    type: ScalingActive
+  - lastTransitionTime: "2024-01-01T02:00:00Z"
+    message: the desired replica count is more than the maximum replica count
+    reason: TooManyReplicas
+    status: "True"
+    type: ScalingLimited
+  observedGeneration: 1

--- a/tests/artifacts/hpa-no-last-scale-time.out
+++ b/tests/artifacts/hpa-no-last-scale-time.out
@@ -1,0 +1,9 @@
+
+HorizontalPodAutoscaler/my-app -n default, created 1m ago
+  Current: Resource is current
+  Scales: Deployment/my-app -n default
+  Replicas: 3/2-10
+  Metrics:
+    cpu:45%/70%
+  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited DesiredWithinRange, recommended size matches current size for 1m

--- a/tests/artifacts/hpa-no-last-scale-time.yaml
+++ b/tests/artifacts/hpa-no-last-scale-time.yaml
@@ -1,0 +1,44 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: "2024-01-01T00:00:00Z"
+  name: my-app
+  namespace: default
+  resourceVersion: "12345"
+  uid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+spec:
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+status:
+  currentReplicas: 3
+  desiredReplicas: 3
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 45
+        averageValue: 450m
+  conditions:
+  - lastTransitionTime: "2024-01-01T00:01:00Z"
+    message: the HPA was able to successfully calculate a replica count
+    reason: ValidMetricFound
+    status: "True"
+    type: ScalingActive
+  - lastTransitionTime: "2024-01-01T00:01:00Z"
+    message: recommended size matches current size
+    reason: DesiredWithinRange
+    status: "False"
+    type: ScalingLimited
+  observedGeneration: 1

--- a/tests/artifacts/hpa-scaling-up.out
+++ b/tests/artifacts/hpa-scaling-up.out
@@ -1,0 +1,10 @@
+
+HorizontalPodAutoscaler/my-app -n default, created 1m ago, last scaled 1m ago
+  Current: Resource is current
+  Scales: Deployment/my-app -n default
+  Replicas: 3/2-10, desired: 7
+  Metrics:
+    cpu:92%/70%
+    memory:480Mi/512Mi
+  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited DesiredWithinRange, the desired count is within the acceptable range for 1m

--- a/tests/artifacts/hpa-scaling-up.yaml
+++ b/tests/artifacts/hpa-scaling-up.yaml
@@ -1,0 +1,56 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: "2024-01-01T00:00:00Z"
+  name: my-app
+  namespace: default
+  resourceVersion: "99999"
+  uid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+spec:
+  maxReplicas: 10
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: AverageValue
+        averageValue: 512Mi
+status:
+  currentReplicas: 3
+  desiredReplicas: 7
+  lastScaleTime: "2024-01-01T01:00:00Z"
+  currentMetrics:
+  - type: Resource
+    resource:
+      name: cpu
+      current:
+        averageUtilization: 92
+        averageValue: 920m
+  - type: Resource
+    resource:
+      name: memory
+      current:
+        averageValue: 480Mi
+  conditions:
+  - lastTransitionTime: "2024-01-01T01:00:00Z"
+    message: the HPA was able to successfully calculate a replica count
+    reason: ValidMetricFound
+    status: "True"
+    type: ScalingActive
+  - lastTransitionTime: "2024-01-01T01:00:00Z"
+    message: the desired count is within the acceptable range
+    reason: DesiredWithinRange
+    status: "False"
+    type: ScalingLimited
+  observedGeneration: 1


### PR DESCRIPTION
## Summary

- Fixes #548: `colorAgo` received nil when `lastScaleTime` is absent (HPA never scaled), causing `invalid value; expected string` at render time
- Rewrites the template for `autoscaling/v2`, replacing the deprecated v1 `currentCPUUtilizationPercentage` fields with a merged `spec.metrics` / `status.currentMetrics` block
- Adds `conditions_summary` and `observed_generation_summary` (standard sub-templates previously missing from HPA)

## Changes

**Bug fix**
- `lastScaleTime` is now wrapped in `{{- with }}` so nil values are skipped cleanly

**New output**
- `Scales: Deployment/name -n ns` — shows `scaleTargetRef`; `--deep` renders the target inline
- `Replicas: 3/2-10` — current/min-max, current turns red when diverging from desired
- `Metrics:` block — merges spec targets with live current values for all metric types (Resource, ContainerResource, Pods, Object, External); utilization % turns red at or above target
- `minReplicas` now uses `hasKey .Spec "minReplicas"` with integer default 1 (fixes old `| default "1"` string bug)

## Test plan

- [ ] `kubectl status hpa <name>` on an HPA that has never scaled (no `lastScaleTime`) — should no longer crash
- [ ] `kubectl status hpa <name>` on an active HPA — verify Replicas + Metrics block renders correctly
- [ ] `kubectl status hpa <name> --deep` — verify scaleTargetRef is rendered inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)