### PR TITLE
Add FlowSchema and PriorityLevelConfiguration templates (APF v1)

### DIFF
--- a/pkg/plugin/templates/FlowSchema.tmpl
+++ b/pkg/plugin/templates/FlowSchema.tmpl
@@ -1,0 +1,62 @@
+{{- define "FlowSchema" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: flowcontrol.apiserver.k8s.io/v1, Kind=FlowSchema */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- /* Dangling=True means the referenced PriorityLevelConfiguration is missing */}}
+    {{- range .Status.conditions }}
+        {{- if and (eq .type "Dangling") (eq .status "True") }}
+            {{- printf "PriorityLevelConfiguration/%s not found — matching requests will be rejected" $.Spec.priorityLevelConfiguration.name | red | bold | nindent 2 }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec }}
+        {{- $plcName := .priorityLevelConfiguration.name }}
+        {{- $prec := .matchingPrecedence | toString | cyan }}
+        {{- $plc := printf "PriorityLevelConfiguration/%s" $plcName | cyan }}
+        {{- "Assigns" | bold | nindent 2 }} precedence={{ $prec }} → {{ $plc }}
+        {{- with .distinguisherMethod }}, queue by {{ .type | cyan }}{{ end }}
+        {{- with .rules }}
+            {{- "Rules" | bold | nindent 2 }}:
+            {{- range . }}
+                {{- /* Render subjects as a compact comma-separated list */}}
+                {{- $subjects := list }}
+                {{- range .subjects }}
+                    {{- if eq .kind "Group" }}
+                        {{- $subjects = append $subjects (printf "group:%s" .group.name) }}
+                    {{- else if eq .kind "User" }}
+                        {{- $subjects = append $subjects (printf "user:%s" .user.name) }}
+                    {{- else if eq .kind "ServiceAccount" }}
+                        {{- $subjects = append $subjects (printf "sa:%s/%s" .serviceAccount.namespace .serviceAccount.name) }}
+                    {{- end }}
+                {{- end }}
+                {{- join ", " $subjects | cyan | nindent 4 }}
+                {{- range .resourceRules }}
+                    {{- $groups := join "," .apiGroups }}
+                    {{- $resources := join "," .resources }}
+                    {{- $verbs := join "," .verbs }}
+                    {{- $scope := "" }}
+                    {{- if .clusterScope }}{{ $scope = " cluster-scoped" }}{{ end }}
+                    {{- $ns := join "," (.namespaces | default (list "*")) }}
+                    {{- if ne $ns "*" }}{{ $scope = printf " ns=%s" $ns }}{{ end }}
+                    {{- printf "[%s] %s/%s%s" $verbs $groups $resources $scope | nindent 6 }}
+                {{- end }}
+                {{- range .nonResourceRules }}
+                    {{- $urls := join "," .nonResourceURLs }}
+                    {{- $verbs := join "," .verbs }}
+                    {{- printf "[%s] non-resource:%s" $verbs $urls | nindent 6 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* Only show the Dangling condition when it is actually dangling (True) — the healthy False state is already implicit */}}
+    {{- range .Status.conditions }}
+        {{- if ne .type "Dangling" }}
+            {{- $.Include "condition_summary" . | nindent 2 }}
+        {{- end }}
+    {{- end }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/FlowSchema.tmpl
+++ b/pkg/plugin/templates/FlowSchema.tmpl
@@ -6,13 +6,18 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- /* Dangling=True means the referenced PriorityLevelConfiguration is missing */}}
-    {{- range .Status.conditions }}
+    {{- $plcName := "" }}
+    {{- with .Spec }}
+        {{- with .priorityLevelConfiguration }}
+            {{- $plcName = .name }}
+        {{- end }}
+    {{- end }}
+    {{- range .StatusConditions }}
         {{- if and (eq .type "Dangling") (eq .status "True") }}
-            {{- printf "PriorityLevelConfiguration/%s not found — matching requests will be rejected" $.Spec.priorityLevelConfiguration.name | red | bold | nindent 2 }}
+            {{- printf "PriorityLevelConfiguration/%s not found — matching requests will be rejected" $plcName | red | bold | nindent 2 }}
         {{- end }}
     {{- end }}
     {{- with .Spec }}
-        {{- $plcName := .priorityLevelConfiguration.name }}
         {{- $prec := .matchingPrecedence | toString | cyan }}
         {{- $plc := printf "PriorityLevelConfiguration/%s" $plcName | cyan }}
         {{- "Assigns" | bold | nindent 2 }} precedence={{ $prec }} → {{ $plc }}
@@ -51,7 +56,7 @@
         {{- end }}
     {{- end }}
     {{- /* Only show the Dangling condition when it is actually dangling (True) — the healthy False state is already implicit */}}
-    {{- range .Status.conditions }}
+    {{- range .StatusConditions }}
         {{- if ne .type "Dangling" }}
             {{- $.Include "condition_summary" . | nindent 2 }}
         {{- end }}

--- a/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
+++ b/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
@@ -12,22 +12,25 @@
         {{- with .Spec.limited }}
             {{- $shares := .nominalConcurrencyShares | toString | cyan }}
             {{- $lend := .lendablePercent | default 0 | toString }}
-            {{- $respType := .limitResponse.type | default "Queue" }}
+            {{- $respType := "Queue" }}
+            {{- with .limitResponse }}{{ $respType = .type | default "Queue" }}{{ end }}
             {{- "Concurrency" | bold | nindent 2 }}: {{ $shares }} nominal shares, {{ $lend | cyan }}% lendable
             {{- if eq $respType "Reject" }}
                 {{- ", overflow: " }}{{ "Reject" | red | bold }}
             {{- else }}
-                {{- with .limitResponse.queuing }}
-                    {{- $queues := .queues | toString | cyan }}
-                    {{- $hand := .handSize | toString | cyan }}
-                    {{- $ql := .queueLengthLimit | toString | cyan }}
-                    {{- ", queues: " }}{{ $queues }}, hand size: {{ $hand }}, max queue depth: {{ $ql }}
+                {{- with .limitResponse }}
+                    {{- with .queuing }}
+                        {{- $queues := .queues | toString | cyan }}
+                        {{- $hand := .handSize | toString | cyan }}
+                        {{- $ql := .queueLengthLimit | toString | cyan }}
+                        {{- ", queues: " }}{{ $queues }}, hand size: {{ $hand }}, max queue depth: {{ $ql }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
     {{- /* Show auto-update annotation only when present — managed by kube-apiserver */}}
-    {{- $autoUpdate := index (.Metadata.annotations | default dict) "apf.kubernetes.io/autoupdate-spec" }}
+    {{- $autoUpdate := index .Annotations "apf.kubernetes.io/autoupdate-spec" }}
     {{- if eq $autoUpdate "true" }}
         {{- "Note" | bold | nindent 2 }}: spec is auto-managed by the API server
     {{- end }}
@@ -36,7 +39,13 @@
         {{- $plcName := .Name }}
         {{- $schemas := list }}
         {{- range $.KubeGet "" "flowschemas" }}
-            {{- if eq .Spec.priorityLevelConfiguration.name $plcName }}
+            {{- $fsPlcName := "" }}
+            {{- with .Spec }}
+                {{- with .priorityLevelConfiguration }}
+                    {{- $fsPlcName = .name }}
+                {{- end }}
+            {{- end }}
+            {{- if eq $fsPlcName $plcName }}
                 {{- $schemas = append $schemas . }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
+++ b/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
@@ -1,0 +1,54 @@
+{{- define "PriorityLevelConfiguration" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: flowcontrol.apiserver.k8s.io/v1, Kind=PriorityLevelConfiguration */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- $type := .Spec.type }}
+    {{- if eq $type "Exempt" }}
+        {{- "Type" | bold | nindent 2 }}: {{ "Exempt" | green }} (requests are never queued or rejected)
+    {{- else if eq $type "Limited" }}
+        {{- with .Spec.limited }}
+            {{- $shares := .nominalConcurrencyShares | toString | cyan }}
+            {{- $lend := .lendablePercent | default 0 | toString }}
+            {{- $respType := .limitResponse.type | default "Queue" }}
+            {{- "Concurrency" | bold | nindent 2 }}: {{ $shares }} nominal shares, {{ $lend | cyan }}% lendable
+            {{- if eq $respType "Reject" }}
+                {{- ", overflow: " }}{{ "Reject" | red | bold }}
+            {{- else }}
+                {{- with .limitResponse.queuing }}
+                    {{- $queues := .queues | toString | cyan }}
+                    {{- $hand := .handSize | toString | cyan }}
+                    {{- $ql := .queueLengthLimit | toString | cyan }}
+                    {{- ", queues: " }}{{ $queues }}, hand size: {{ $hand }}, max queue depth: {{ $ql }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* Show auto-update annotation only when present — managed by kube-apiserver */}}
+    {{- $autoUpdate := index (.Metadata.annotations | default dict) "apf.kubernetes.io/autoupdate-spec" }}
+    {{- if eq $autoUpdate "true" }}
+        {{- "Note" | bold | nindent 2 }}: spec is auto-managed by the API server
+    {{- end }}
+    {{- /* In non-shallow mode, show which FlowSchemas route to this priority level */}}
+    {{- if not ($.Config.GetBool "shallow") }}
+        {{- $plcName := .Name }}
+        {{- $schemas := list }}
+        {{- range $.KubeGet "" "flowschemas" }}
+            {{- if eq .Spec.priorityLevelConfiguration.name $plcName }}
+                {{- $schemas = append $schemas . }}
+            {{- end }}
+        {{- end }}
+        {{- with $schemas }}
+            {{- "FlowSchemas" | bold | nindent 2 }}:
+            {{- range . }}
+                {{- $prec := .Spec.matchingPrecedence | toString }}
+                {{- printf "precedence=%-5s %s" $prec .Name | cyan | nindent 4 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/tests/artifacts/flowschema-catch-all.out
+++ b/tests/artifacts/flowschema-catch-all.out
@@ -1,0 +1,8 @@
+
+FlowSchema/global-default, created 1m ago, gen:1
+  Current: Resource is current
+  Assigns precedence=9900 → PriorityLevelConfiguration/global-default, queue by ByUser
+  Rules:
+    group:system:unauthenticated, group:system:authenticated
+      [*] */* cluster-scoped
+      [*] non-resource:*

--- a/tests/artifacts/flowschema-catch-all.yaml
+++ b/tests/artifacts/flowschema-catch-all.yaml
@@ -1,0 +1,47 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: global-default
+  resourceVersion: "72"
+  uid: e5b3036c-32c0-4458-aa3c-3728cdf39295
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 9900
+  priorityLevelConfiguration:
+    name: global-default
+  rules:
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - group:
+        name: system:unauthenticated
+      kind: Group
+    - group:
+        name: system:authenticated
+      kind: Group
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-27T15:26:06Z"
+    message: This FlowSchema references the PriorityLevelConfiguration object named
+      "global-default" and it exists
+    reason: Found
+    status: "False"
+    type: Dangling

--- a/tests/artifacts/flowschema-exempt.out
+++ b/tests/artifacts/flowschema-exempt.out
@@ -1,0 +1,8 @@
+
+FlowSchema/exempt, created 1m ago, gen:1
+  Current: Resource is current
+  Assigns precedence=1 → PriorityLevelConfiguration/exempt
+  Rules:
+    group:system:masters
+      [*] */* cluster-scoped
+      [*] non-resource:*

--- a/tests/artifacts/flowschema-exempt.yaml
+++ b/tests/artifacts/flowschema-exempt.yaml
@@ -1,0 +1,42 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: exempt
+  resourceVersion: "74"
+  uid: 272efc66-8607-46bb-8faa-6a1a0c7d3e8e
+spec:
+  matchingPrecedence: 1
+  priorityLevelConfiguration:
+    name: exempt
+  rules:
+  - nonResourceRules:
+    - nonResourceURLs:
+      - '*'
+      verbs:
+      - '*'
+    resourceRules:
+    - apiGroups:
+      - '*'
+      clusterScope: true
+      namespaces:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    subjects:
+    - group:
+        name: system:masters
+      kind: Group
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-27T15:26:07Z"
+    message: This FlowSchema references the PriorityLevelConfiguration object named
+      "exempt" and it exists
+    reason: Found
+    status: "False"
+    type: Dangling

--- a/tests/artifacts/flowschema-leader-election.out
+++ b/tests/artifacts/flowschema-leader-election.out
@@ -1,0 +1,7 @@
+
+FlowSchema/system-leader-election, created 1m ago, gen:1
+  Current: Resource is current
+  Assigns precedence=100 → PriorityLevelConfiguration/leader-election, queue by ByUser
+  Rules:
+    user:system:kube-controller-manager, user:system:kube-scheduler, sa:kube-system/*
+      [get,create,update] coordination.k8s.io/leases

--- a/tests/artifacts/flowschema-leader-election.yaml
+++ b/tests/artifacts/flowschema-leader-election.yaml
@@ -1,0 +1,47 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: system-leader-election
+  resourceVersion: "55"
+  uid: 48c04168-c37e-4f32-9495-90bd0c90e6eb
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 100
+  priorityLevelConfiguration:
+    name: leader-election
+  rules:
+  - resourceRules:
+    - apiGroups:
+      - coordination.k8s.io
+      namespaces:
+      - '*'
+      resources:
+      - leases
+      verbs:
+      - get
+      - create
+      - update
+    subjects:
+    - kind: User
+      user:
+        name: system:kube-controller-manager
+    - kind: User
+      user:
+        name: system:kube-scheduler
+    - kind: ServiceAccount
+      serviceAccount:
+        name: '*'
+        namespace: kube-system
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-27T15:26:06Z"
+    message: This FlowSchema references the PriorityLevelConfiguration object named
+      "leader-election" and it exists
+    reason: Found
+    status: "False"
+    type: Dangling

--- a/tests/artifacts/prioritylevelconfiguration-exempt.out
+++ b/tests/artifacts/prioritylevelconfiguration-exempt.out
@@ -1,0 +1,5 @@
+
+PriorityLevelConfiguration/exempt, created 1m ago, gen:1
+  Current: Resource is current
+  Type: Exempt (requests are never queued or rejected)
+  Note: spec is auto-managed by the API server

--- a/tests/artifacts/prioritylevelconfiguration-exempt.yaml
+++ b/tests/artifacts/prioritylevelconfiguration-exempt.yaml
@@ -1,0 +1,16 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: exempt
+  resourceVersion: "66"
+  uid: de3c176a-e238-4ef7-802a-aefb576fa0e1
+spec:
+  exempt:
+    lendablePercent: 0
+    nominalConcurrencyShares: 0
+  type: Exempt
+status: {}

--- a/tests/artifacts/prioritylevelconfiguration-limited-queue.out
+++ b/tests/artifacts/prioritylevelconfiguration-limited-queue.out
@@ -1,0 +1,5 @@
+
+PriorityLevelConfiguration/global-default, created 1m ago, gen:1
+  Current: Resource is current
+  Concurrency: 20 nominal shares, 50% lendable, queues: 128, hand size: 6, max queue depth: 50
+  Note: spec is auto-managed by the API server

--- a/tests/artifacts/prioritylevelconfiguration-limited-queue.yaml
+++ b/tests/artifacts/prioritylevelconfiguration-limited-queue.yaml
@@ -1,0 +1,22 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: global-default
+  resourceVersion: "42"
+  uid: b30d2913-196e-4525-91f3-0f104e821752
+spec:
+  limited:
+    lendablePercent: 50
+    limitResponse:
+      queuing:
+        handSize: 6
+        queueLengthLimit: 50
+        queues: 128
+      type: Queue
+    nominalConcurrencyShares: 20
+  type: Limited
+status: {}

--- a/tests/artifacts/prioritylevelconfiguration-limited-reject.out
+++ b/tests/artifacts/prioritylevelconfiguration-limited-reject.out
@@ -1,0 +1,5 @@
+
+PriorityLevelConfiguration/catch-all, created 1m ago, gen:1
+  Current: Resource is current
+  Concurrency: 5 nominal shares, 0% lendable, overflow: Reject
+  Note: spec is auto-managed by the API server

--- a/tests/artifacts/prioritylevelconfiguration-limited-reject.yaml
+++ b/tests/artifacts/prioritylevelconfiguration-limited-reject.yaml
@@ -1,0 +1,18 @@
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "true"
+  creationTimestamp: "2026-06-27T15:26:06Z"
+  generation: 1
+  name: catch-all
+  resourceVersion: "64"
+  uid: c35a5e90-e5af-4fa0-abf7-9d5edde03fe1
+spec:
+  limited:
+    lendablePercent: 0
+    limitResponse:
+      type: Reject
+    nominalConcurrencyShares: 5
+  type: Limited
+status: {}


### PR DESCRIPTION
## Summary

- **`FlowSchema`** — shows priority level assignment with precedence, queue distinguisher method, and per-rule subjects (user/group/serviceaccount) with resource+verb scope. The `Dangling` condition (referenced PLC missing) surfaces as a bold red error; the healthy state is silently suppressed since it adds no diagnostic value.
- **`PriorityLevelConfiguration`** — shows Exempt vs Limited type, concurrency shares, lendable percent, and Queue config (queues/handSize/maxQueueDepth) or `Reject` overflow in red. In non-shallow mode, cross-references which FlowSchemas route into this level via a live cluster query.
- 6 static test artifacts captured from minikube (k8s 1.35.1) covering all branches: Exempt PLC, Limited+Queue, Limited+Reject, FlowSchema with wildcard rules, targeted resource rules, and ByUser distinguisher.

Both resources are `flowcontrol.apiserver.k8s.io/v1` (GA since k8s 1.29), have no web UI, and are niche but very hard to debug without tooling.

## Test plan

- [x] `make test` passes (all 6 new artifact pairs + existing suite)
- [x] Live: `go run ./cmd/main.go flowschema exempt --shallow` — correct output, Dangling condition suppressed
- [x] Live: `go run ./cmd/main.go flowschema system-leader-election --shallow` — ByUser distinguisher, targeted subjects/rules shown
- [x] Live: `go run ./cmd/main.go prioritylevelconfiguration exempt --shallow` — Exempt type path
- [x] Live: `go run ./cmd/main.go prioritylevelconfiguration catch-all --shallow` — Reject overflow shown in red
- [x] Live: `go run ./cmd/main.go prioritylevelconfiguration workload-high` — FlowSchemas cross-reference populated (non-shallow)
- [x] Live: `go run ./cmd/main.go prioritylevelconfiguration workload-high --shallow` — FlowSchemas section hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)