### PR TITLE
Extract template conventions into CONVENTIONS.md

### DIFF
--- a/.claude/skills/generate-template/SKILL.md
+++ b/.claude/skills/generate-template/SKILL.md
@@ -25,7 +25,7 @@ Generate kubectl-status Go template files for resource kinds and write them to
 kubectl api-resources | grep -i <name>
 ```
 
-Note the exact **Kind** string (case-sensitive — used as the template `define` name).
+Note the exact **Kind** string (case-sensitive — used as the template `define` name) and the `APIVERSION` column value.
 
 ### 2. Read the full CRD schema
 
@@ -36,9 +36,8 @@ kubectl get crd <full-crd-name> -o json | jq '.spec.versions[0].schema.openAPIV3
 Read `spec` and `status` sub-schemas **in full** — not just top-level keys. For each field, check its `description` to understand what it means. Use that meaning to decide whether it warrants inclusion, applying the output philosophy in CONVENTIONS.md.
 
 Pay specific attention to:
-- **Timestamps** — apply the date formatting pattern in CONVENTIONS.md § Dates.
+- **Timestamps** — apply the date formatting rules in CONVENTIONS.md § Dates.
 - **Booleans and enums** — never emit raw `true`/`false`; emit a meaningful label only when the value is operationally interesting.
-- **Fields that are always at their default** — omit them.
 
 ### 3. Sample live instances
 
@@ -53,176 +52,11 @@ Cross-reference the schema against what is actually populated. Skip status field
 
 File: `~/.kubectl-status/templates/<Kind>.tmpl`
 
-#### Structure
+Copy the `define` wrapper and bookend sections from any existing template. The GVK comment (`{{- /* GVK: group/version, Kind=<Kind> */ -}}`) must follow the `gotype` comment immediately after `define`. Section order and what `status_summary_line` already covers are in CONVENTIONS.md § Section order.
 
-```
-{{- define "<Kind>" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* GVK: <group>/<version>, Kind=<Kind> */ -}}
-    {{- template "status_summary_line" . }}
-    {{- template "kstatus_summary" . }}
-    {{- template "finalizer_details_on_termination" . }}
-    {{- template "observed_generation_summary" . }}
-    {{- template "application_details" . }}
-    ... resource-specific content ...
-    {{- template "conditions_summary" . }}
-    {{- template "recent_updates" . }}
-    {{- template "events" . }}
-    {{- template "owners" . }}
-{{- end }}
-```
-
-The GVK comment (`{{- /* GVK: ... */ -}}`) must always follow the `gotype` comment. Use the exact group/version from `kubectl api-resources` output (column `APIVERSION`).
-
-Section order and what `status_summary_line` already covers are defined in CONVENTIONS.md § Section order.
-
-#### Output and style conventions
-
-All design rules are in CONVENTIONS.md. Key reminders for implementation:
-
-- **Prose over key:value** — when fields form a sentence, write prose; fall back to `Bold: cyan` for standalone fields. See CONVENTIONS.md § Prose over key:value.
-- **Value highlighting** — `| cyan` on all plain values; never override `redBoldIf`, `redIf`, `colorKeyword`, `colorAgo`. Integers need `| toString` first.
-- **Zero-value fields** — `{{with}}` hides `false`/`0`/`""`; use `{{if hasKey}}` when zero is operationally meaningful.
-- **Dates** — `colorAgo` for past only; date-string for future (colorAgo goes negative for future timestamps).
-- **Conditions** — always `conditions_summary`; never re-render manually.
-
-#### Single-item list collapsing
-
-See CONVENTIONS.md § Single-item list collapsing for the rule. Implementation:
-
-```
-{{- with .Spec.hostnames }}
-    {{- "Hostnames" | bold | nindent 2 }}:
-    {{- if eq (len .) 1 }}
-        {{- " " }}{{ index . 0 | cyan }}
-    {{- else }}
-        {{- range . }}
-            {{- . | cyan | nindent 4 }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-```
-
-Lists of structs follow the same rule — if there is one item, render its key fields inline after the title:
-
-```
-{{- with .Spec.parentRefs }}
-    {{- "Parents" | bold | nindent 2 }}:
-    {{- if eq (len .) 1 }}
-        {{- $p := index . 0 }}
-        {{- " " }}{{ printf "%s/%s" ($p.kind | default "Gateway") $p.name | cyan }}
-        {{- with $p.sectionName }} [{{ . | cyan }}]{{ end }}
-    {{- else }}
-        {{- range . }}
-            {{- printf "%s/%s" (.kind | default "Gateway") .name | cyan | nindent 4 }}
-            {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-```
-
-Exception: skip collapsing when items have rich sub-fields (conditions, nested refs) that always require indented lines.
-
-#### Merging parallel spec/status lists
-
-See CONVENTIONS.md § Merging parallel spec/status lists for the rule. Implementation — range over spec, look up matching status entry by key:
-
-```
-{{- with .Spec.listeners }}
-    {{- "Listeners" | bold | nindent 2 }}:
-    {{- range . }}
-        {{- $spec := . }}
-        {{- $status := dict }}
-        {{- range $.Status.listeners }}
-            {{- if eq .name $spec.name }}{{ $status = . }}{{ end }}
-        {{- end }}
-        {{- .name | bold | nindent 4 }}: port={{ printf "%d" (.port | int) | cyan }}/{{ .protocol | cyan }}
-        {{- with .hostname }}, host={{ . | cyan }}{{ end }}
-        {{- with $status.supportedKinds }}, accepts={{ range $i, $k := . }}{{ if $i }}/{{ end }}{{ $k.kind | cyan }}{{ end }}{{ end }}
-        {{- if hasKey $status "attachedRoutes" }}, routes={{ $status.attachedRoutes | toString | cyan }}{{ end }}
-        {{- range $status.conditions }}
-            {{- $.Include "condition_summary" . | nindent 6 }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-```
-
-How to spot this pattern: a `status` list whose items share a key field (usually `name`) with a `spec` list, where status items carry only runtime fields (counts, conditions, supported kinds).
-
-#### Label selectors
-
-Any `LabelSelector` field must use the `labelSelector` pipe function — manually joining `matchLabels` silently drops `matchExpressions`. See CONVENTIONS.md § Label selectors for the rule.
-
-Standard selector block (implements all three rendering modes — see CONVENTIONS.md § Rendering depth):
-
-```
-{{- with .Spec.selector }}
-    {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $matchLabels := .matchLabels }}
-        {{- if $.Config.GetBool "deep" }}
-            {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                {{- $.IncludeRenderableObject . | nindent 4 }}
-            {{- end }}
-        {{- else }}
-            {{- $svcs := $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
-            {{- $deploys := $.KubeGetByLabelsMap $.Namespace "deployments" $matchLabels }}
-            {{- $daemonsets := $.KubeGetByLabelsMap $.Namespace "daemonsets" $matchLabels }}
-            {{- $statefulsets := $.KubeGetByLabelsMap $.Namespace "statefulsets" $matchLabels }}
-            {{- range $svcs }}
-                {{- $.Include "service_health_summary" . | nindent 4 }}
-            {{- end }}
-            {{- if or $deploys $daemonsets $statefulsets }}
-                {{- range $deploys }}{{ $.Include "workload_health_summary" . | nindent 4 }}{{ end }}
-                {{- range $daemonsets }}{{ $.Include "workload_health_summary" . | nindent 4 }}{{ end }}
-                {{- range $statefulsets }}{{ $.Include "workload_health_summary" . | nindent 4 }}{{ end }}
-            {{- else }}
-                {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.Include "pod_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-```
-
-`selector_with_health_summary` in `common.tmpl` implements this pattern — prefer it when you don't need custom health summary logic.
-
-Note: `KubeGetByLabelsMap` queries workload metadata labels. `KubeGetServicesMatchingLabels` checks whether the service's selector is a subset of `matchLabels`.
-
-#### Reference fields
-
-See CONVENTIONS.md § Rendering depth for the rule. Use `$.Include "resource_ref"` (not `template`) so the result can be piped to `nindent`.
-
-Single ref:
-```
-{{- with .Spec.issuerRef }}
-    {{- if $.Config.GetBool "deep" }}
-        {{- $obj := $.KubeGetFirst (coalesce .namespace $.Namespace) (.kind | default "Issuer") .name }}
-        {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
-    {{- else }}
-        {{- "Issuer" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Issuer") "name" .name "namespace" .namespace) }}
-    {{- end }}
-{{- end }}
-```
-
-List of refs:
-```
-{{- with .Spec.resourceRefs }}
-    {{- if $.Config.GetBool "deep" }}
-        {{- range . }}
-            {{- $obj := $.KubeGetFirst (coalesce .namespace $.Namespace) .kind .name }}
-            {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
-        {{- end }}
-    {{- else }}
-        {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace) | nindent 2 }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-```
-
-Identify ref fields by looking for objects with `kind`, `name` (and optionally `namespace`, `group`, `apiVersion`) properties, or by reading the field description.
+All design rules are in CONVENTIONS.md. Implementation pointers:
+- **Label selectors** — use `selector_with_health_summary` from `common.tmpl`; only hand-roll when custom health logic is needed.
+- **Reference fields** — `HTTPRoute.tmpl` has worked examples of both single-ref and list-of-refs forms.
 
 ### 5. Verify
 

--- a/.claude/skills/generate-template/SKILL.md
+++ b/.claude/skills/generate-template/SKILL.md
@@ -12,9 +12,9 @@ Generate kubectl-status Go template files for resource kinds and write them to
 
 ## Reference material — read before writing
 
+- **`CONVENTIONS.md`** — output philosophy, color rules, and all template design conventions. Read this first.
 - **`pkg/plugin/templates/common.tmpl`** — all shared sub-templates and available functions.
 - **`pkg/plugin/templates/`** — built-in templates as style examples.
-- **`CONTRIBUTING.md`** — read the **General Guidelines** section (Output Contents Guidelines and Color Coding Guidelines).
 - **`~/.kubectl-status/templates/`** — user CRD template examples.
 
 ## Steps
@@ -33,10 +33,10 @@ Note the exact **Kind** string (case-sensitive — used as the template `define`
 kubectl get crd <full-crd-name> -o json | jq '.spec.versions[0].schema.openAPIV3Schema.properties'
 ```
 
-Read `spec` and `status` sub-schemas **in full** — not just top-level keys. For each field, check its `description` to understand what it means. Use that meaning to decide whether it warrants inclusion, applying the Output Contents Guidelines under **General Guidelines** in CONTRIBUTING.md.
+Read `spec` and `status` sub-schemas **in full** — not just top-level keys. For each field, check its `description` to understand what it means. Use that meaning to decide whether it warrants inclusion, applying the output philosophy in CONVENTIONS.md.
 
 Pay specific attention to:
-- **Timestamps** — apply the date formatting pattern below.
+- **Timestamps** — apply the date formatting pattern in CONVENTIONS.md § Dates.
 - **Booleans and enums** — never emit raw `true`/`false`; emit a meaningful label only when the value is operationally interesting.
 - **Fields that are always at their default** — omit them.
 
@@ -74,49 +74,21 @@ File: `~/.kubectl-status/templates/<Kind>.tmpl`
 
 The GVK comment (`{{- /* GVK: ... */ -}}`) must always follow the `gotype` comment. Use the exact group/version from `kubectl api-resources` output (column `APIVERSION`).
 
-Do not reorder the shared sub-templates. Do not repeat what `status_summary_line` already shows (Kind, Name, Namespace, creation time, owner, phase).
+Section order and what `status_summary_line` already covers are defined in CONVENTIONS.md § Section order.
 
-#### Prose over key:value
+#### Output and style conventions
 
-When multiple related fields form a natural sentence, write prose rather than stacked labels:
+All design rules are in CONVENTIONS.md. Key reminders for implementation:
 
-```
-{{- "Issued by" | nindent 2 }} {{ printf "%s/%s" .kind .name | cyan | bold }} for {{ $primary | cyan }} · stored in {{ printf "secret/%s" $.Spec.secretName | cyan }}
-```
+- **Prose over key:value** — when fields form a sentence, write prose; fall back to `Bold: cyan` for standalone fields. See CONVENTIONS.md § Prose over key:value.
+- **Value highlighting** — `| cyan` on all plain values; never override `redBoldIf`, `redIf`, `colorKeyword`, `colorAgo`. Integers need `| toString` first.
+- **Zero-value fields** — `{{with}}` hides `false`/`0`/`""`; use `{{if hasKey}}` when zero is operationally meaningful.
+- **Dates** — `colorAgo` for past only; date-string for future (colorAgo goes negative for future timestamps).
+- **Conditions** — always `conditions_summary`; never re-render manually.
 
-Indent supporting detail under a prose line with `nindent 4` to show grouping:
+#### Single-item list collapsing
 
-```
-  Issued by ClusterIssuer/cluster-issuer for "foo" · stored in secret/foo-tls
-    Org: ServiceNow
-    Also valid for: foo.svc, foo.svc.cluster.local
-```
-
-Fall back to `"Label" | bold | nindent 2 }}: {{ value | cyan }}` for fields that stand alone.
-
-#### Value highlighting
-
-Apply `| cyan` to plain values so they are visually distinct from bold labels. Do **not** stack `cyan` on top of a semantic color function (`redBoldIf`, `redIf`, `colorKeyword`, `colorAgo`) — those must not be overridden.
-
-`cyan` expects a string. Integer fields must be converted first:
-
-```
-{{- $statusListener.attachedRoutes | toString | cyan }}
-```
-
-#### Zero-value fields
-
-`{{- with .someField }}` skips when the value is zero, `false`, or empty — which hides operationally meaningful zeroes (e.g. `routes=0` means nothing is attached). Use `if hasKey` instead when zero is significant:
-
-```
-{{- if hasKey $statusEntry "attachedRoutes" }}, routes={{ $statusEntry.attachedRoutes | toString | cyan }}{{ end }}
-```
-
-Use `with` only when the zero/empty case genuinely means "omit this field entirely".
-
-#### Single-item lists
-
-When a list field is rendered as an indented block under a bold title, check the length at render time. If there is only one item, collapse it onto the title line instead — the indented block form only pays off when there are multiple items to scan:
+See CONVENTIONS.md § Single-item list collapsing for the rule. Implementation:
 
 ```
 {{- with .Spec.hostnames }}
@@ -131,7 +103,7 @@ When a list field is rendered as an indented block under a bold title, check the
 {{- end }}
 ```
 
-Apply this wherever a label + list would otherwise always produce a block. Lists of structs follow the same rule — if there is one item, render its key fields inline after the title rather than indenting a sub-block:
+Lists of structs follow the same rule — if there is one item, render its key fields inline after the title:
 
 ```
 {{- with .Spec.parentRefs }}
@@ -149,11 +121,11 @@ Apply this wherever a label + list would otherwise always produce a block. Lists
 {{- end }}
 ```
 
-**Exception:** skip this collapsing when the items themselves have rich sub-fields (conditions, nested refs) that always require indented lines — collapsing the header does not help if the body still expands below it.
+Exception: skip collapsing when items have rich sub-fields (conditions, nested refs) that always require indented lines.
 
 #### Merging parallel spec/status lists
 
-Some resources split a single logical list across `spec` and `status` — same items, complementary fields (e.g. Gateway `spec.listeners` + `status.listeners`, both keyed by `name`). **Do not render them as two separate blocks.** Merge them by ranging over the spec list and looking up the matching status entry by key:
+See CONVENTIONS.md § Merging parallel spec/status lists for the rule. Implementation — range over spec, look up matching status entry by key:
 
 ```
 {{- with .Spec.listeners }}
@@ -175,40 +147,13 @@ Some resources split a single logical list across `spec` and `status` — same i
 {{- end }}
 ```
 
-**How to spot this pattern in the schema:** look for a `status` field whose items have a `name` (or similar key) that matches item names in a `spec` list, where the status items carry only runtime fields (counts, conditions, supported kinds) and no config. When you see this, always merge — the reader should never have to cross-reference two separate blocks by name.
-
-#### Dates
-
-`colorAgo` uses `time.Since()`, so future dates produce a confusing negative output. For past dates use `colorAgo` with a relative hint; for future dates show only the date portion:
-
-```
-{{- $issuedDate := (split "T" .Status.issuedAt)._0 }}
-{{- "Issued" | bold | nindent 2 }} {{ $issuedDate | cyan }} ({{ .Status.issuedAt | colorAgo }}{{ agoSuffix }}), expires {{ (split "T" .Status.notAfter)._0 | cyan }}
-```
-
-#### Conditions
-
-`conditions_summary` renders `.status.conditions[]` with coloring and timestamps already applied. Do not re-render conditions manually.
+How to spot this pattern: a `status` list whose items share a key field (usually `name`) with a `spec` list, where status items carry only runtime fields (counts, conditions, supported kinds).
 
 #### Label selectors
 
-Any field that is a Kubernetes `LabelSelector` (has `matchLabels` and/or `matchExpressions`) must be rendered with the `labelSelector` pipe function — it handles both selector forms and produces a `kubectl get --selector`-compatible string:
+Any `LabelSelector` field must use the `labelSelector` pipe function — manually joining `matchLabels` silently drops `matchExpressions`. See CONVENTIONS.md § Label selectors for the rule.
 
-```
-{{- with .Spec.selector }}
-    {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
-{{- end }}
-```
-
-Do **not** manually join `matchLabels` keys — that silently drops `matchExpressions`.
-
-When a `LabelSelector` targets pods (as in PDB, NetworkPolicy, etc.), show matching resource health summaries indented under the selector line. Three shared sub-templates in `common.tmpl` produce compact single-line summaries:
-
-- **`pod_health_summary`** — `Pod/name -n ns Running, 2/2 ready`
-- **`service_health_summary`** — `Service/name -n ns, 3 ready, 1 not ready`
-- **`workload_health_summary`** — `Deployment/name -n ns, 2/2 ready` / `DaemonSet/name -n ns, 3/3 scheduled`
-
-Standard selector block pattern (respects all three modes — `--shallow`, default, `--deep`):
+Standard selector block (implements all three rendering modes — see CONVENTIONS.md § Rendering depth):
 
 ```
 {{- with .Spec.selector }}
@@ -241,13 +186,13 @@ Standard selector block pattern (respects all three modes — `--shallow`, defau
 {{- end }}
 ```
 
-Behaviour: `--shallow` → selector string only; default → services + workloads as single-line summaries (falls back to pods if no workloads match); `--deep` → full inline pod renders.
+`selector_with_health_summary` in `common.tmpl` implements this pattern — prefer it when you don't need custom health summary logic.
 
-Note: `KubeGetByLabelsMap` queries metadata labels of the workload resources, not their pod template labels. This works for the common Kubernetes pattern where Deployments/DS/STS carry the same labels as their pod selector. `KubeGetServicesMatchingLabels` checks whether the service's selector is a subset of `matchLabels`, which correctly identifies services fronting the same pods.
+Note: `KubeGetByLabelsMap` queries workload metadata labels. `KubeGetServicesMatchingLabels` checks whether the service's selector is a subset of `matchLabels`.
 
-#### Reference fields (`--deep` inline rendering)
+#### Reference fields
 
-Any field that references another Kubernetes resource by kind/name must be rendered inline when `--deep` is set. Always show the reference as `Kind/name -n namespace` using the `resource_ref` template in the default case. Use `$.Include "resource_ref"` (not `template`) so the result can be piped to `nindent`.
+See CONVENTIONS.md § Rendering depth for the rule. Use `$.Include "resource_ref"` (not `template`) so the result can be piped to `nindent`.
 
 Single ref:
 ```
@@ -277,8 +222,7 @@ List of refs:
 {{- end }}
 ```
 
-Identify ref fields in the schema by looking for objects with `kind`, `name` (and optionally `namespace`, `group`, `apiVersion`) properties, or by reading the field description.
-
+Identify ref fields by looking for objects with `kind`, `name` (and optionally `namespace`, `group`, `apiVersion`) properties, or by reading the field description.
 
 ### 5. Verify
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,8 @@ community looks forward to your contributions. 🎉
   - [Suggesting Enhancements](#suggesting-enhancements)
     - [Before Submitting an Enhancement](#before-submitting-an-enhancement)
     - [How Do I Submit a Good Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion-)
-  - [General Guidelines](#general-guidelines)
-    - [Output Contents Guidelines](#output-contents-guidelines)
-    - [Color Coding Guidelines](#color-coding-guidelines)
-  - [Claude Code Integration](#claude-code-integration)
   - [Your First Code Contribution](#your-first-code-contribution)
+  - [Claude Code Integration](#claude-code-integration)
   - [Improving The Documentation](#improving-the-documentation)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
@@ -157,55 +154,10 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/berger
 - **Explain why this enhancement would be useful** to most kubectl-status users. You may also want to point out the
   other projects that solved it better and which could serve as inspiration.
 
-### General Guidelines
+### Design conventions
 
-#### Output Contents Guidelines
+Before writing or reviewing any template output, read [**CONVENTIONS.md**](CONVENTIONS.md). It covers output philosophy, color coding, template section order, prose style, value highlighting, and the shallow/default/deep rendering pattern.
 
-* Aim output to be for humans "only", don't put any effort to make the output friendly for parsers.
-* Try to keep the output as compact as possible. Compact output is one of the main differentiation points
-  from `kubectl describe`.
-* It's tempting to assume colors always work but don't forget that users will want to share the output with others by
-  copy-paste, which results in lost ASCII color codes. E.g., coloring "Ready" in green or red to indicate the status is
-  usually not ideal. Prefer "Not Ready" for representing the faulty state in such cases.
-* Not all status fields/values are meaningful as they are represented in the raw Kubernetes resources, don't try to keep
-  them as they are if you can make it more human-friendly. E.g., Prefer "Not Ready" over "Ready: false".
-* Drop not so meaningful fields or fields with a well-known default from the output. E.g., podIP, hostIP, containerID,
-  imageID of a pod doesn't hold much value for understanding the status of a pod.
-* Be opinionated about representing the status, as long as it helps users get the current status of the resource in
-  question.
-* Assume some level of knowledge and don't try to over-explain, but explain non-obvious/edge cases and be explicit about
-  possibly impacting states of resources. E.g., ongoing rollout issues, or not having any "Ready" Pods in a Deployment (
-  usually means Outage), or a Service with no endpoints (again likely an Outage).
-* Don't include spec fields unless they have significant value for setting the context for the current status. E.g.,
-  Knowing the .spec.replicas value is relevant to understand the status of a ReplicaSet, but ingress host values are
-  pure spec.
-* When some related information is not available in the status fields of a resource, go the extra mile of doing further
-  queries to obtain more information which may be helpful for users to understand the current status. E.g., fetch
-  NodeMetrics and Pods when showing a node's status.
-* Being aligned with the terminology used by Kubernetes and used in the individual status fields is good but not
-  mandatory.
-* If you can identify conventions in the status fields, make them generic templates and include them in the
-  DefaultResource template, so any other CRDs following those conventions can benefit right away without having to
-  implement a new Kind template. E.g., `observedGeneration`, `conditions`, `replicas`.
-
-#### Color Coding Guidelines
-
-* Follow traffic lights convention. Users expect them to map to error/warning/ok consecutively. But, prefer \[`red`
-  /`yellow`/regular] over \[`red`/`yellow`/`green`] to prevent `green` over-usage.
-* Don't use `green` extensively. Use when a dedicated status field indicates an explicit healthy status. E.g., use green
-  when Ready is True (or "active", "running"), but don't use when ready replicas are matching the desired replicas.
-* Use `yellow` for issues that are well known to be transient but may be impacting or bad practices. E.g., ongoing
-  rollout, or using a `latest` image tag.
-* Use `bold red` for potential issues that need attention.
-* Prefer `red` over `bold red` for long explanation/description of a faulty state. E.g.
-  for `.status.conditions[].message` field for a faulty condition.
-* Prefer `bold red` over `red` if the highlighted text is a single word, camelCase, or PascalCase. E.g. for `
-  .status.conditions[].reason field for a faulty condition.
-* When you need to colorize a short key/value pair in a faulty state, prefer highlighting both the key and the value,
-  not either. E.g., For `readyPodCount:0`, paint the whole expression to `red` rather than just key or value.
-
-<!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines
-     the structure of the information to be included. If you do so, reference it here in the description. -->
 ### Your First Code Contribution
 
 Then use `make` to get the compiled binary:
@@ -230,8 +182,6 @@ Before submitting a PR, ensure tests pass:
 ```bash
 make test
 ```
-
-kubectl-status follows the below guidelines to have a consistent user experience across different resources.
 
 ### Claude Code Integration
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,144 @@
+# kubectl-status Conventions
+
+Design rules that apply to all kubectl-status output and templates. Read this before writing or reviewing a template.
+
+For the step-by-step template authoring workflow (reading CRD schemas, sampling live instances, verifying output) see [`CONTRIBUTING.md`](CONTRIBUTING.md#your-first-code-contribution).
+
+## Output philosophy
+
+- **Human-only output.** Don't make output parser-friendly — no stable column widths, no machine-parseable structure.
+- **Compact over complete.** Compact output is the main differentiator from `kubectl describe`. Omit fields with well-known defaults (e.g. `podIP`, `hostIP`, `containerID`).
+- **Readable without color.** Users share output via copy-paste, losing ANSI codes. Never rely on color alone to convey state — use text that is unambiguous in plain output. E.g. prefer `Not Ready` over coloring the word `Ready` red.
+- **Transform, don't transcribe.** Raw Kubernetes field values are often not human-friendly. Prefer `Not Ready` over `Ready: false`.
+- **Be opinionated.** Express status clearly. Spell out impact where it matters: a Service with no endpoints likely means an outage — say so.
+- **Surface what isn't in the resource.** When status fields alone are insufficient, make additional API calls. E.g. fetch NodeMetrics and Pods when showing a Node.
+- **Spec fields only when contextually necessary.** Include spec only when it sets context for understanding current status (e.g. `.spec.replicas` for a ReplicaSet). Omit pure configuration (e.g. Ingress host values).
+- **Promote generic patterns.** If a convention appears across multiple resource types (e.g. `observedGeneration`, `conditions`, `replicas`), implement it in `DefaultResource` or `common.tmpl` so all resources benefit.
+
+## Color coding
+
+Traffic-light convention, but restrained:
+
+| Color | Use for |
+|---|---|
+| regular | Healthy / nominal state |
+| `green` | Explicit healthy signal from a dedicated status field — `Ready: True`, `Running`, `Active`. Do **not** use just because counts match. |
+| `yellow` | Known-transient issues or bad practices — ongoing rollout, `latest` image tag. |
+| `red` | Faulty states requiring attention. Use for long messages (condition `.message`). |
+| `bold red` | Single words, camelCase, or PascalCase in a faulty state (condition `.reason`, a resource kind). |
+
+For short key/value pairs in a faulty state, colorize the whole expression — not just the key or just the value. E.g. paint `readyPodCount:0` as one `red` unit.
+
+## Template conventions
+
+### Section order
+
+Every template follows this fixed structure. Do not add content that duplicates what `status_summary_line` already shows (Kind, Name, Namespace, creation time, owner reference, phase).
+
+```
+{{- template "status_summary_line" . }}
+{{- template "kstatus_summary" . }}
+{{- template "finalizer_details_on_termination" . }}
+{{- template "observed_generation_summary" . }}
+{{- template "application_details" . }}
+... resource-specific content ...
+{{- template "conditions_summary" . }}
+{{- template "recent_updates" . }}
+{{- template "events" . }}
+{{- template "owners" . }}
+```
+
+The bookend sections (`kstatus_summary`, `conditions_summary`, `recent_updates`, `events`, `owners`) stay in this order. Resource-specific body sections go where they make most sense contextually — typically immediately after the content they annotate. Omit a bookend section when it adds no signal for the resource type (e.g. `kstatus_summary` always reports "Resource is always ready" for CronJob — omit it).
+
+### Prose over key:value
+
+When multiple related fields form a natural sentence, write prose rather than stacking `Label: value` pairs:
+
+```
+  Issued by ClusterIssuer/cluster-issuer for "foo" · stored in secret/foo-tls
+    Org: ServiceNow
+    Also valid for: foo.svc, foo.svc.cluster.local
+```
+
+Reserve `**Bold label**: cyan value` for fields that genuinely stand alone and don't connect to adjacent fields.
+
+### Value highlighting
+
+Apply `| cyan` to plain values so they are visually distinct from bold labels. Never stack `cyan` on top of a semantic color function — `redBoldIf`, `redIf`, `colorKeyword`, and `colorAgo` must not be overridden.
+
+`cyan` expects a string; convert integers first: `{{ .count | toString | cyan }}`.
+
+### Zero-value fields
+
+`{{- with .field }}` skips when the value is `false`, `0`, or `""`. This hides operationally meaningful zeroes — `routes=0` means nothing is attached and is worth showing. Use `if hasKey` when zero is significant:
+
+```
+{{- if hasKey $status "attachedRoutes" }}, routes={{ $status.attachedRoutes | toString | cyan }}{{ end }}
+```
+
+Use `with` only when the zero/empty case genuinely means "omit this field entirely".
+
+### Single-item list collapsing
+
+An indented block for a single item wastes vertical space. When rendering a labeled list, check the length: if there is exactly one item, collapse it onto the title line. The block form only pays off with multiple items to scan.
+
+Exception: when items themselves have rich sub-fields (conditions, nested refs) that always need indented lines, collapsing the header does not help.
+
+### Merging parallel spec/status lists
+
+Some resources split a single logical list across `spec` and `status` — same items keyed by name, with complementary fields (e.g. `spec.listeners` carries port/protocol/hostname; `status.listeners` carries conditions and attached route counts). **Never render these as two separate blocks** — that forces the reader to cross-reference by name.
+
+Spot the pattern: a `status` list whose items have a key field (usually `name`) that matches items in a `spec` list, where status items carry only runtime fields. When you see it, range over spec and look up the matching status entry by key.
+
+### Dates
+
+`colorAgo` uses `time.Since()` — it produces a confusing negative value for future timestamps. Use `colorAgo` only for past dates. For future dates (expiry, scheduled time), show only the date portion (`(split "T" .timestamp)._0`).
+
+### Conditions
+
+Use `conditions_summary` for `.status.conditions[]`. It applies coloring and relative timestamps. Never re-render conditions manually.
+
+### Label selectors
+
+Any field that is a Kubernetes `LabelSelector` (`matchLabels` and/or `matchExpressions`) must be rendered with the `labelSelector` pipe function. Manually joining `matchLabels` keys silently drops `matchExpressions`.
+
+When a selector targets pods, show matching resource health summaries indented under the selector line — see [Rendering depth](#rendering-depth) below.
+
+### Rendering depth
+
+Any template section that fetches related resources must respect the three rendering modes:
+
+**`--shallow`** — skip the section entirely. Some Go helpers already return an empty slice in shallow mode (e.g. `KubeGetIngressesMatchingService`); for label-based lookups, gate explicitly in the template with `if not ($.Config.GetBool "shallow")`.
+
+**default** — compact single-line summaries using shared sub-templates from `common.tmpl`:
+
+| Sub-template | Example output |
+|---|---|
+| `pod_health_summary` | `Pod/name -n ns, 2/2 ready` |
+| `service_health_summary` | `Service/name -n ns, 3 ready, 1 not ready` |
+| `workload_health_summary` | `Deployment/name -n ns, 2/2 ready` |
+| `job_health_summary` | `Job/name -n ns, Active, started 5m ago` |
+
+**`--deep`** — full inline render with `$.IncludeRenderableObject . | nindent 4`.
+
+For **label selectors**, `selector_with_health_summary` in `common.tmpl` implements all three modes automatically — prefer it over hand-rolling the same logic.
+
+For **reference fields** (spec fields pointing to another resource by kind/name), show `Kind/name -n ns` via the `resource_ref` sub-template in the default case, and `$.IncludeRenderableObject` in deep mode. `HTTPRoute.tmpl` has worked examples of both single-ref and list-of-refs forms.
+
+### Go template `and`/`or` do not short-circuit
+
+Unlike most languages, Go templates evaluate **all** arguments to `and` and `or` before applying the logic. `{{ if and .A (someFunc .A.B) }}` panics when `.A` is nil because `.A.B` is always evaluated. Use nested `with`/`if` blocks for any chained field access that could be nil:
+
+```
+{{- with .Status.lastSuccessfulTime }}
+    {{- if lt . $threshold }}
+```
+
+Never rely on `and` to guard a nil dereference.
+
+### Omit spec fields at their Kubernetes default
+
+Show a spec field only when it deviates from the Kubernetes-defined default. Emitting the default adds noise for the vast majority of users running standard configurations. Common defaults to suppress: `RollingUpdate` (Deployment strategy), `Allow` (CronJob concurrencyPolicy), `/metrics` and `HTTP` (ServiceMonitor endpoint path/scheme), `NonIndexed` (Job completionMode), `TerminatingOrFailed` (Job podReplacementPolicy).
+
+Use `ne (.field | default "DefaultValue") "DefaultValue"` to gate the output.
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fully supported.
 - [Features](#features)
 - [Usage](#usage)
 - [Development](#development)
-    * [Guidelines](./CONTRIBUTING.md#general-guidelines)
+    * [Conventions](./CONVENTIONS.md)
 - [License](#license)
 
 ## Installation
@@ -84,7 +84,8 @@ kubectl status node -l node-role.kubernetes.io/master  # Show status of nodes ma
 
 ## Development
 
-Please see [CONTRIBUTING.md](./CONTRIBUTING.md) file for development related documents.
+- [CONVENTIONS.md](./CONVENTIONS.md) — output philosophy, color rules, and template patterns
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — how to build, test, and submit changes
 
 The project includes a [Claude Code](https://claude.ai/code) skill (`/generate-template`) that can scaffold kubectl-status templates for any CRD in your current context. See [Claude Code Integration](./CONTRIBUTING.md#claude-code-integration) in CONTRIBUTING.md.
 

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -266,6 +266,8 @@
     {{- with .Spec.selector }}
         {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
         {{- $matchLabels := .matchLabels }}
+        {{- /* $matchLabels is nil when the selector uses only matchExpressions; passing nil to
+             KubeGetByLabelsMap builds an empty selector and matches every pod in the namespace. */ -}}
         {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
             {{- if $.Config.GetBool "deep" }}
                 {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}


### PR DESCRIPTION
## Summary

- Consolidates output philosophy, color coding, and all template design rules from `CONTRIBUTING.md` and `.claude/skills/generate-template/SKILL.md` into a new canonical `CONVENTIONS.md`
- `CONTRIBUTING.md` now has a single paragraph pointing to `CONVENTIONS.md` instead of duplicating the full guidelines
- `generate-template/SKILL.md` is compressed to short reminders + `§ Section` cross-references; concrete rules live in one place
- Adds two new sections not previously documented: Go template `and`/`or` short-circuit footgun, and spec-field default suppression
- Adds a nil-guard comment in `common.tmpl` for `matchExpressions`-only selectors (where `matchLabels` is nil)
- `README.md` splits the old single "See CONTRIBUTING.md" line into two distinct bullets for discoverability

## Test plan

- [ ] `make test` passes (no template or Go code logic changed)
- [ ] CONVENTIONS.md renders correctly on GitHub (table, code blocks, section anchors)
- [ ] Cross-references in SKILL.md (`CONVENTIONS.md § <Section>`) resolve to real headings
- [ ] README.md links to CONVENTIONS.md and CONTRIBUTING.md both resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)