### PR TITLE
Support and highlight NodePort services

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -382,6 +382,22 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.pod.regex",
 		}.assert(t, nodeNameModifier)
 	})
+	t.Run("sts-with-nodeport", func(t *testing.T) {
+		viperTestHack(t)
+		// using sts here as the pod name is predictable in that case, not true for deployments and ds
+		applyManifest(t, "e2e-artifacts/sts-with-nodeport.yaml")
+		waitFor(t, "sts/sts-with-nodeport", "jsonpath={.status.readyReplicas}=1")
+		cmdTest{
+			// Log/volume usage bytes come from live kubelet stats and aren't reproducible
+			// across runs, so this is matched as a regex rather than exact text.
+			args:            []string{"pod/sts-with-nodeport-0", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.pod.regex",
+		}.assert(t, nodeNameModifier)
+		cmdTest{
+			args:            []string{"pdb/sts-with-nodeport", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.pdb.regex",
+		}.assert(t, nodeNameModifier)
+	})
 }
 
 func applyManifest(t *testing.T, filepath string) {

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -9,7 +9,7 @@
     {{- if eq .Spec.type "NodePort" }}
         {{- " " }}{{ "NodePort" | yellow | bold }}:
         {{- range $index, $port := .Spec.ports }}
-            {{- if $index }}, {{ end }}{{ $port.nodePort | toString | cyan }}{{ with $port.name }} ({{ . }}){{ end }}
+            {{- if $index }}, {{ end }}{{ with $port.nodePort }}{{ . | toString | cyan }}{{ else }}{{ "auto" | yellow }}{{ end }}{{ with $port.name }} ({{ . }}){{ end }}
         {{- end }}
     {{- end }}
     {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -6,6 +6,12 @@
     {{- if eq .Spec.type "LoadBalancer" }}
         {{- template "load_balancer_ingress" . }}
     {{- end }}
+    {{- if eq .Spec.type "NodePort" }}
+        {{- " " }}{{ "NodePort" | yellow | bold }}:
+        {{- range $index, $port := .Spec.ports }}
+            {{- if $index }}, {{ end }}{{ $port.nodePort | toString | cyan }}{{ with $port.name }} ({{ . }}){{ end }}
+        {{- end }}
+    {{- end }}
     {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
     {{- if $slices }}
         {{- if hasKey (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -223,7 +223,7 @@
 {{- define "service_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
-    {{- with .Spec }}{{ with .type }}, {{ . | colorKeyword }}{{ end }}{{ end }}
+    {{- with .Spec }}{{ with .type }}, {{ if eq . "NodePort" }}{{ . | yellow | bold }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}{{ end }}
     {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
     {{- $ready := 0 }}{{ $notReady := 0 }}
     {{- range $slices }}
@@ -243,6 +243,7 @@
         {{- range . }}
             {{- ", " }}
             {{- if .name }}{{ printf "%s(%d/%s)" .name (.port | int) (.protocol | default "TCP") | cyan }}{{ else }}{{ printf "%d/%s" (.port | int) (.protocol | default "TCP") | cyan }}{{ end }}
+            {{- with .nodePort }}{{ printf "→%d" (. | int) | yellow | bold }}{{ end }}
         {{- end }}
     {{- end }}{{ end }}
 {{- end }}

--- a/tests/artifacts/service-nodeport-unallocated.out
+++ b/tests/artifacts/service-nodeport-unallocated.out
@@ -1,0 +1,4 @@
+
+Service/web -n nodeport-demo NodePort:auto (http)
+  Current: Service is ready
+  Missing Endpoint: Service has no matching endpoint.

--- a/tests/artifacts/service-nodeport-unallocated.yaml
+++ b/tests/artifacts/service-nodeport-unallocated.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: nodeport-demo
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  selector:
+    app: web
+  type: NodePort
+status: {}

--- a/tests/artifacts/service-nodeport.out
+++ b/tests/artifacts/service-nodeport.out
@@ -1,0 +1,4 @@
+
+Service/web -n nodeport-demo, created 1m ago NodePort:30080 (http)
+  Current: Service is ready
+  Missing Endpoint: Service has no matching endpoint.

--- a/tests/artifacts/service-nodeport.yaml
+++ b/tests/artifacts/service-nodeport.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"web","namespace":"nodeport-demo"},"spec":{"ports":[{"name":"http","nodePort":30080,"port":80,"targetPort":80}],"selector":{"app":"web"},"type":"NodePort"}}
+  creationTimestamp: "2026-07-04T07:28:58Z"
+  name: web
+  namespace: nodeport-demo
+  resourceVersion: "249838"
+  uid: 42acaba0-9b33-48af-b7ab-46cf21b912b3
+spec:
+  clusterIP: 10.110.96.91
+  clusterIPs:
+  - 10.110.96.91
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30080
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
@@ -1,0 +1,14 @@
+\A
+PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, gen:1
+  Current: AllowedDisruptions has been computed.
+  Budget: min available=1, Constrained
+  Selector: app=sts-with-nodeport
+    Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
+    Pod/sts-with-nodeport-0 -n default Running, 1/1 ready
+  healthy:1/expected:1, disruptions allowed:0
+    no disruptions allowed — all pods must stay healthy to meet the budget
+  DisruptionAllowed InsufficientPods for 1m
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kube-controller-manager \(status\)
+\z

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -1,0 +1,12 @@
+\A
+Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodeport, gen:1 Running BestEffort
+  Current: Pod is Ready
+  Managed by sts-with-nodeport application
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Services: Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
+  Known/recorded manage events:
+    1m ago Updated by kube-controller-manager \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z

--- a/tests/e2e-artifacts/sts-with-nodeport.yaml
+++ b/tests/e2e-artifacts/sts-with-nodeport.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sts-with-nodeport
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sts-with-nodeport
+  template:
+    metadata:
+      labels:
+        app: sts-with-nodeport
+    spec:
+      containers:
+      - name: sts-with-nodeport
+        image: registry.k8s.io/pause:3.9
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sts-with-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: sts-with-nodeport
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 80
+    nodePort: 30081
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sts-with-nodeport
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: sts-with-nodeport


### PR DESCRIPTION
## Summary
- Fixes #339: NodePort services are easy to overlook, so surface the allocated node ports wherever a Service is rendered.
- Full `Service` render: show `NodePort:<port> (<name>)` per port, alongside the existing Headless/LoadBalancer inline highlights.
- Compact `service_health_summary` (used by Pod's `Services:` line, PodDisruptionBudget's selector summary, and Ingress's matched-service summary): highlight the `NodePort` type in yellow/bold instead of the unhighlighted `colorKeyword` default, and append each port's `nodePort` value.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (178 offline tests pass, including new `tests/artifacts/service-nodeport.*` captured from a real minikube cluster)
- [x] New live e2e case `tests/e2e-artifacts/sts-with-nodeport.*` covering the compact `service_health_summary` path (requires live label-based Service lookups, unreachable under `--local`/`--shallow`), verified with `RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/... -run TestE2EDynamicManifests/sts-with-nodeport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)