### PR TITLE
Rewrite Job and CronJob templates for batch/v1 and modern K8s APIs

### DIFF
--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -1,9 +1,22 @@
 {{- define "CronJob" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: batch/v1, Kind=CronJob */ -}}
     {{- template "status_summary_line" . }}
-    {{- if .Status.lastScheduleTime }}, last ran at {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
+    {{- with .Spec.schedule }}, schedule: {{ . | cyan }}{{ with $.Spec.timeZone }} [{{ . | cyan }}]{{ end }}{{ end }}
+    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}
+    {{- else if .Status.lastScheduleTime }}, last ran at {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
     {{- else }}
         {{- "Not yet scheduled" | yellow | bold | nindent 2 }}
+    {{- end }}
+    {{- if and .Status.lastSuccessfulTime .Status.lastScheduleTime }}
+        {{- if lt .Status.lastSuccessfulTime .Status.lastScheduleTime }}
+            {{- "Last succeeded" | nindent 2 }}: {{ .Status.lastSuccessfulTime | colorAgo }}{{ agoSuffix }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec.concurrencyPolicy }}
+        {{- if ne . "Allow" }}
+            {{- printf "Concurrency: %s" . | yellow | nindent 2 }}
+        {{- end }}
     {{- end }}
     {{- with .Status.active }}
         {{- range . }}

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -3,9 +3,9 @@
     {{- /* GVK: batch/v1, Kind=CronJob */ -}}
     {{- template "status_summary_line" . }}
     {{- with .Spec.schedule }}, schedule: {{ . | cyan }}{{ with $.Spec.timeZone }} [{{ . | cyan }}]{{ end }}{{ end }}
-    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}
-    {{- else if .Status.lastScheduleTime }}, last ran at {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
-    {{- else }}
+    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}{{ end }}
+    {{- if .Status.lastScheduleTime }}, last ran at {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
+    {{- else if not .Spec.suspend }}
         {{- "Not yet scheduled" | yellow | bold | nindent 2 }}
     {{- end }}
     {{- if and .Status.lastSuccessfulTime .Status.lastScheduleTime }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -3,17 +3,15 @@
     {{- /* GVK: batch/v1, Kind=Job */ -}}
     {{- template "status_summary_line" . }}
     {{- if .Status.startTime }}, started at {{ .Status.startTime }}{{ relativeTime .Status.startTime }}{{ end }}
-    {{- if .Status.completionTime }}
+    {{- if and .Status.startTime .Status.completionTime }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $ranfor := $completed.Sub $started }} and {{ "completed" | green }} in {{ $ranfor | colorDuration }}
     {{- end }}
-    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}
-    {{- else }}
-        {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
-        {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
-        {{- if .Status.failed }}, {{ "Failed" | red | bold }}{{ end }}
-    {{- end }}
+    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}{{ end }}
+    {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
+    {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
+    {{- if .Status.failed }}, {{ printf "Failed: %d" (.Status.failed | int) | red | bold }}{{ with .Spec.backoffLimit }}/{{ . | toString }}{{ end }}{{ end }}
     {{- if eq (.Spec.completionMode | default "NonIndexed") "Indexed" }}
         {{- template "job_indexed_details" . }}
     {{- else }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -25,6 +25,24 @@
             {{- printf "replacement: %s" . | yellow | nindent 2 }}
         {{- end }}
     {{- end }}
+    {{- if and .Status.failed (not ($.Config.GetBool "shallow")) }}
+        {{- $failedPods := list }}
+        {{- range $.KubeGetByLabelsMap $.Namespace "pods" (dict "job-name" .Name) }}
+            {{- if eq .Status.phase "Failed" }}
+                {{- $failedPods = append $failedPods . }}
+            {{- end }}
+        {{- end }}
+        {{- with $failedPods }}
+            {{- "Failed pods" | red | bold | nindent 2 }}:
+            {{- range . }}
+                {{- if $.Config.GetBool "deep" }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- else }}
+                    {{- $.Include "job_failed_pod_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
     {{- template "conditions_summary" . }}
@@ -32,6 +50,20 @@
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
+{{- end -}}
+
+{{- define "job_failed_pod_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- .Name | bold }}
+    {{- range .Status.containerStatuses }}
+        {{- with .state.terminated }}
+            {{- if ne (.reason | default "") "Completed" }}
+                {{- ": " }}{{ .reason | default "Error" | colorKeyword }}
+                {{- if .exitCode }}, exit {{ .exitCode | toString | cyan }}{{ end }}
+                {{- with .message }}, {{ . | trim | red }}{{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "job_indexed_details" }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -1,15 +1,29 @@
 {{- define "Job" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: batch/v1, Kind=Job */ -}}
     {{- template "status_summary_line" . }}
-    {{- /* See https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#parallel-jobs */ -}}
-    {{- if eq (coalesce .Spec.completions .Spec.parallelism 1 | toString) "1" }}
-        {{- template "job_non_parallel" . }}
-    {{- else if .Spec.completions }}
-        {{- /* TODO: handle "fixed completion count jobs" better */ -}}
-        {{- template "job_parallel" . }}
-    {{- else if .Spec.parallelism }}
-        {{- /* TODO: handle "work queue jobs" better */ -}}
-        {{- template "job_parallel" . }}
+    {{- if .Status.startTime }}, started at {{ .Status.startTime }}{{ relativeTime .Status.startTime }}{{ end }}
+    {{- if .Status.completionTime }}
+        {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- $ranfor := $completed.Sub $started }} and {{ "completed" | green }} in {{ $ranfor | colorDuration }}
+    {{- end }}
+    {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}
+    {{- else }}
+        {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
+        {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
+        {{- if .Status.failed }}, {{ "Failed" | red | bold }}{{ end }}
+    {{- end }}
+    {{- if eq (.Spec.completionMode | default "NonIndexed") "Indexed" }}
+        {{- template "job_indexed_details" . }}
+    {{- else }}
+        {{- if and .Status.active .Status.ready }}, {{ .Status.ready | toString | cyan }} ready{{ end }}
+        {{- with .Status.terminating }}, {{ . | toString | cyan }} terminating{{ end }}
+    {{- end }}
+    {{- with .Spec.podReplacementPolicy }}
+        {{- if ne . "TerminatingOrFailed" }}
+            {{- printf "replacement: %s" . | yellow | nindent 2 }}
+        {{- end }}
     {{- end }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
@@ -20,15 +34,17 @@
     {{- template "owners" . }}
 {{- end -}}
 
-{{- define "job_non_parallel" }}
+{{- define "job_indexed_details" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
-    {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
-    {{- if .Status.failed }}, {{ "Failed" | red | bold }}{{ end }}
-{{- end -}}
-
-{{- define "job_parallel" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
-    {{- if .Status.failed }}, {{ "Failed" | red | bold }} {{ .Status.failed }}/{{ .Spec.backoffLimit }} times.{{ end }}
+    {{- $total := .Spec.completions | int }}
+    {{- $succeeded := coalesce .Status.succeeded 0 | int }}
+    {{- printf "Indexed: %d/%d" $succeeded $total | bold | nindent 2 }}
+    {{- with .Status.completedIndexes }} ({{ . | cyan }}){{ end }}
+    {{- if .Status.active }}, {{ .Status.active | toString | cyan }} active{{ end }}
+    {{- if .Status.ready }}, {{ .Status.ready | toString | cyan }} ready{{ end }}
+    {{- with .Status.terminating }}, {{ . | toString | cyan }} terminating{{ end }}
+    {{- with .Status.failedIndexes }}
+        {{- printf "Failed indexes: %s" . | red | bold | nindent 2 }}
+        {{- with $.Spec.backoffLimitPerIndex }} (limit: {{ . | toString | cyan }} per index){{ end }}
+    {{- end }}
 {{- end -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -73,7 +73,7 @@
         {{- $startedIn := $started.Sub $created}}
         {{- if gt ($startedIn.Seconds | int) 0 }}, started after {{ $startedIn.Seconds | ago }}{{ end }}
     {{- end }}
-    {{- if and .Status.completionTime (ne .Kind "Job") }}
+    {{- if and .Status.startTime .Status.completionTime (ne .Kind "Job") }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $ranfor := $completed.Sub $started }} and {{ "completed" | green }} in {{ $ranfor | colorDuration }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -67,13 +67,13 @@
         {{- if $index }},{{ end }}{{ $ownerReference.kind | bold }}/{{ $ownerReference.name }}
     {{- end }}{{ end }}
     {{- with .Metadata.generation }}, gen:{{ . }}{{ end }}
-    {{- if .Status.startTime }}
+    {{- if and .Status.startTime (ne .Kind "Job") }}
         {{- $created := .Metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z" }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" }}
         {{- $startedIn := $started.Sub $created}}
         {{- if gt ($startedIn.Seconds | int) 0 }}, started after {{ $startedIn.Seconds | ago }}{{ end }}
     {{- end }}
-    {{- if .Status.completionTime }}
+    {{- if and .Status.completionTime (ne .Kind "Job") }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
         {{- $ranfor := $completed.Sub $started }} and {{ "completed" | green }} in {{ $ranfor | colorDuration }}

--- a/tests/artifacts/cronjob-last-failed.out
+++ b/tests/artifacts/cronjob-last-failed.out
@@ -1,0 +1,5 @@
+
+CronJob/hello -n default, created 1m ago, gen:3, schedule: */1 * * * *, last ran at 2026-06-29T01:35:00Z (1m ago)
+  Last succeeded: 1m ago
+  Active: Job/hello-29711615 is running.
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-last-failed.yaml
+++ b/tests/artifacts/cronjob-last-failed.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo Hello from the Kubernetes cluster"],"image":"busybox:1.36","name":"hello"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T01:28:09Z"
+  generation: 3
+  name: hello
+  namespace: default
+  resourceVersion: "209451"
+  uid: 5696c5c4-6a70-496c-ad29-1d4c89c3d51b
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - exit 1
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: hello
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status:
+  active:
+  - apiVersion: batch/v1
+    kind: Job
+    name: hello-29711615
+    namespace: default
+    resourceVersion: "209450"
+    uid: cceb76b0-9edf-4b63-b89a-fd0a5c8a7213
+  lastScheduleTime: "2026-06-29T01:35:00Z"
+  lastSuccessfulTime: "2026-06-29T01:34:11Z"

--- a/tests/artifacts/cronjob-regular-active.out
+++ b/tests/artifacts/cronjob-regular-active.out
@@ -1,4 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, last ran at 2020-03-18T00:47:00Z (1m ago)
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:47:00Z (1m ago)
   Active: Job/hello-1584492420 is running.
   Current: Resource is always ready

--- a/tests/artifacts/cronjob-regular-new.out
+++ b/tests/artifacts/cronjob-regular-new.out
@@ -1,4 +1,4 @@
 
-CronJob/hello -n default, created 1m ago
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *
   Not yet scheduled
   Current: Resource is always ready

--- a/tests/artifacts/cronjob-regular-scheduled-and-active.out
+++ b/tests/artifacts/cronjob-regular-scheduled-and-active.out
@@ -1,4 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, last ran at 2020-03-18T00:48:00Z (1m ago)
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:48:00Z (1m ago)
   Active: Job/hello-1584492480 is running.
   Current: Resource is always ready

--- a/tests/artifacts/cronjob-regular-scheduled.out
+++ b/tests/artifacts/cronjob-regular-scheduled.out
@@ -1,3 +1,3 @@
 
-CronJob/hello -n default, created 1m ago, last ran at 2020-03-18T00:47:00Z (1m ago)
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:47:00Z (1m ago)
   Current: Resource is always ready

--- a/tests/artifacts/cronjob-simple-active.out
+++ b/tests/artifacts/cronjob-simple-active.out
@@ -1,0 +1,3 @@
+
+CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T01:31:00Z (1m ago)
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-simple-active.yaml
+++ b/tests/artifacts/cronjob-simple-active.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo Hello from the Kubernetes cluster"],"image":"busybox:1.36","name":"hello"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T01:28:09Z"
+  generation: 1
+  name: hello
+  namespace: default
+  resourceVersion: "209005"
+  uid: 5696c5c4-6a70-496c-ad29-1d4c89c3d51b
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: hello
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status:
+  lastScheduleTime: "2026-06-29T01:31:00Z"
+  lastSuccessfulTime: "2026-06-29T01:31:43Z"

--- a/tests/artifacts/cronjob-simple-live.out
+++ b/tests/artifacts/cronjob-simple-live.out
@@ -1,0 +1,3 @@
+
+CronJob/cronjob-simple -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T02:41:00Z (1m ago)
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-simple-live.yaml
+++ b/tests/artifacts/cronjob-simple-live.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"cronjob-simple","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["sh","-c","echo done"],"image":"busybox","name":"worker"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T02:31:42Z"
+  generation: 1
+  name: cronjob-simple
+  namespace: default
+  resourceVersion: "216824"
+  uid: 8d566fc1-f876-4229-9986-26974e004178
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - echo done
+            image: busybox
+            imagePullPolicy: Always
+            name: worker
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status:
+  lastScheduleTime: "2026-06-29T02:41:00Z"
+  lastSuccessfulTime: "2026-06-29T02:41:20Z"

--- a/tests/artifacts/cronjob-simple-new.out
+++ b/tests/artifacts/cronjob-simple-new.out
@@ -1,0 +1,4 @@
+
+CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *
+  Not yet scheduled
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-simple-new.yaml
+++ b/tests/artifacts/cronjob-simple-new.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo Hello from the Kubernetes cluster"],"image":"busybox:1.36","name":"hello"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T01:28:09Z"
+  generation: 1
+  name: hello
+  namespace: default
+  resourceVersion: "208438"
+  uid: 5696c5c4-6a70-496c-ad29-1d4c89c3d51b
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: hello
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status: {}

--- a/tests/artifacts/cronjob-simple-scheduled.out
+++ b/tests/artifacts/cronjob-simple-scheduled.out
@@ -1,0 +1,5 @@
+
+CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T01:31:00Z (1m ago)
+  Last succeeded: 1m ago
+  Active: Job/hello-29711611 is running.
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-simple-scheduled.yaml
+++ b/tests/artifacts/cronjob-simple-scheduled.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo Hello from the Kubernetes cluster"],"image":"busybox:1.36","name":"hello"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T01:28:09Z"
+  generation: 1
+  name: hello
+  namespace: default
+  resourceVersion: "208872"
+  uid: 5696c5c4-6a70-496c-ad29-1d4c89c3d51b
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: hello
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status:
+  active:
+  - apiVersion: batch/v1
+    kind: Job
+    name: hello-29711611
+    namespace: default
+    resourceVersion: "208868"
+    uid: 0b7a0efa-a8f2-4588-9a38-620f4afa521a
+  lastScheduleTime: "2026-06-29T01:31:00Z"
+  lastSuccessfulTime: "2026-06-29T01:30:52Z"

--- a/tests/artifacts/cronjob-suspended.out
+++ b/tests/artifacts/cronjob-suspended.out
@@ -1,3 +1,3 @@
 
-CronJob/hello -n default, created 1m ago, gen:2, schedule: */1 * * * *, Suspended
+CronJob/hello -n default, created 1m ago, gen:2, schedule: */1 * * * *, Suspended, last ran at 2026-06-29T01:34:00Z (1m ago)
   Current: Resource is always ready

--- a/tests/artifacts/cronjob-suspended.out
+++ b/tests/artifacts/cronjob-suspended.out
@@ -1,0 +1,3 @@
+
+CronJob/hello -n default, created 1m ago, gen:2, schedule: */1 * * * *, Suspended
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-suspended.yaml
+++ b/tests/artifacts/cronjob-suspended.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo Hello from the Kubernetes cluster"],"image":"busybox:1.36","name":"hello"}],"restartPolicy":"OnFailure"}}}},"schedule":"*/1 * * * *"}}
+  creationTimestamp: "2026-06-29T01:28:09Z"
+  generation: 2
+  name: hello
+  namespace: default
+  resourceVersion: "209394"
+  uid: 5696c5c4-6a70-496c-ad29-1d4c89c3d51b
+spec:
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: hello
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: '*/1 * * * *'
+  successfulJobsHistoryLimit: 3
+  suspend: true
+status:
+  lastScheduleTime: "2026-06-29T01:34:00Z"
+  lastSuccessfulTime: "2026-06-29T01:34:11Z"

--- a/tests/artifacts/cronjob-tz.out
+++ b/tests/artifacts/cronjob-tz.out
@@ -1,0 +1,5 @@
+
+CronJob/cronjob-tz -n default, created 1m ago, gen:1, schedule: 30 9 * * 1-5 [Europe/Berlin]
+  Not yet scheduled
+  Concurrency: Forbid
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-tz.yaml
+++ b/tests/artifacts/cronjob-tz.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"cronjob-tz","namespace":"default"},"spec":{"concurrencyPolicy":"Forbid","jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["sh","-c","echo done"],"image":"busybox","name":"worker"}],"restartPolicy":"OnFailure"}}}},"schedule":"30 9 * * 1-5","timeZone":"Europe/Berlin"}}
+  creationTimestamp: "2026-06-29T02:31:48Z"
+  generation: 1
+  name: cronjob-tz
+  namespace: default
+  resourceVersion: "215380"
+  uid: ea4f8776-5742-41dd-8888-da9bd6d63f4f
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - sh
+            - -c
+            - echo done
+            image: busybox
+            imagePullPolicy: Always
+            name: worker
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 30 9 * * 1-5
+  successfulJobsHistoryLimit: 3
+  suspend: false
+  timeZone: Europe/Berlin
+status: {}

--- a/tests/artifacts/cronjob-with-timezone.out
+++ b/tests/artifacts/cronjob-with-timezone.out
@@ -1,0 +1,5 @@
+
+CronJob/morning-report -n default, created 1m ago, gen:1, schedule: 0 9 * * 1-5 [Europe/Berlin]
+  Not yet scheduled
+  Concurrency: Forbid
+  Current: Resource is always ready

--- a/tests/artifacts/cronjob-with-timezone.yaml
+++ b/tests/artifacts/cronjob-with-timezone.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"CronJob","metadata":{"annotations":{},"name":"morning-report","namespace":"default"},"spec":{"concurrencyPolicy":"Forbid","jobTemplate":{"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","date; echo morning standup"],"image":"busybox:1.36","name":"report"}],"restartPolicy":"OnFailure"}}}},"schedule":"0 9 * * 1-5","timeZone":"Europe/Berlin"}}
+  creationTimestamp: "2026-06-29T01:28:19Z"
+  generation: 1
+  name: morning-report
+  namespace: default
+  resourceVersion: "208453"
+  uid: 4cf5c2d7-6a06-4f01-a705-b15cd23aded6
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata: {}
+    spec:
+      template:
+        metadata: {}
+        spec:
+          containers:
+          - command:
+            - /bin/sh
+            - -c
+            - date; echo morning standup
+            image: busybox:1.36
+            imagePullPolicy: IfNotPresent
+            name: report
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          dnsPolicy: ClusterFirst
+          restartPolicy: OnFailure
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+  schedule: 0 9 * * 1-5
+  successfulJobsHistoryLimit: 3
+  suspend: false
+  timeZone: Europe/Berlin
+status: {}

--- a/tests/artifacts/job-active.out
+++ b/tests/artifacts/job-active.out
@@ -1,3 +1,3 @@
 
-Job/hello-1584493380 -n default, created 1m ago by CronJob/hello, Active
+Job/hello-1584493380 -n default, created 1m ago by CronJob/hello, started at 2020-03-18T01:03:07Z (1m ago), Active
   Current: Job in progress. success:0, active: 1, failed: 0

--- a/tests/artifacts/job-complete.out
+++ b/tests/artifacts/job-complete.out
@@ -1,4 +1,4 @@
 
-Job/hello-1584493380 -n default, created 1m ago by CronJob/hello and completed in 1m, Succeeded
+Job/hello-1584493380 -n default, created 1m ago by CronJob/hello, started at 2020-03-18T01:03:07Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
   Complete for 1m

--- a/tests/artifacts/job-fail-exit1.out
+++ b/tests/artifacts/job-fail-exit1.out
@@ -1,5 +1,5 @@
 
-Job/job-fail-exit1 -n default, created 1m ago, gen:1, started at 2026-06-29T02:31:34Z (1m ago), Failed
+Job/job-fail-exit1 -n default, created 1m ago, gen:1, started at 2026-06-29T02:31:34Z (1m ago), Failed: 2/1
   Failed: Job Failed. failed: 2/1
     Stalled: JobFailed, Job Failed. failed: 2/1
   FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-fail-exit1.out
+++ b/tests/artifacts/job-fail-exit1.out
@@ -1,0 +1,6 @@
+
+Job/job-fail-exit1 -n default, created 1m ago, gen:1, started at 2026-06-29T02:31:34Z (1m ago), Failed
+  Failed: Job Failed. failed: 2/1
+    Stalled: JobFailed, Job Failed. failed: 2/1
+  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-fail-exit1.yaml
+++ b/tests/artifacts/job-fail-exit1.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-fail-exit1","namespace":"default"},"spec":{"backoffLimit":1,"template":{"spec":{"containers":[{"command":["sh","-c","exit 1"],"image":"busybox","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T02:31:34Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+    batch.kubernetes.io/job-name: job-fail-exit1
+    controller-uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+    job-name: job-fail-exit1
+  name: job-fail-exit1
+  namespace: default
+  resourceVersion: "215470"
+  uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+spec:
+  backoffLimit: 1
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+        batch.kubernetes.io/job-name: job-fail-exit1
+        controller-uid: af35fc67-c2e1-4c6f-b3a5-6772a8117128
+        job-name: job-fail-exit1
+    spec:
+      containers:
+      - command:
+        - sh
+        - -c
+        - exit 1
+        image: busybox
+        imagePullPolicy: Always
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: "2026-06-29T02:32:17Z"
+    lastTransitionTime: "2026-06-29T02:32:17Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: FailureTarget
+  - lastProbeTime: "2026-06-29T02:32:17Z"
+    lastTransitionTime: "2026-06-29T02:32:17Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: Failed
+  failed: 2
+  ready: 0
+  startTime: "2026-06-29T02:31:34Z"
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-failed.out
+++ b/tests/artifacts/job-failed.out
@@ -1,5 +1,5 @@
 
-Job/job-failed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:23Z (1m ago), Failed
+Job/job-failed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:23Z (1m ago), Failed: 3/2
   Failed: Job Failed. failed: 3/1
     Stalled: JobFailed, Job Failed. failed: 3/1
   FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-failed.out
+++ b/tests/artifacts/job-failed.out
@@ -1,0 +1,6 @@
+
+Job/job-failed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:23Z (1m ago), Failed
+  Failed: Job Failed. failed: 3/1
+    Stalled: JobFailed, Job Failed. failed: 3/1
+  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-failed.yaml
+++ b/tests/artifacts/job-failed.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-failed","namespace":"default"},"spec":{"backoffLimit":2,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","exit 1"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:23Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+    batch.kubernetes.io/job-name: job-failed
+    controller-uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+    job-name: job-failed
+  name: job-failed
+  namespace: default
+  resourceVersion: "208997"
+  uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+spec:
+  backoffLimit: 2
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+        batch.kubernetes.io/job-name: job-failed
+        controller-uid: caf67de1-6b59-4912-9c41-a2a07e22a707
+        job-name: job-failed
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - exit 1
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: "2026-06-29T01:31:42Z"
+    lastTransitionTime: "2026-06-29T01:31:42Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: FailureTarget
+  - lastProbeTime: "2026-06-29T01:31:43Z"
+    lastTransitionTime: "2026-06-29T01:31:43Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: Failed
+  failed: 3
+  ready: 0
+  startTime: "2026-06-29T01:27:23Z"
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-from-cronjob-failed.out
+++ b/tests/artifacts/job-from-cronjob-failed.out
@@ -1,0 +1,6 @@
+
+Job/cronjob-failing-29711681 -n default, created 1m ago by CronJob/cronjob-failing, gen:1, started at 2026-06-29T02:41:00Z (1m ago), Failed
+  Failed: Job Failed. failed: 1/1
+    Stalled: JobFailed, Job Failed. failed: 1/1
+  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-from-cronjob-failed.out
+++ b/tests/artifacts/job-from-cronjob-failed.out
@@ -1,5 +1,5 @@
 
-Job/cronjob-failing-29711681 -n default, created 1m ago by CronJob/cronjob-failing, gen:1, started at 2026-06-29T02:41:00Z (1m ago), Failed
+Job/cronjob-failing-29711681 -n default, created 1m ago by CronJob/cronjob-failing, gen:1, started at 2026-06-29T02:41:00Z (1m ago), Failed: 1
   Failed: Job Failed. failed: 1/1
     Stalled: JobFailed, Job Failed. failed: 1/1
   FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-from-cronjob-failed.yaml
+++ b/tests/artifacts/job-from-cronjob-failed.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    batch.kubernetes.io/cronjob-scheduled-timestamp: "2026-06-29T02:41:00Z"
+  creationTimestamp: "2026-06-29T02:41:00Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+    batch.kubernetes.io/job-name: cronjob-failing-29711681
+    controller-uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+    job-name: cronjob-failing-29711681
+  name: cronjob-failing-29711681
+  namespace: default
+  ownerReferences:
+  - apiVersion: batch/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: CronJob
+    name: cronjob-failing
+    uid: b5711485-915b-42b6-bff8-1783653abcf7
+  resourceVersion: "216834"
+  uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+spec:
+  backoffLimit: 0
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+        batch.kubernetes.io/job-name: cronjob-failing-29711681
+        controller-uid: 358e650a-cd9b-4165-979d-38a6eea1c9e1
+        job-name: cronjob-failing-29711681
+    spec:
+      containers:
+      - command:
+        - sh
+        - -c
+        - exit 1
+        image: busybox
+        imagePullPolicy: Always
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: "2026-06-29T02:41:23Z"
+    lastTransitionTime: "2026-06-29T02:41:23Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: FailureTarget
+  - lastProbeTime: "2026-06-29T02:41:23Z"
+    lastTransitionTime: "2026-06-29T02:41:23Z"
+    message: Job has reached the specified backoff limit
+    reason: BackoffLimitExceeded
+    status: "True"
+    type: Failed
+  failed: 1
+  ready: 0
+  startTime: "2026-06-29T02:41:00Z"
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-indexed-backoff-active.out
+++ b/tests/artifacts/job-indexed-backoff-active.out
@@ -1,0 +1,5 @@
+
+Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Active, Succeeded, Failed
+  Indexed: 2/6 (1,3), 2 active
+  Failed indexes: 0,2 (limit: 1 per index)
+  Current: Job in progress. success:2, active: 2, failed: 4

--- a/tests/artifacts/job-indexed-backoff-active.out
+++ b/tests/artifacts/job-indexed-backoff-active.out
@@ -1,5 +1,5 @@
 
-Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Active, Succeeded, Failed
+Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Active, Succeeded, Failed: 4/2147483647
   Indexed: 2/6 (1,3), 2 active
   Failed indexes: 0,2 (limit: 1 per index)
   Current: Job in progress. success:2, active: 2, failed: 4

--- a/tests/artifacts/job-indexed-backoff-active.yaml
+++ b/tests/artifacts/job-indexed-backoff-active.yaml
@@ -1,0 +1,64 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-indexed-backoff","namespace":"default"},"spec":{"backoffLimitPerIndex":1,"completionMode":"Indexed","completions":6,"maxFailedIndexes":4,"parallelism":3,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","if [ $((JOB_COMPLETION_INDEX % 2)) -eq 0 ]; then exit 1; else exit 0; fi"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:53Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+    batch.kubernetes.io/job-name: job-indexed-backoff
+    controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+    job-name: job-indexed-backoff
+  name: job-indexed-backoff
+  namespace: default
+  resourceVersion: "208907"
+  uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+spec:
+  backoffLimit: 2147483647
+  backoffLimitPerIndex: 1
+  completionMode: Indexed
+  completions: 6
+  manualSelector: false
+  maxFailedIndexes: 4
+  parallelism: 3
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+        batch.kubernetes.io/job-name: job-indexed-backoff
+        controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+        job-name: job-indexed-backoff
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - if [ $((JOB_COMPLETION_INDEX % 2)) -eq 0 ]; then exit 1; else exit 0; fi
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  active: 2
+  completedIndexes: 1,3
+  failed: 4
+  failedIndexes: 0,2
+  ready: 0
+  startTime: "2026-06-29T01:27:54Z"
+  succeeded: 2
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-indexed-complete.out
+++ b/tests/artifacts/job-indexed-complete.out
@@ -1,0 +1,6 @@
+
+Job/job-indexed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:52Z (1m ago) and completed in 1m, Succeeded
+  Indexed: 5/5 (0-4)
+  Current: Job Completed. succeeded: 5/5
+  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-indexed-complete.yaml
+++ b/tests/artifacts/job-indexed-complete.yaml
@@ -1,0 +1,73 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-indexed","namespace":"default"},"spec":{"backoffLimit":6,"completionMode":"Indexed","completions":5,"parallelism":3,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","echo processing index $JOB_COMPLETION_INDEX"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:51Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+    batch.kubernetes.io/job-name: job-indexed
+    controller-uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+    job-name: job-indexed
+  name: job-indexed
+  namespace: default
+  resourceVersion: "208964"
+  uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+spec:
+  backoffLimit: 6
+  completionMode: Indexed
+  completions: 5
+  manualSelector: false
+  parallelism: 3
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+        batch.kubernetes.io/job-name: job-indexed
+        controller-uid: cd3c94f2-ad54-414c-a2a3-04372a07a138
+        job-name: job-indexed
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - echo processing index $JOB_COMPLETION_INDEX
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  completedIndexes: 0-4
+  completionTime: "2026-06-29T01:31:29Z"
+  conditions:
+  - lastProbeTime: "2026-06-29T01:31:29Z"
+    lastTransitionTime: "2026-06-29T01:31:29Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: SuccessCriteriaMet
+  - lastProbeTime: "2026-06-29T01:31:33Z"
+    lastTransitionTime: "2026-06-29T01:31:33Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: Complete
+  ready: 0
+  startTime: "2026-06-29T01:27:52Z"
+  succeeded: 5
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-indexed-partial-failure.out
+++ b/tests/artifacts/job-indexed-partial-failure.out
@@ -1,5 +1,5 @@
 
-Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Succeeded, Failed
+Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Succeeded, Failed: 6/2147483647
   Indexed: 3/6 (1,3,5)
   Failed indexes: 0,2,4 (limit: 1 per index)
   Failed: Job Failed. failed: 6/6

--- a/tests/artifacts/job-indexed-partial-failure.out
+++ b/tests/artifacts/job-indexed-partial-failure.out
@@ -1,0 +1,8 @@
+
+Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:54Z (1m ago), Succeeded, Failed
+  Indexed: 3/6 (1,3,5)
+  Failed indexes: 0,2,4 (limit: 1 per index)
+  Failed: Job Failed. failed: 6/6
+    Stalled: JobFailed, Job Failed. failed: 6/6
+  FailureTarget FailedIndexes, Job has failed indexes for 1m
+  Failed FailedIndexes, Job has failed indexes for 1m

--- a/tests/artifacts/job-indexed-partial-failure.yaml
+++ b/tests/artifacts/job-indexed-partial-failure.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-indexed-backoff","namespace":"default"},"spec":{"backoffLimitPerIndex":1,"completionMode":"Indexed","completions":6,"maxFailedIndexes":4,"parallelism":3,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","if [ $((JOB_COMPLETION_INDEX % 2)) -eq 0 ]; then exit 1; else exit 0; fi"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:53Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+    batch.kubernetes.io/job-name: job-indexed-backoff
+    controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+    job-name: job-indexed-backoff
+  name: job-indexed-backoff
+  namespace: default
+  resourceVersion: "209040"
+  uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+spec:
+  backoffLimit: 2147483647
+  backoffLimitPerIndex: 1
+  completionMode: Indexed
+  completions: 6
+  manualSelector: false
+  maxFailedIndexes: 4
+  parallelism: 3
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+        batch.kubernetes.io/job-name: job-indexed-backoff
+        controller-uid: 38092ea9-6527-4da0-9de7-922bb9ebc060
+        job-name: job-indexed-backoff
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - if [ $((JOB_COMPLETION_INDEX % 2)) -eq 0 ]; then exit 1; else exit 0; fi
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  completedIndexes: 1,3,5
+  conditions:
+  - lastProbeTime: "2026-06-29T01:31:57Z"
+    lastTransitionTime: "2026-06-29T01:31:57Z"
+    message: Job has failed indexes
+    reason: FailedIndexes
+    status: "True"
+    type: FailureTarget
+  - lastProbeTime: "2026-06-29T01:31:57Z"
+    lastTransitionTime: "2026-06-29T01:31:57Z"
+    message: Job has failed indexes
+    reason: FailedIndexes
+    status: "True"
+    type: Failed
+  failed: 6
+  failedIndexes: 0,2,4
+  ready: 0
+  startTime: "2026-06-29T01:27:54Z"
+  succeeded: 3
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-simple-complete.out
+++ b/tests/artifacts/job-simple-complete.out
@@ -1,0 +1,5 @@
+
+Job/job-simple -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:22Z (1m ago) and completed in 1m, Succeeded
+  Current: Job Completed. succeeded: 1/1
+  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-simple-complete.yaml
+++ b/tests/artifacts/job-simple-complete.yaml
@@ -1,0 +1,72 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-simple","namespace":"default"},"spec":{"backoffLimit":3,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","echo done"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:21Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: 8bce2b02-d489-4990-a700-4adf971124ae
+    batch.kubernetes.io/job-name: job-simple
+    controller-uid: 8bce2b02-d489-4990-a700-4adf971124ae
+    job-name: job-simple
+  name: job-simple
+  namespace: default
+  resourceVersion: "208621"
+  uid: 8bce2b02-d489-4990-a700-4adf971124ae
+spec:
+  backoffLimit: 3
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 8bce2b02-d489-4990-a700-4adf971124ae
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: 8bce2b02-d489-4990-a700-4adf971124ae
+        batch.kubernetes.io/job-name: job-simple
+        controller-uid: 8bce2b02-d489-4990-a700-4adf971124ae
+        job-name: job-simple
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - echo done
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  completionTime: "2026-06-29T01:29:36Z"
+  conditions:
+  - lastProbeTime: "2026-06-29T01:29:36Z"
+    lastTransitionTime: "2026-06-29T01:29:36Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: SuccessCriteriaMet
+  - lastProbeTime: "2026-06-29T01:29:40Z"
+    lastTransitionTime: "2026-06-29T01:29:40Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: Complete
+  ready: 0
+  startTime: "2026-06-29T01:27:22Z"
+  succeeded: 1
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-suspended.out
+++ b/tests/artifacts/job-suspended.out
@@ -1,0 +1,6 @@
+
+Job/job-suspended -n default, created 1m ago, gen:1, Suspended
+  Indexed: 0/5
+  InProgress: Job not started
+    Reconciling: JobNotStarted, Job not started
+  Suspended JobSuspended, Job suspended for 1m

--- a/tests/artifacts/job-suspended.yaml
+++ b/tests/artifacts/job-suspended.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-suspended","namespace":"default"},"spec":{"completionMode":"Indexed","completions":5,"suspend":true,"template":{"spec":{"containers":[{"command":["/bin/sh","-c","echo done"],"image":"busybox:1.36","name":"worker"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:23Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+    batch.kubernetes.io/job-name: job-suspended
+    controller-uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+    job-name: job-suspended
+  name: job-suspended
+  namespace: default
+  resourceVersion: "208346"
+  uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+spec:
+  backoffLimit: 6
+  completionMode: Indexed
+  completions: 5
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+  suspend: true
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+        batch.kubernetes.io/job-name: job-suspended
+        controller-uid: e5540bf0-ac5f-4d74-ba8f-f89c2fafa2d3
+        job-name: job-suspended
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - echo done
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: "2026-06-29T01:27:24Z"
+    lastTransitionTime: "2026-06-29T01:27:24Z"
+    message: Job suspended
+    reason: JobSuspended
+    status: "True"
+    type: Suspended
+  ready: 0
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/tests/artifacts/job-with-sidecar-complete.out
+++ b/tests/artifacts/job-with-sidecar-complete.out
@@ -1,0 +1,5 @@
+
+Job/job-with-sidecar -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:55Z (1m ago) and completed in 1m, Succeeded
+  Current: Job Completed. succeeded: 1/1
+  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-with-sidecar-complete.yaml
+++ b/tests/artifacts/job-with-sidecar-complete.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"batch/v1","kind":"Job","metadata":{"annotations":{},"name":"job-with-sidecar","namespace":"default"},"spec":{"template":{"spec":{"containers":[{"command":["/bin/sh","-c","sleep 8 \u0026\u0026 echo main done"],"image":"busybox:1.36","name":"main"}],"initContainers":[{"command":["/bin/sh","-c","while true; do echo sidecar; sleep 5; done"],"image":"busybox:1.36","name":"log-collector","restartPolicy":"Always"}],"restartPolicy":"Never"}}}}
+  creationTimestamp: "2026-06-29T01:27:54Z"
+  generation: 1
+  labels:
+    batch.kubernetes.io/controller-uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+    batch.kubernetes.io/job-name: job-with-sidecar
+    controller-uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+    job-name: job-with-sidecar
+  name: job-with-sidecar
+  namespace: default
+  resourceVersion: "208941"
+  uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+spec:
+  backoffLimit: 6
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/controller-uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+        batch.kubernetes.io/job-name: job-with-sidecar
+        controller-uid: b05ebff9-b34b-41ce-8d2b-de971a987fd1
+        job-name: job-with-sidecar
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - sleep 8 && echo main done
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - while true; do echo sidecar; sleep 5; done
+        image: busybox:1.36
+        imagePullPolicy: IfNotPresent
+        name: log-collector
+        resources: {}
+        restartPolicy: Always
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  completionTime: "2026-06-29T01:31:22Z"
+  conditions:
+  - lastProbeTime: "2026-06-29T01:31:22Z"
+    lastTransitionTime: "2026-06-29T01:31:22Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: SuccessCriteriaMet
+  - lastProbeTime: "2026-06-29T01:31:23Z"
+    lastTransitionTime: "2026-06-29T01:31:23Z"
+    message: Reached expected number of succeeded pods
+    reason: CompletionsReached
+    status: "True"
+    type: Complete
+  ready: 0
+  startTime: "2026-06-29T01:27:55Z"
+  succeeded: 1
+  terminating: 0
+  uncountedTerminatedPods: {}


### PR DESCRIPTION
## Summary

- **Job.tmpl**: ISO timestamp for `startTime` (matching CronJob style); Indexed mode shows per-index summary (`Indexed: X/Y (completed-ranges)`), failed indexes with `backoffLimitPerIndex` annotation, active/ready/terminating counts; `podReplacementPolicy` surfaced when non-default; `suspend` shown inline; failure count with backoff limit (`Failed: 3/2`); failed pod summaries in default mode (compact) and `--deep` mode (full inline render)
- **CronJob.tmpl**: `schedule` on first line with optional `[timeZone]`; `lastSuccessfulTime` shown only when older than `lastScheduleTime` (signals recent failures); `concurrencyPolicy` when non-default; `lastScheduleTime` shown even when suspended; `batch/v1` era (v1beta1 removed in 1.25)
- **common.tmpl**: `startTime`/`completionTime` in `status_summary_line` skip Job (Job.tmpl owns them); `completionTime` block guarded with `startTime` check

## Test plan

- [x] 13 new YAML+out artifact pairs captured from real minikube (k8s 1.35.1): simple-complete, failed, suspended, indexed-complete, indexed-partial-failure (backoffLimitPerIndex), indexed-backoff-active, with-sidecar-complete, cronjob-simple-{new,scheduled,active}, cronjob-{suspended,with-timezone,last-failed}
- [x] 4 additional artifacts captured this session: job-fail-exit1, job-from-cronjob-failed, cronjob-tz, cronjob-simple-live
- [x] Failed pod summaries validated live against minikube (default + --deep + --shallow modes)
- [x] `make test` passes

Closes #180
Partially addresses #177 (Job done; Deployment/StatefulSet/DaemonSet still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)