### PR TITLE
Show pods using a PVC in its status output

### DIFF
--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -18,9 +18,13 @@
     {{- $usingPods := list }}
     {{- range $.KubeGet $.Namespace "pods" }}
         {{- $pod := . }}
+        {{- $added := false }}
         {{- range $pod.Spec.volumes | default list }}
             {{- if and (hasKey . "persistentVolumeClaim") (eq .persistentVolumeClaim.claimName $pvcName) }}
-                {{- $usingPods = append $usingPods $pod }}
+                {{- if not $added }}
+                    {{- $usingPods = append $usingPods $pod }}
+                    {{- $added = true }}
+                {{- end }}
                 {{- if not (hasKey $volStats "usedBytes") }}
                     {{- $volName := .name }}
                     {{- $nodeSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}

--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -12,14 +12,16 @@
     {{- with index .Annotations "volume.beta.kubernetes.io/storage-provisioner" }}, provisioned by {{ . | bold }}{{ end }}
     {{- with index .Annotations "volume.kubernetes.io/selected-node" }}, attached on {{ "Node" | bold }}/{{ . }}{{ end }}
     {{- if not .Spec.volumeName }}, {{ "Pending" | red | bold }}: no paired PV yet{{ end }}
-    {{- /* Disk usage: find a running pod that has this PVC mounted */ -}}
+    {{- /* Disk usage: find running pods that have this PVC mounted, collect usage stats from the first one */ -}}
     {{- $pvcName := $.Name }}
     {{- $volStats := dict }}
+    {{- $usingPods := list }}
     {{- range $.KubeGet $.Namespace "pods" }}
-        {{- if not (hasKey $volStats "usedBytes") }}
-            {{- $pod := . }}
-            {{- range $pod.Spec.volumes | default list }}
-                {{- if and (hasKey . "persistentVolumeClaim") (eq .persistentVolumeClaim.claimName $pvcName) }}
+        {{- $pod := . }}
+        {{- range $pod.Spec.volumes | default list }}
+            {{- if and (hasKey . "persistentVolumeClaim") (eq .persistentVolumeClaim.claimName $pvcName) }}
+                {{- $usingPods = append $usingPods $pod }}
+                {{- if not (hasKey $volStats "usedBytes") }}
                     {{- $volName := .name }}
                     {{- $nodeSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
                     {{- $podStat := dict }}
@@ -54,6 +56,12 @@
         {{- if $allocStorage }} storage {{ ($status.capacity | default dict).storage | cyan }} → {{ $allocStorage | cyan }}{{ end }}
         {{- with $status.resizeStatus }} ({{ . | colorKeyword }}){{ end }}
         {{- with $allocStatusStorage }} {{ . }}{{ end }}
+    {{- end }}
+    {{- if $usingPods }}
+        {{- "Pods" | bold | nindent 2 }}:
+        {{- range $usingPods }}
+            {{- $.Include "pod_health_summary" . | nindent 4 }}
+        {{- end }}
     {{- end }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}


### PR DESCRIPTION
## Summary

- Fixes #195
- The PVC template now lists all pods that have the PVC mounted, using the same `pod_health_summary` format used by other resource templates (Deployments, StatefulSets, etc.)
- Refactors the existing pod-iteration loop to collect all matching pods (previously it short-circuited after finding disk stats from the first pod), while preserving the optimization of only fetching node volume stats once

## Behaviour

When a PVC is mounted by one or more pods, a **Pods** section appears after the resize tracking info:

```
PersistentVolumeClaim/data-web-0 -n default, created 5d ago  Bound
  PVC uses PersistentVolume/pvc-..., with Filesystem mode, asks for 10Gi, usage: 1.2GiB/10GiB[12%]
  Pods:
    Pod/web-0 Running, 1/1 ready
    Pod/web-1 Running, 1/1 ready
```

The section is suppressed when no pods are found (e.g. in `--shallow` mode or when the PVC is unbound/unused).

## Test plan

- [x] All existing artifact tests pass (`go test ./...` — 140 tests)
- [x] Manual e2e: `kubectl status pvc/<name>` on a live cluster with pods mounting the PVC shows the Pods section