### PR TITLE
Show probe/lifecycle details on containers with failure signals

### DIFF
--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -365,25 +365,32 @@
     {{- end }}
     {{- $runningNotReady := and .containerStatus.state.running (not .containerStatus.ready) }}
     {{- $hasRestarts := gt (.containerStatus.restartCount | int) 0 }}
-    {{- $lastTerminated := .containerStatus.lastState.terminated }}
-    {{- if and $hasRestarts .containerSpec.livenessProbe (eq ($lastTerminated.exitCode | int) 137) (ne $lastTerminated.reason "OOMKilled") }}
-        {{- "(possible liveness probe SIGKILL)" | red | nindent 2 }}
+    {{- if and $hasRestarts .containerSpec.livenessProbe }}
+        {{- with .containerStatus.lastState.terminated }}
+            {{- if and (eq (.exitCode | int) 137) (ne .reason "OOMKilled") }}
+                {{- "(possible liveness probe SIGKILL)" | red | nindent 2 }}
+            {{- end }}
+        {{- end }}
     {{- end }}
     {{- if and $runningNotReady .containerSpec.readinessProbe }}
         {{- "readinessProbe:" | yellow | nindent 2 }} {{ template "probe_summary" .containerSpec.readinessProbe }}
     {{- end }}
     {{- if and $hasRestarts .containerSpec.livenessProbe }}
         {{- $p := .containerSpec.livenessProbe -}}
-        {{- $budget := add ($p.initialDelaySeconds | int) (mul ($p.failureThreshold | int) ($p.periodSeconds | int)) -}}
+        {{- $budget := add ($p.initialDelaySeconds | default 0 | int) (mul ($p.failureThreshold | default 3 | int) ($p.periodSeconds | default 10 | int)) -}}
         {{- "livenessProbe:" | yellow | nindent 2 }} {{ template "probe_summary" $p }} {{ "kill budget:" | bold }} {{ printf "%ds" $budget | cyan }}
     {{- end }}
     {{- if and $hasRestarts .containerSpec.startupProbe }}
         {{- $p := .containerSpec.startupProbe -}}
-        {{- $budget := add ($p.initialDelaySeconds | int) (mul ($p.failureThreshold | int) ($p.periodSeconds | int)) -}}
+        {{- $budget := add ($p.initialDelaySeconds | default 0 | int) (mul ($p.failureThreshold | default 3 | int) ($p.periodSeconds | default 10 | int)) -}}
         {{- "startupProbe:" | yellow | nindent 2 }} {{ template "probe_summary" $p }} {{ "kill budget:" | bold }} {{ printf "%ds" $budget | cyan }}
     {{- end }}
-    {{- if and (eq .containerStatus.state.waiting.reason "PostStartHookError") .containerSpec.lifecycle.postStart }}
-        {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" .containerSpec.lifecycle.postStart }}
+    {{- with .containerStatus.state.waiting }}
+        {{- if eq .reason "PostStartHookError" }}
+            {{- with $.containerSpec.lifecycle.postStart }}
+                {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" . }}
+            {{- end }}
+        {{- end }}
     {{- end }}
     {{- with .containerStats }}
         {{- with .rootfs }}
@@ -436,7 +443,7 @@
 {{- define "probe_summary" }}
     {{- /* Displays probe action type and timing parameters. Expects a probe object. */ -}}
     {{- with .exec }}{{ "exec" | bold }} {{ .command | join " " | cyan }}{{ end -}}
-    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" .scheme (.host | default "localhost") .port .path | cyan }}{{ end -}}
+    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" (.scheme | default "HTTP") (.host | default "localhost") .port .path | cyan }}{{ end -}}
     {{- with .tcpSocket }}{{ "tcpSocket" | bold }} {{ printf "%s:%v" (.host | default "localhost") .port | cyan }}{{ end -}}
     {{- with .grpc }}{{ "grpc" | bold }} {{ printf ":%v" .port | cyan }}{{ with .service }} {{ . | cyan }}{{ end }}{{ end -}}
     {{- $parts := list -}}
@@ -450,7 +457,7 @@
 {{- define "lifecycle_hook_summary" }}
     {{- /* Displays a lifecycle hook action. Expects a LifecycleHandler object. */ -}}
     {{- with .exec }}{{ "exec" | bold }} {{ .command | join " " | cyan }}{{ end -}}
-    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" .scheme (.host | default "localhost") .port .path | cyan }}{{ end -}}
+    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" (.scheme | default "HTTP") (.host | default "localhost") .port .path | cyan }}{{ end -}}
     {{- with .tcpSocket }}{{ "tcpSocket" | bold }} {{ printf "%s:%v" (.host | default "localhost") .port | cyan }}{{ end -}}
     {{- with .sleep }}{{ "sleep" | bold }} {{ printf "%vs" .seconds | cyan }}{{ end -}}
 {{- end -}}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -283,6 +283,28 @@
             {{- range . }}{{ .name | cyan | nindent 4 }}{{ end }}
         {{- end }}
     {{- end }}
+    {{- with .Spec.readinessGates }}
+        {{- if eq (len .) 1 }}
+            {{- $condType := (index . 0).conditionType }}
+            {{- $cond := $.StatusConditions | getMatchingItemInMapList (dict "type" $condType) }}
+            {{- if $cond }}
+                {{- "Readiness gate:" | yellow | nindent 2 }} {{ $.Include "condition_summary" $cond }}
+            {{- else }}
+                {{- "Readiness gate:" | yellow | nindent 2 }} {{ $condType | cyan }}: condition not yet set
+            {{- end }}
+        {{- else }}
+            {{- printf "Readiness gates (%d):" (len .) | yellow | nindent 2 }}
+            {{- range . }}
+                {{- $condType := .conditionType }}
+                {{- $cond := $.StatusConditions | getMatchingItemInMapList (dict "type" $condType) }}
+                {{- if $cond }}
+                    {{- $.Include "condition_summary" $cond | nindent 4 }}
+                {{- else }}
+                    {{- $condType | cyan | nindent 4 }}: condition not yet set
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "container_usage" -}}
@@ -341,6 +363,28 @@
     {{- with .containerStatus.lastState }}
         {{- "previously:" | yellow | nindent 2 }} {{ template "container_state_summary" . }}
     {{- end }}
+    {{- $runningNotReady := and .containerStatus.state.running (not .containerStatus.ready) }}
+    {{- $hasRestarts := gt (.containerStatus.restartCount | int) 0 }}
+    {{- $lastTerminated := .containerStatus.lastState.terminated }}
+    {{- if and $hasRestarts .containerSpec.livenessProbe (eq ($lastTerminated.exitCode | int) 137) (ne $lastTerminated.reason "OOMKilled") }}
+        {{- "(possible liveness probe SIGKILL)" | red | nindent 2 }}
+    {{- end }}
+    {{- if and $runningNotReady .containerSpec.readinessProbe }}
+        {{- "readinessProbe:" | yellow | nindent 2 }} {{ template "probe_summary" .containerSpec.readinessProbe }}
+    {{- end }}
+    {{- if and $hasRestarts .containerSpec.livenessProbe }}
+        {{- $p := .containerSpec.livenessProbe -}}
+        {{- $budget := add ($p.initialDelaySeconds | int) (mul ($p.failureThreshold | int) ($p.periodSeconds | int)) -}}
+        {{- "livenessProbe:" | yellow | nindent 2 }} {{ template "probe_summary" $p }} {{ "kill budget:" | bold }} {{ printf "%ds" $budget | cyan }}
+    {{- end }}
+    {{- if and $hasRestarts .containerSpec.startupProbe }}
+        {{- $p := .containerSpec.startupProbe -}}
+        {{- $budget := add ($p.initialDelaySeconds | int) (mul ($p.failureThreshold | int) ($p.periodSeconds | int)) -}}
+        {{- "startupProbe:" | yellow | nindent 2 }} {{ template "probe_summary" $p }} {{ "kill budget:" | bold }} {{ printf "%ds" $budget | cyan }}
+    {{- end }}
+    {{- if and (eq .containerStatus.state.waiting.reason "PostStartHookError") .containerSpec.lifecycle.postStart }}
+        {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" .containerSpec.lifecycle.postStart }}
+    {{- end }}
     {{- with .containerStats }}
         {{- with .rootfs }}
             {{- if .usedBytes }}
@@ -387,6 +431,28 @@
             {{- " " }}{{ template "exit_code_summary" . }}
         {{- end }}
     {{- end }}
+{{- end -}}
+
+{{- define "probe_summary" }}
+    {{- /* Displays probe action type and timing parameters. Expects a probe object. */ -}}
+    {{- with .exec }}{{ "exec" | bold }} {{ .command | join " " | cyan }}{{ end -}}
+    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" .scheme (.host | default "localhost") .port .path | cyan }}{{ end -}}
+    {{- with .tcpSocket }}{{ "tcpSocket" | bold }} {{ printf "%s:%v" (.host | default "localhost") .port | cyan }}{{ end -}}
+    {{- with .grpc }}{{ "grpc" | bold }} {{ printf ":%v" .port | cyan }}{{ with .service }} {{ . | cyan }}{{ end }}{{ end -}}
+    {{- $parts := list -}}
+    {{- with .initialDelaySeconds }}{{ $parts = append $parts (printf "delay %ds" (. | int)) }}{{ end -}}
+    {{- with .periodSeconds }}{{ $parts = append $parts (printf "every %ds" (. | int)) }}{{ end -}}
+    {{- with .timeoutSeconds }}{{ $parts = append $parts (printf "timeout %ds" (. | int)) }}{{ end -}}
+    {{- with .failureThreshold }}{{ $parts = append $parts (printf "fail after %dx" (. | int)) }}{{ end -}}
+    {{- if $parts }} ({{ join ", " $parts }}){{ end -}}
+{{- end -}}
+
+{{- define "lifecycle_hook_summary" }}
+    {{- /* Displays a lifecycle hook action. Expects a LifecycleHandler object. */ -}}
+    {{- with .exec }}{{ "exec" | bold }} {{ .command | join " " | cyan }}{{ end -}}
+    {{- with .httpGet }}{{ "httpGet" | bold }} {{ printf "%s://%s:%v%s" .scheme (.host | default "localhost") .port .path | cyan }}{{ end -}}
+    {{- with .tcpSocket }}{{ "tcpSocket" | bold }} {{ printf "%s:%v" (.host | default "localhost") .port | cyan }}{{ end -}}
+    {{- with .sleep }}{{ "sleep" | bold }} {{ printf "%vs" .seconds | cyan }}{{ end -}}
 {{- end -}}
 
 {{- define "pod_ephemeral_containers" }}

--- a/tests/artifacts/multiple-2-pods-docs.out
+++ b/tests/artifacts/multiple-2-pods-docs.out
@@ -4,6 +4,8 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
   previously: Started 1m ago and Completed after 1m
+  livenessProbe: httpGet HTTP://127.0.0.1:2381/health?exclude=NOSPACE&serializable=true (delay 10s, every 10s, timeout 15s, fail after 8x) kill budget: 90s
+  startupProbe: httpGet HTTP://127.0.0.1:2381/health?serializable=false (delay 10s, every 10s, timeout 15s, fail after 24x) kill budget: 250s
   Volumes:
     etcd-certs (HostPath: /var/lib/minikube/certs/etcd, type: DirectoryOrCreate)
     etcd-data (HostPath: /var/lib/minikube/etcd, type: DirectoryOrCreate)

--- a/tests/artifacts/multiple-2-pods-list.out
+++ b/tests/artifacts/multiple-2-pods-list.out
@@ -4,6 +4,8 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
   previously: Started 1m ago and Completed after 1m
+  livenessProbe: httpGet HTTP://127.0.0.1:2381/health?exclude=NOSPACE&serializable=true (delay 10s, every 10s, timeout 15s, fail after 8x) kill budget: 90s
+  startupProbe: httpGet HTTP://127.0.0.1:2381/health?serializable=false (delay 10s, every 10s, timeout 15s, fail after 24x) kill budget: 250s
   Volumes:
     etcd-certs (HostPath: /var/lib/minikube/certs/etcd, type: DirectoryOrCreate)
     etcd-data (HostPath: /var/lib/minikube/etcd, type: DirectoryOrCreate)

--- a/tests/artifacts/pod-liveness-kill-137.out
+++ b/tests/artifacts/pod-liveness-kill-137.out
@@ -1,0 +1,12 @@
+
+Pod/pod-liveness-kill-137 -n default, created 1m ago, gen:1, started after 0s Running BestEffort
+  Failed: Containers in CrashLoop state: app
+    Stalled: ContainerCrashLooping, Containers in CrashLoop state: app
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  Standalone POD.
+  Containers: app (busybox:1.36) Waiting CrashLoopBackOff: back-off 20s restarting failed container=app pod=pod-liveness-kill-137_default(d2bf2b74-5f4b-45e4-b391-5b8cd9d253eb), restarted 3 times
+  previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)
+  (possible liveness probe SIGKILL)
+  livenessProbe: exec false (delay 1s, every 2s, timeout 1s, fail after 2x) kill budget: 5s

--- a/tests/artifacts/pod-liveness-kill-137.yaml
+++ b/tests/artifacts/pod-liveness-kill-137.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"pod-liveness-kill-137","namespace":"default"},"spec":{"containers":[{"command":["/bin/sh","-c","trap '' TERM; sleep 3600"],"image":"busybox:1.36","livenessProbe":{"exec":{"command":["false"]},"failureThreshold":2,"initialDelaySeconds":1,"periodSeconds":2},"name":"app"}],"terminationGracePeriodSeconds":1}}
+  creationTimestamp: "2026-06-30T18:50:42Z"
+  generation: 1
+  name: pod-liveness-kill-137
+  namespace: default
+  resourceVersion: "4933"
+  uid: d2bf2b74-5f4b-45e4-b391-5b8cd9d253eb
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - -c
+    - trap '' TERM; sleep 3600
+    image: busybox:1.36
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+        - "false"
+      failureThreshold: 2
+      initialDelaySeconds: 1
+      periodSeconds: 2
+      successThreshold: 1
+      timeoutSeconds: 1
+    name: app
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-npfkw
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 1
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-npfkw
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:54:13Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:54:06Z"
+    observedGeneration: 1
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:54:49Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:54:49Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:53:15Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://ed9b173747815e677c03e7d315221fa1746cd246a9485d14a9f1ceac506ca2db
+    image: busybox:1.36
+    imageID: docker-pullable://busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    lastState:
+      terminated:
+        containerID: docker://ed9b173747815e677c03e7d315221fa1746cd246a9485d14a9f1ceac506ca2db
+        exitCode: 137
+        finishedAt: "2026-06-30T18:54:47Z"
+        reason: Error
+        startedAt: "2026-06-30T18:54:40Z"
+    name: app
+    ready: false
+    resources: {}
+    restartCount: 3
+    started: false
+    state:
+      waiting:
+        message: back-off 20s restarting failed container=app pod=pod-liveness-kill-137_default(d2bf2b74-5f4b-45e4-b391-5b8cd9d253eb)
+        reason: CrashLoopBackOff
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-npfkw
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.244.0.21
+  podIPs:
+  - ip: 10.244.0.21
+  qosClass: BestEffort
+  startTime: "2026-06-30T18:54:06Z"

--- a/tests/artifacts/pod-poststart-hook-error.out
+++ b/tests/artifacts/pod-poststart-hook-error.out
@@ -1,0 +1,11 @@
+
+Pod/pod-poststart-hook-error -n default, created 1m ago, gen:1 Running BestEffort
+  InProgress: Pod is running but is not Ready
+    Reconciling: PodRunningNotReady, Pod is running but is not Ready
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  Standalone POD.
+  Containers: app (busybox:1.36) Waiting PostStartHookError: Exec lifecycle hook ([/bin/sh -c exit 1]) for Container "app" in Pod "pod-poststart-hook-error_default(9af6a317-3023-4f5d-b537-68ca9118a791)" failed - error: command '/bin/sh -c exit 1' exited with 1: , message: ""
+  previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)
+  postStart: exec /bin/sh -c exit 1

--- a/tests/artifacts/pod-poststart-hook-error.yaml
+++ b/tests/artifacts/pod-poststart-hook-error.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"pod-poststart-hook-error","namespace":"default"},"spec":{"containers":[{"command":["sleep","3600"],"image":"busybox:1.36","lifecycle":{"postStart":{"exec":{"command":["/bin/sh","-c","exit 1"]}}},"name":"app"}]}}
+  creationTimestamp: "2026-06-30T18:47:32Z"
+  generation: 1
+  name: pod-poststart-hook-error
+  namespace: default
+  resourceVersion: "4642"
+  uid: 9af6a317-3023-4f5d-b537-68ca9118a791
+spec:
+  containers:
+  - command:
+    - sleep
+    - "3600"
+    image: busybox:1.36
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      postStart:
+        exec:
+          command:
+          - /bin/sh
+          - -c
+          - exit 1
+    name: app
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-pvlzl
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-pvlzl
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:48:14Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:47:32Z"
+    observedGeneration: 1
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:47:32Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:47:32Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:47:32Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://d6a1bbf73f7375a8265b8792b16b6fc7969887938cf5937dba163bafbe979a50
+    image: busybox:1.36
+    imageID: docker-pullable://busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    lastState:
+      terminated:
+        containerID: docker://d6a1bbf73f7375a8265b8792b16b6fc7969887938cf5937dba163bafbe979a50
+        exitCode: 137
+        finishedAt: "2026-06-30T18:48:13Z"
+        reason: Error
+        startedAt: "2026-06-30T18:47:42Z"
+    name: app
+    ready: false
+    resources: {}
+    restartCount: 0
+    started: false
+    state:
+      waiting:
+        message: 'Exec lifecycle hook ([/bin/sh -c exit 1]) for Container "app" in
+          Pod "pod-poststart-hook-error_default(9af6a317-3023-4f5d-b537-68ca9118a791)"
+          failed - error: command ''/bin/sh -c exit 1'' exited with 1: , message:
+          ""'
+        reason: PostStartHookError
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-pvlzl
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.244.0.14
+  podIPs:
+  - ip: 10.244.0.14
+  qosClass: BestEffort
+  startTime: "2026-06-30T18:47:32Z"

--- a/tests/artifacts/pod-probe-liveness-restarting.out
+++ b/tests/artifacts/pod-probe-liveness-restarting.out
@@ -1,0 +1,12 @@
+
+Pod/probe-liveness-restarting -n default, created 1m ago, gen:1 Running BestEffort
+  InProgress: Pod is running but is not Ready
+    Reconciling: PodRunningNotReady, Pod is running but is not Ready
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  Standalone POD.
+  Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready, restarted 1 times
+  previously: Started 1m ago and Completed after 1m
+  livenessProbe: exec /bin/sh -c cat /tmp/healthy (delay 1s, every 5s, timeout 1s, fail after 2x) kill budget: 11s
+  startupProbe: exec /bin/sh -c test -f /tmp/started (delay 1s, every 3s, timeout 1s, fail after 3x) kill budget: 10s

--- a/tests/artifacts/pod-probe-liveness-restarting.yaml
+++ b/tests/artifacts/pod-probe-liveness-restarting.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"probe-liveness-restarting","namespace":"default"},"spec":{"containers":[{"image":"registry.k8s.io/pause:3.9","livenessProbe":{"exec":{"command":["/bin/sh","-c","cat /tmp/healthy"]},"failureThreshold":2,"initialDelaySeconds":1,"periodSeconds":5},"name":"app","startupProbe":{"exec":{"command":["/bin/sh","-c","test -f /tmp/started"]},"failureThreshold":3,"initialDelaySeconds":1,"periodSeconds":3}}]}}
+  creationTimestamp: "2026-06-30T18:20:24Z"
+  generation: 1
+  name: probe-liveness-restarting
+  namespace: default
+  resourceVersion: "3258"
+  uid: adc3e428-fe75-4dfd-b408-7856ddf6a053
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - cat /tmp/healthy
+      failureThreshold: 2
+      initialDelaySeconds: 1
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 1
+    name: app
+    resources: {}
+    startupProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - test -f /tmp/started
+      failureThreshold: 3
+      initialDelaySeconds: 1
+      periodSeconds: 3
+      successThreshold: 1
+      timeoutSeconds: 1
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-rgjm6
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-rgjm6
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:32Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:24Z"
+    observedGeneration: 1
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:24Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:24Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:24Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://b639b7e429943d3c1a8cfdb4092223d257a163b4edee7264aea59f944190775d
+    image: registry.k8s.io/pause:3.9
+    imageID: docker-pullable://registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097
+    lastState:
+      terminated:
+        containerID: docker://a614cc8372e773c7e5e623551e8029740ee3f7c62281e40a360b53c1b44f6f79
+        exitCode: 0
+        finishedAt: "2026-06-30T18:20:41Z"
+        reason: Completed
+        startedAt: "2026-06-30T18:20:30Z"
+    name: app
+    ready: false
+    resources: {}
+    restartCount: 1
+    started: false
+    state:
+      running:
+        startedAt: "2026-06-30T18:20:44Z"
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-rgjm6
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.244.0.13
+  podIPs:
+  - ip: 10.244.0.13
+  qosClass: BestEffort
+  startTime: "2026-06-30T18:20:24Z"

--- a/tests/artifacts/pod-probe-readiness-failing.out
+++ b/tests/artifacts/pod-probe-readiness-failing.out
@@ -1,0 +1,10 @@
+
+Pod/probe-readiness-failing -n default, created 1m ago, gen:1 Running BestEffort
+  InProgress: Pod is running but is not Ready
+    Reconciling: PodRunningNotReady, Pod is running but is not Ready
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  Standalone POD.
+  Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready
+  readinessProbe: httpGet HTTP://localhost:8080/ready (delay 1s, every 5s, timeout 1s, fail after 3x)

--- a/tests/artifacts/pod-probe-readiness-failing.yaml
+++ b/tests/artifacts/pod-probe-readiness-failing.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"probe-readiness-failing","namespace":"default"},"spec":{"containers":[{"image":"registry.k8s.io/pause:3.9","name":"app","readinessProbe":{"failureThreshold":3,"httpGet":{"path":"/ready","port":8080},"initialDelaySeconds":1,"periodSeconds":5}}]}}
+  creationTimestamp: "2026-06-30T18:20:20Z"
+  generation: 1
+  name: probe-readiness-failing
+  namespace: default
+  resourceVersion: "3228"
+  uid: b7c8263f-0e7e-46c5-95b5-7d28f60dc4b9
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    imagePullPolicy: IfNotPresent
+    name: app
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /ready
+        port: 8080
+        scheme: HTTP
+      initialDelaySeconds: 1
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 1
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-mzxv5
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-mzxv5
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:27Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:20Z"
+    observedGeneration: 1
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:20Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:20Z"
+    message: 'containers with unready status: [app]'
+    observedGeneration: 1
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:20:20Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://d607c87012a25e88a5d7bbf13de77c9a545874a1c2b5cee19dd531dd25899103
+    image: registry.k8s.io/pause:3.9
+    imageID: docker-pullable://registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097
+    lastState: {}
+    name: app
+    ready: false
+    resources: {}
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2026-06-30T18:20:25Z"
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-mzxv5
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.244.0.12
+  podIPs:
+  - ip: 10.244.0.12
+  qosClass: BestEffort
+  startTime: "2026-06-30T18:20:20Z"

--- a/tests/artifacts/pod-readiness-gate.out
+++ b/tests/artifacts/pod-readiness-gate.out
@@ -1,0 +1,9 @@
+
+Pod/pod-readiness-gate -n default, created 1m ago, gen:1 Running BestEffort
+  InProgress: Pod is running but is not Ready
+    Reconciling: PodRunningNotReady, Pod is running but is not Ready
+  PodScheduled -> Initialized -> ContainersReady -> Not Ready
+    Ready ReadinessGatesNotReady, corresponding condition of pod readiness gate "custom.io/feature-ready" does not exist. for 1m
+    Readiness gate: custom.io/feature-ready: condition not yet set
+  Standalone POD.
+  Containers: app (registry.k8s.io/pause:3.9) Running for 1m and Ready

--- a/tests/artifacts/pod-readiness-gate.yaml
+++ b/tests/artifacts/pod-readiness-gate.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"pod-readiness-gate","namespace":"default"},"spec":{"containers":[{"image":"registry.k8s.io/pause:3.9","name":"app"}],"readinessGates":[{"conditionType":"custom.io/feature-ready"}]}}
+  creationTimestamp: "2026-06-30T18:55:47Z"
+  generation: 1
+  name: pod-readiness-gate
+  namespace: default
+  resourceVersion: "5012"
+  uid: 8161bfe1-ba9e-40a2-b88f-c9f48b49473c
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    imagePullPolicy: IfNotPresent
+    name: app
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-m8kwh
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  readinessGates:
+  - conditionType: custom.io/feature-ready
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: kube-api-access-m8kwh
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:55:53Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:55:47Z"
+    observedGeneration: 1
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:55:47Z"
+    message: corresponding condition of pod readiness gate "custom.io/feature-ready"
+      does not exist.
+    observedGeneration: 1
+    reason: ReadinessGatesNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:55:53Z"
+    observedGeneration: 1
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-30T18:55:47Z"
+    observedGeneration: 1
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://bacb4fc564bd9510b8800eb85c7b2c861915f826bd57d5050b1c23f801d501ff
+    image: registry.k8s.io/pause:3.9
+    imageID: docker-pullable://registry.k8s.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097
+    lastState: {}
+    name: app
+    ready: true
+    resources: {}
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2026-06-30T18:55:52Z"
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-m8kwh
+      readOnly: true
+      recursiveReadOnly: Disabled
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.244.0.22
+  podIPs:
+  - ip: 10.244.0.22
+  qosClass: BestEffort
+  startTime: "2026-06-30T18:55:47Z"


### PR DESCRIPTION
## Summary

- **readinessProbe** shown when container is running but not ready
- **livenessProbe / startupProbe** shown when container has restarts, with a kill budget (`initialDelaySeconds + failureThreshold × periodSeconds`) so you can tell how long until the next kill
- **postStart lifecycle hook** shown when container is waiting with `PostStartHookError`
- **Exit 137 annotation**: when `lastState.exitCode == 137` and a liveness probe exists and `reason != OOMKilled`, annotate as `(possible liveness probe SIGKILL)`
- **readinessGates** always shown with their current condition status (collapses to single line for 1 gate, same pattern as scheduling gates)

Closes #172

## Test plan
- [ ] `make test` passes (177 tests)
- [ ] `pod-probe-readiness-failing`: readinessProbe shown, no livenessProbe/startupProbe
- [ ] `pod-probe-liveness-restarting`: livenessProbe + startupProbe shown with kill budgets
- [ ] `pod-liveness-kill-137`: kill annotation + livenessProbe shown
- [ ] `pod-poststart-hook-error`: postStart hook shown
- [ ] `pod-readiness-gate`: single readiness gate collapsed inline with "condition not yet set"

🤖 Generated with [Claude Code](https://claude.com/claude-code)