### PR TITLE
Improve CronJob, DaemonSet, and StatefulSet templates

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -177,8 +178,11 @@ func TestE2EAgainstVanillaMinikube(t *testing.T) {
 func testHack(t *testing.T) {
 	t.Helper()
 	durationRevert := plugin.SetDurationRound(func(_ interface{}) string { return "1m" })
+	fixedNow := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+	nowRevert := plugin.SetNowFunc(func() time.Time { return fixedNow })
 	t.Cleanup(func() {
 		durationRevert()
+		nowRevert()
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-sprout/sprout v0.4.1
 	github.com/ivanpirog/coloredcobra v1.0.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/go-sprout/sprout"
+	"github.com/robfig/cron/v3"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 	resource2 "k8s.io/apimachinery/pkg/api/resource"
@@ -21,6 +22,16 @@ import (
 )
 
 var durationRound = DefaultDurationRound()
+
+var nowFunc = time.Now
+
+// SetNowFunc is a helper method for tests
+func SetNowFunc(f func() time.Time) (revertFunc func()) {
+	nowFunc = f
+	return func() {
+		nowFunc = time.Now
+	}
+}
 
 func DefaultDurationRound() func(duration interface{}) string {
 	return (sprout.GenericFuncMap()["durationRound"]).(func(duration interface{}) string)
@@ -68,6 +79,7 @@ func funcMap() template.FuncMap {
 		"forOrSince":               forOrSince,
 		"relativeTime":             relativeTime,
 		"labelSelector":            labelSelector,
+		"cronNextTime":             cronNextTime,
 	}
 }
 
@@ -410,6 +422,28 @@ func (r RenderableObject) IncludeRenderableObject(obj RenderableObject) (output 
 	klog.V(5).InfoS("called IncludeRenderableObject", "r", r, "obj", obj)
 	renderString, _ := obj.renderString()
 	return renderString
+}
+
+func cronNextTime(schedule string, timezone interface{}) string {
+	tz, _ := timezone.(string)
+	schedStr := schedule
+	if !strings.Contains(schedule, "TZ") && tz != "" {
+		if _, err := time.LoadLocation(tz); err == nil {
+			schedStr = fmt.Sprintf("TZ=%s %s", tz, schedule)
+		}
+	}
+	sched, err := cron.ParseStandard(schedStr)
+	if err != nil {
+		return ""
+	}
+	now := nowFunc()
+	next := sched.Next(now)
+	nextStr := next.UTC().Format("2006-01-02T15:04:05Z")
+	if viper.GetBool("absolute-time") {
+		return nextStr
+	}
+	duration := next.Sub(now).Round(time.Second)
+	return fmt.Sprintf("%s (in %s)", nextStr, colorDuration(duration))
 }
 
 func labelSelector(s map[string]interface{}) string {

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -438,6 +438,9 @@ func cronNextTime(schedule string, timezone interface{}) string {
 	}
 	now := nowFunc()
 	next := sched.Next(now)
+	if next.IsZero() {
+		return ""
+	}
 	nextStr := next.UTC().Format("2006-01-02T15:04:05Z")
 	if viper.GetBool("absolute-time") {
 		return nextStr

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -4,13 +4,9 @@
     {{- template "status_summary_line" . }}
     {{- with .Spec.schedule }}, schedule: {{ . | cyan }}{{ with $.Spec.timeZone }} [{{ . | cyan }}]{{ end }}{{ end }}
     {{- if .Spec.suspend }}, {{ "Suspended" | yellow | bold }}{{ end }}
-    {{- if .Status.lastScheduleTime }}, last ran at {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
-    {{- else if not .Spec.suspend }}
-        {{- "Not yet scheduled" | yellow | bold | nindent 2 }}
-    {{- end }}
-    {{- if and .Status.lastSuccessfulTime .Status.lastScheduleTime }}
-        {{- if lt .Status.lastSuccessfulTime .Status.lastScheduleTime }}
-            {{- "Last succeeded" | nindent 2 }}: {{ .Status.lastSuccessfulTime | colorAgo }}{{ agoSuffix }}
+    {{- if not .Status.lastScheduleTime }}
+        {{- if not .Spec.suspend }}
+            {{- "Not yet scheduled" | yellow | bold | nindent 2 }}
         {{- end }}
     {{- end }}
     {{- with .Spec.concurrencyPolicy }}
@@ -23,7 +19,32 @@
             {{- "Active" | green | nindent 2 }}: {{ .kind | bold }}/{{ .name }} is running.
         {{- end }}
     {{- end }}
-    {{- template "kstatus_summary" . }}
+    {{- $cronJobJobs := list }}
+    {{- range $.KubeGet $.Namespace "Jobs" }}
+        {{- $job := . }}
+        {{- range .Metadata.ownerReferences }}
+            {{- if and .controller (eq .kind "CronJob") (eq .name $.Name) }}
+                {{- $cronJobJobs = append $cronJobJobs $job }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with $cronJobJobs }}
+        {{- "Jobs" | bold | nindent 2 }}, keep last {{ $.Spec.successfulJobsHistoryLimit | default 3 | int | toString | cyan }} successful / {{ $.Spec.failedJobsHistoryLimit | default 1 | int | toString | cyan }} failed:
+        {{- range . }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- $.IncludeRenderableObject . | nindent 4 }}
+            {{- else }}
+                {{- $.Include "job_health_summary" . | nindent 4 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- if .Status.lastScheduleTime }}
+        {{- "Last ran" | nindent 2 }}: {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
+        {{- if and .Status.lastSuccessfulTime (lt .Status.lastSuccessfulTime .Status.lastScheduleTime) }}, last succeeded: {{ .Status.lastSuccessfulTime }}{{ relativeTime .Status.lastSuccessfulTime }}{{ end }}
+        {{- if not .Spec.suspend }}, next: {{ cronNextTime .Spec.schedule .Spec.timeZone }}{{ end }}
+    {{- else if and .Spec.schedule (not .Spec.suspend) }}
+        {{- "Next" | nindent 2 }}: {{ cronNextTime .Spec.schedule .Spec.timeZone }}
+    {{- end }}
     {{- template "finalizer_details_on_termination" . }}
     {{- template "application_details" . }}
     {{- template "recent_updates" . }}

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -40,7 +40,7 @@
     {{- end }}
     {{- if .Status.lastScheduleTime }}
         {{- "Last ran" | nindent 2 }}: {{ .Status.lastScheduleTime }}{{ relativeTime .Status.lastScheduleTime }}
-        {{- if and .Status.lastSuccessfulTime (lt .Status.lastSuccessfulTime .Status.lastScheduleTime) }}, last succeeded: {{ .Status.lastSuccessfulTime }}{{ relativeTime .Status.lastSuccessfulTime }}{{ end }}
+        {{- if .Status.lastSuccessfulTime }}{{- if lt .Status.lastSuccessfulTime .Status.lastScheduleTime }}, last succeeded: {{ .Status.lastSuccessfulTime }}{{ relativeTime .Status.lastSuccessfulTime }}{{ end }}{{ end }}
         {{- if not .Spec.suspend }}, next: {{ cronNextTime .Spec.schedule .Spec.timeZone }}{{ end }}
     {{- else if and .Spec.schedule (not .Spec.suspend) }}
         {{- "Next" | nindent 2 }}: {{ cronNextTime .Spec.schedule .Spec.timeZone }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -5,24 +5,7 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
-    {{- with .Spec.selector }}
-        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
-        {{- $matchLabels := .matchLabels }}
-        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
-                {{- end }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.Include "pod_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "selector_with_health_summary" . }}
     {{- template "daemonset_replicas_status" . }}
     {{- template "conditions_summary" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -35,16 +35,18 @@
 
 {{- define "recent_daemonset_rollouts" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- $sectionHeader := false }}
-    {{- $previousRevision := "" }}
+    {{- $revisions := list }}
     {{- range .KubeGetByLabelsMap .Namespace "controllerrevisions" .Labels }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- if not $sectionHeader }}
-                {{- "Rollouts:" | nindent 2 }}
-                {{- template "rollout_diffs_flag_help" $ }}
-                {{- $sectionHeader = true }}
-            {{- end }}
+            {{- $revisions = append $revisions . }}
+        {{- end }}
+    {{- end }}
+    {{- if ge (len $revisions) 2 }}
+        {{- "Rollouts:" | nindent 2 }}
+        {{- template "rollout_diffs_flag_help" $ }}
+        {{- $previousRevision := "" }}
+        {{- range $revisions }}
             {{- "" | nindent 4 }}
             {{- with .Metadata.creationTimestamp }}{{ . | colorAgo }}{{ agoSuffix }}{{ end }} used {{ .Kind | bold }}/{{ .Name }}.
             {{- if and $previousRevision ($.Config.GetBool "include-rollout-diffs") }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -5,6 +5,24 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
+    {{- with .Spec.selector }}
+        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
+        {{- $matchLabels := .matchLabels }}
+        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
+                    {{- $.Include "service_health_summary" . | nindent 4 }}
+                {{- end }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.Include "pod_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- template "daemonset_replicas_status" . }}
     {{- template "conditions_summary" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -65,16 +65,18 @@
 {{- define "recent_deployment_rollouts" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- $deploymentRevision := index .Annotations "deployment.kubernetes.io/revision" }}
-    {{- $sectionHeader := false }}
-    {{- $previousReplicaSet := "" }}
+    {{- $replicaSets := list }}
     {{- range .KubeGet .Namespace "ReplicaSets" }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- if not $sectionHeader }}
-                {{- "Rollouts:" | nindent 2}}
-                {{- template "rollout_diffs_flag_help" $ }}
-                {{- $sectionHeader = true }}
-            {{- end }}
+            {{- $replicaSets = append $replicaSets . }}
+        {{- end }}
+    {{- end }}
+    {{- if ge (len $replicaSets) 2 }}
+        {{- "Rollouts:" | nindent 2}}
+        {{- template "rollout_diffs_flag_help" $ }}
+        {{- $previousReplicaSet := "" }}
+        {{- range $replicaSets }}
             {{- with .Metadata.creationTimestamp }}{{ . | colorAgo | nindent 4 }}{{ agoSuffix }}{{ end }}, managed by {{ .Kind | bold }}/{{ .Name }}
             {{- $replicationSetRevision := index .Annotations "deployment.kubernetes.io/revision" }}
             {{- $activeReplicaSet := eq $deploymentRevision $replicationSetRevision }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -16,24 +16,7 @@
     {{- with .Spec.strategy }}{{ if ne (.type | default "RollingUpdate") "RollingUpdate" }}
         {{- "Strategy" | bold | nindent 2 }}: {{ .type | yellow }}
     {{- end }}{{ end }}
-    {{- with .Spec.selector }}
-        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
-        {{- $matchLabels := .matchLabels }}
-        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
-                {{- end }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.Include "pod_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "selector_with_health_summary" . }}
     {{- template "conditions_summary" . }}
     {{- template "suspended" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -5,24 +5,7 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
-    {{- with .Spec.selector }}
-        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
-        {{- $matchLabels := .matchLabels }}
-        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
-                {{- end }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.Include "pod_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "selector_with_health_summary" . }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
     {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -129,16 +129,18 @@
 
 {{- define "recent_statefulset_rollouts" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- $sectionHeader := false }}
-    {{- $previousRevision := "" }}
+    {{- $revisions := list }}
     {{- range .KubeGetByLabelsMap .Namespace "controllerrevisions" .Labels }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- if not $sectionHeader }}
-                {{- "Rollouts:" | nindent 2 }}
-                {{- template "rollout_diffs_flag_help" $ }}
-                {{- $sectionHeader = true }}
-            {{- end }}
+            {{- $revisions = append $revisions . }}
+        {{- end }}
+    {{- end }}
+    {{- if ge (len $revisions) 2 }}
+        {{- "Rollouts:" | nindent 2 }}
+        {{- template "rollout_diffs_flag_help" $ }}
+        {{- $previousRevision := "" }}
+        {{- range $revisions }}
             {{- "" | nindent 4 }}
             {{- with .Metadata.creationTimestamp }}{{ . | colorAgo }}{{ agoSuffix }}{{ end }} used {{ .Kind | bold }}/{{ .Name }}.
             {{- if and $previousRevision ($.Config.GetBool "include-rollout-diffs") }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -5,6 +5,24 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
+    {{- with .Spec.selector }}
+        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
+        {{- $matchLabels := .matchLabels }}
+        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
+                    {{- $.Include "service_health_summary" . | nindent 4 }}
+                {{- end }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.Include "pod_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
     {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -249,6 +249,28 @@
     {{- end }}
 {{- end -}}
 
+{{- define "selector_with_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- with .Spec.selector }}
+        {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
+        {{- $matchLabels := .matchLabels }}
+        {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- range $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
+                    {{- $.Include "service_health_summary" . | nindent 4 }}
+                {{- end }}
+                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
+                    {{- $.Include "pod_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- define "workload_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -235,6 +235,20 @@
     {{- end }}
 {{- end }}
 
+{{- define "job_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
+    {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
+    {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
+    {{- if .Status.failed }}, {{ printf "Failed: %d" (.Status.failed | int) | red | bold }}{{ end }}
+    {{- if .Status.startTime }}, started {{ .Status.startTime | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- if and .Status.startTime .Status.completionTime }}
+        {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- ", ran for " }}{{ $completed.Sub $started | colorDuration }}
+    {{- end }}
+{{- end -}}
+
 {{- define "workload_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}

--- a/tests/artifacts/cronjob-last-failed.out
+++ b/tests/artifacts/cronjob-last-failed.out
@@ -1,5 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, gen:3, schedule: */1 * * * *, last ran at 2026-06-29T01:35:00Z (1m ago)
-  Last succeeded: 1m ago
+CronJob/hello -n default, created 1m ago, gen:3, schedule: */1 * * * *
   Active: Job/hello-29711615 is running.
-  Current: Resource is always ready
+  Last ran: 2026-06-29T01:35:00Z (1m ago), last succeeded: 2026-06-29T01:34:11Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-regular-active.out
+++ b/tests/artifacts/cronjob-regular-active.out
@@ -1,4 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:47:00Z (1m ago)
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *
   Active: Job/hello-1584492420 is running.
-  Current: Resource is always ready
+  Last ran: 2020-03-18T00:47:00Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-regular-new.out
+++ b/tests/artifacts/cronjob-regular-new.out
@@ -1,4 +1,4 @@
 
 CronJob/hello -n default, created 1m ago, schedule: */1 * * * *
   Not yet scheduled
-  Current: Resource is always ready
+  Next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-regular-scheduled-and-active.out
+++ b/tests/artifacts/cronjob-regular-scheduled-and-active.out
@@ -1,4 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:48:00Z (1m ago)
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *
   Active: Job/hello-1584492480 is running.
-  Current: Resource is always ready
+  Last ran: 2020-03-18T00:48:00Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-regular-scheduled.out
+++ b/tests/artifacts/cronjob-regular-scheduled.out
@@ -1,3 +1,3 @@
 
-CronJob/hello -n default, created 1m ago, schedule: */1 * * * *, last ran at 2020-03-18T00:47:00Z (1m ago)
-  Current: Resource is always ready
+CronJob/hello -n default, created 1m ago, schedule: */1 * * * *
+  Last ran: 2020-03-18T00:47:00Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-simple-active.out
+++ b/tests/artifacts/cronjob-simple-active.out
@@ -1,3 +1,3 @@
 
-CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T01:31:00Z (1m ago)
-  Current: Resource is always ready
+CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *
+  Last ran: 2026-06-29T01:31:00Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-simple-live.out
+++ b/tests/artifacts/cronjob-simple-live.out
@@ -1,3 +1,3 @@
 
-CronJob/cronjob-simple -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T02:41:00Z (1m ago)
-  Current: Resource is always ready
+CronJob/cronjob-simple -n default, created 1m ago, gen:1, schedule: */1 * * * *
+  Last ran: 2026-06-29T02:41:00Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-simple-new.out
+++ b/tests/artifacts/cronjob-simple-new.out
@@ -1,4 +1,4 @@
 
 CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *
   Not yet scheduled
-  Current: Resource is always ready
+  Next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-simple-scheduled.out
+++ b/tests/artifacts/cronjob-simple-scheduled.out
@@ -1,5 +1,4 @@
 
-CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *, last ran at 2026-06-29T01:31:00Z (1m ago)
-  Last succeeded: 1m ago
+CronJob/hello -n default, created 1m ago, gen:1, schedule: */1 * * * *
   Active: Job/hello-29711611 is running.
-  Current: Resource is always ready
+  Last ran: 2026-06-29T01:31:00Z (1m ago), last succeeded: 2026-06-29T01:30:52Z (1m ago), next: 2026-06-30T00:01:00Z (in 1m)

--- a/tests/artifacts/cronjob-suspended.out
+++ b/tests/artifacts/cronjob-suspended.out
@@ -1,3 +1,3 @@
 
-CronJob/hello -n default, created 1m ago, gen:2, schedule: */1 * * * *, Suspended, last ran at 2026-06-29T01:34:00Z (1m ago)
-  Current: Resource is always ready
+CronJob/hello -n default, created 1m ago, gen:2, schedule: */1 * * * *, Suspended
+  Last ran: 2026-06-29T01:34:00Z (1m ago)

--- a/tests/artifacts/cronjob-tz.out
+++ b/tests/artifacts/cronjob-tz.out
@@ -2,4 +2,4 @@
 CronJob/cronjob-tz -n default, created 1m ago, gen:1, schedule: 30 9 * * 1-5 [Europe/Berlin]
   Not yet scheduled
   Concurrency: Forbid
-  Current: Resource is always ready
+  Next: 2026-06-30T07:30:00Z (in 1m)

--- a/tests/artifacts/cronjob-with-timezone.out
+++ b/tests/artifacts/cronjob-with-timezone.out
@@ -2,4 +2,4 @@
 CronJob/morning-report -n default, created 1m ago, gen:1, schedule: 0 9 * * 1-5 [Europe/Berlin]
   Not yet scheduled
   Concurrency: Forbid
-  Current: Resource is always ready
+  Next: 2026-06-30T07:00:00Z (in 1m)

--- a/tests/artifacts/ds-kube-proxy.out
+++ b/tests/artifacts/ds-kube-proxy.out
@@ -1,0 +1,5 @@
+
+DaemonSet/kube-proxy -n kube-system, created 1m ago, gen:1
+  Current: All replicas scheduled as expected. Replicas: 1
+  Selector: k8s-app=kube-proxy
+  desired:1, current:1, available:1, ready:1, updated:1

--- a/tests/artifacts/ds-kube-proxy.yaml
+++ b/tests/artifacts/ds-kube-proxy.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    deprecated.daemonset.template.generation: "1"
+  creationTimestamp: "2026-06-29T08:38:02Z"
+  generation: 1
+  labels:
+    k8s-app: kube-proxy
+  name: kube-proxy
+  namespace: kube-system
+  resourceVersion: "45734"
+  uid: a392a9df-8558-414a-91ad-46d657ca6180
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: registry.k8s.io/kube-proxy:v1.35.1
+        imagePullPolicy: IfNotPresent
+        name: kube-proxy
+        resources: {}
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/kube-proxy
+          name: kube-proxy
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: kube-proxy
+      serviceAccountName: kube-proxy
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-proxy
+        name: kube-proxy
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - hostPath:
+          path: /lib/modules
+          type: ""
+        name: lib-modules
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+  observedGeneration: 1
+  updatedNumberScheduled: 1

--- a/tests/artifacts/sts-inital-rollout-done.out
+++ b/tests/artifacts/sts-inital-rollout-done.out
@@ -1,5 +1,6 @@
 
 StatefulSet/web -n test1, created 1m ago, gen:1
   Current: Partition rollout complete. updated: 3
+  Selector: app=nginx
   desired:3, existing:3, ready:3, current:3, updated:3
   Volume Claims: www (1Gi)

--- a/tests/artifacts/sts-new.out
+++ b/tests/artifacts/sts-new.out
@@ -2,6 +2,7 @@
 StatefulSet/web -n test1, created 1m ago, gen:1
   InProgress: Replicas: 0/3
     Reconciling: LessReplicas, Replicas: 0/3
+  Selector: app=nginx
   desired:3, ready:0, current:0
   Outage: StatefulSet has no Ready replicas.
   Ongoing rollout: Waiting for statefulset spec update to be observed...

--- a/tests/artifacts/sts-ongoing-update-rollout-with-diff.out
+++ b/tests/artifacts/sts-ongoing-update-rollout-with-diff.out
@@ -2,6 +2,7 @@
 StatefulSet/web -n test1, created 1m ago, gen:2
   InProgress: Ready: 2/3
     Reconciling: LessReady, Ready: 2/3
+  Selector: app=nginx
   desired:3, existing:3, ready:2, current:3
   Ongoing rollout: Waiting for 1 pods to be ready...
   Stuck Rollout?: Still replacing the first Pod, may indicate a stuck rollout.

--- a/tests/artifacts/sts-ongoing-update-rollout.out
+++ b/tests/artifacts/sts-ongoing-update-rollout.out
@@ -2,6 +2,7 @@
 StatefulSet/web -n test1, created 1m ago, gen:2
   InProgress: Ready: 2/3
     Reconciling: LessReady, Ready: 2/3
+  Selector: app=nginx
   desired:3, existing:3, ready:2, current:3
   Ongoing rollout: Waiting for 1 pods to be ready...
   Stuck Rollout?: Still replacing the first Pod, may indicate a stuck rollout.

--- a/tests/artifacts/sts-stuck-initial-rollout.out
+++ b/tests/artifacts/sts-stuck-initial-rollout.out
@@ -2,6 +2,7 @@
 StatefulSet/web -n test1, created 1m ago, gen:1
   InProgress: Replicas: 1/3
     Reconciling: LessReplicas, Replicas: 1/3
+  Selector: app=nginx
   desired:3, existing:1, ready:0, current:1, updated:1
   Outage: StatefulSet has no Ready replicas.
   Stuck Initial Rollout? First rollout not yet progressed.

--- a/tests/artifacts/sts-suspended.out
+++ b/tests/artifacts/sts-suspended.out
@@ -1,6 +1,7 @@
 
 StatefulSet/web -n test1, created 1m ago, gen:4
   Current: Partition rollout complete. updated: 0
+  Selector: app=nginx
   desired:0, ready:0, current:0
   Suspended: Scaled down to 0.
   Outage: StatefulSet has no Ready replicas.


### PR DESCRIPTION
## Summary

- **CronJob**: Overhaul template with schedule timing, job history (showing `successfulJobsHistoryLimit`/`failedJobsHistoryLimit`), and health summary
- **DaemonSet / StatefulSet**: Add Selector section (mirrors the existing Deployment pattern)
- **Rollouts**: Hide the Rollouts section when fewer than 2 rollouts exist to reduce noise

## Changes

- `pkg/plugin/templates/CronJob.tmpl` — schedule display, job history limits, health summary
- `pkg/plugin/templates/DaemonSet.tmpl` — new Selector section
- `pkg/plugin/templates/StatefulSet.tmpl` — new Selector section
- `pkg/plugin/templates/common.tmpl` — shared helper for selector display
- `pkg/plugin/template_functions_static.go` — supporting template functions
- Test artifacts updated for all affected resource kinds

## Test plan

- [x] `make test` passes
- [x] Verify CronJob output shows schedule timing, job history limits, and health summary
- [x] Verify DaemonSet/StatefulSet output shows Selector section
- [x] Verify resources with < 2 rollouts omit the Rollouts section

🤖 Generated with [Claude Code](https://claude.com/claude-code)