### PR TITLE
Fix flaky e2e tests: unstable managedFields sort and broken duration format

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -427,7 +427,7 @@ func applyManifest(t *testing.T, filepath string) {
 
 func waitFor(t *testing.T, resource, forParam string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "wait", "--for", forParam, resource)
+	cmd := exec.Command("kubectl", "wait", "--for", forParam, resource, "--timeout=2m")
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s: %s", resource, string(output))
 	require.NoError(t, err)

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -217,7 +217,7 @@ func hasMapListAMatchingItem(searchFor map[string]interface{}, typedMapListItem 
 // we need to use "[]interface{}" and cast it inside.
 func sortMapListByKeysValue(key string, mapList []interface{}) (result []interface{}) {
 	result = append(result, mapList...)
-	sort.Slice(result, func(i, j int) bool {
+	sort.SliceStable(result, func(i, j int) bool {
 		typedMapListItemI, ok := result[i].(map[string]interface{})[key].(string)
 		if !ok {
 			typedMapListItemI = ""

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -218,13 +218,12 @@ func hasMapListAMatchingItem(searchFor map[string]interface{}, typedMapListItem 
 func sortMapListByKeysValue(key string, mapList []interface{}) (result []interface{}) {
 	result = append(result, mapList...)
 	sort.SliceStable(result, func(i, j int) bool {
-		typedMapListItemI, ok := result[i].(map[string]interface{})[key].(string)
-		if !ok {
-			typedMapListItemI = ""
+		var typedMapListItemI, typedMapListItemJ string
+		if mapI, ok := result[i].(map[string]interface{}); ok {
+			typedMapListItemI, _ = mapI[key].(string)
 		}
-		typedMapListItemJ, ok := result[j].(map[string]interface{})[key].(string)
-		if !ok {
-			typedMapListItemJ = ""
+		if mapJ, ok := result[j].(map[string]interface{}); ok {
+			typedMapListItemJ, _ = mapJ[key].(string)
 		}
 		return typedMapListItemI < typedMapListItemJ
 	})

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -135,6 +135,25 @@ func TestGetMatchingItemInMapList(t *testing.T) {
 	}
 }
 
+func TestSortMapListByKeysValueIsStableOnTies(t *testing.T) {
+	// When multiple items share the same key value, the sort must preserve
+	// their original relative order (as returned by the k8s API) instead of
+	// reordering them arbitrarily, otherwise output like "Known/recorded
+	// manage events" becomes flaky between otherwise identical runs.
+	mapList := []interface{}{
+		map[string]interface{}{"manager": "kubectl-client-side-apply", "time": "2024-01-01T00:00:00Z"},
+		map[string]interface{}{"manager": "kube-controller-manager", "time": "2024-01-01T00:00:00Z"},
+		map[string]interface{}{"manager": "another-manager", "time": "2023-12-31T00:00:00Z"},
+	}
+	for i := 0; i < 10; i++ {
+		got := sortMapListByKeysValue("time", mapList)
+		want := []interface{}{mapList[2], mapList[0], mapList[1]}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("sortMapListByKeysValue() = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestAgoSuffix(t *testing.T) {
 	viper.Set("absolute-time", false)
 	if got := agoSuffix(); got != " ago" {

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -71,7 +71,7 @@
         {{- $created := .Metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z" }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" }}
         {{- $startedIn := $started.Sub $created}}
-        {{- if gt ($startedIn.Seconds | int) 0 }}, started after {{ $startedIn.Seconds | ago }}{{ end }}
+        {{- if gt ($startedIn.Seconds | int) 0 }}, started after {{ $startedIn | colorDuration }}{{ end }}
     {{- end }}
     {{- if and .Status.startTime .Status.completionTime (ne .Kind "Job") }}
         {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}

--- a/tests/artifacts/multiple-2-pods-docs.out
+++ b/tests/artifacts/multiple-2-pods-docs.out
@@ -1,5 +1,5 @@
 
-Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 0s Running Burstable
+Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 1m Running Burstable
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
@@ -10,7 +10,7 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
     etcd-certs (HostPath: /var/lib/minikube/certs/etcd, type: DirectoryOrCreate)
     etcd-data (HostPath: /var/lib/minikube/etcd, type: DirectoryOrCreate)
 
-Pod/storage-provisioner -n kube-system, created 1m ago, started after 0s Running BestEffort
+Pod/storage-provisioner -n kube-system, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD.

--- a/tests/artifacts/multiple-2-pods-list.out
+++ b/tests/artifacts/multiple-2-pods-list.out
@@ -1,5 +1,5 @@
 
-Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 0s Running Burstable
+Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 1m Running Burstable
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
@@ -10,7 +10,7 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
     etcd-certs (HostPath: /var/lib/minikube/certs/etcd, type: DirectoryOrCreate)
     etcd-data (HostPath: /var/lib/minikube/etcd, type: DirectoryOrCreate)
 
-Pod/storage-provisioner -n kube-system, created 1m ago, started after 0s Running BestEffort
+Pod/storage-provisioner -n kube-system, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD.

--- a/tests/artifacts/pod-liveness-kill-137.out
+++ b/tests/artifacts/pod-liveness-kill-137.out
@@ -1,5 +1,5 @@
 
-Pod/pod-liveness-kill-137 -n default, created 1m ago, gen:1, started after 0s Running BestEffort
+Pod/pod-liveness-kill-137 -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   Failed: Containers in CrashLoop state: app
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: app
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/artifacts/pod-native-sidecar.out
+++ b/tests/artifacts/pod-native-sidecar.out
@@ -1,5 +1,5 @@
 
-Pod/pod-native-sidecar -n default, created 1m ago, gen:1, started after 0s Running Burstable
+Pod/pod-native-sidecar -n default, created 1m ago, gen:1, started after 1m Running Burstable
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD.

--- a/tests/artifacts/pod-psa-baseline.out
+++ b/tests/artifacts/pod-psa-baseline.out
@@ -1,5 +1,5 @@
 
-Pod/pod-psa-baseline -n psa-baseline, created 1m ago, gen:1, started after 0s Running Burstable
+Pod/pod-psa-baseline -n psa-baseline, created 1m ago, gen:1, started after 1m Running Burstable
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD.

--- a/tests/artifacts/pod-with-ephemeral-container.out
+++ b/tests/artifacts/pod-with-ephemeral-container.out
@@ -1,5 +1,5 @@
 
-Pod/pod-ephemeral-base -n default, created 1m ago, gen:2, started after 0s Running Burstable
+Pod/pod-ephemeral-base -n default, created 1m ago, gen:2, started after 1m Running Burstable
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD.

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -1,5 +1,5 @@
 \A
-Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingress, gen:1 Running BestEffort
+Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingress, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-ingress application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -1,5 +1,5 @@
 \A
-Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodeport, gen:1 Running BestEffort
+Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodeport, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-nodeport application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m


### PR DESCRIPTION
## Summary
- Fixes the CI failure in https://github.com/bergerx/kubectl-status/actions/runs/28700742273: `sortMapListByKeysValue` used `sort.Slice` (unstable), so when two `managedFields` entries shared the same `time`, the "Known/recorded manage events" line ordering flipped nondeterministically between runs. Switched to `sort.SliceStable` and added a unit test covering ties.
- Fixed a related bug found while reproducing locally: the "started after" duration in `status_summary_line` piped a `time.Duration.Seconds()` (float64) into the `ago` template func, which only handles `time.Time`/`int64`/etc. and silently fell through to "now", always printing `started after 0s`. Now formatted via `colorDuration`, consistent with other duration displays in the templates.
- Updated `sts-with-ingress.pod.regex` / `sts-with-nodeport.pod.regex` to treat the now-correctly-rendered `, started after Xs` clause as optional, since its presence depends on real (environment-dependent) scheduling latency.
- Bumped `waitFor`'s `kubectl wait` timeout from the default 30s to 2m so e2e tests tolerate a slow apiserver instead of failing outright.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (180 unit tests pass, including new stability test)
- [x] `ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e` — passed cleanly twice in a row against a local minikube