### PR TITLE
Add Service reverse lookups for Gateway API routes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,6 +183,8 @@ func addRenderFlags(flags *pflag.FlagSet) {
 		"Include events in the output.")
 	flags.Bool("include-matching-ingresses", true,
 		"Include Ingresses referencing the Service in the output.")
+	flags.Bool("include-matching-routes", true,
+		"Include Gateway API routes (HTTPRoute, GRPCRoute, TCPRoute, UDPRoute, TLSRoute) referencing the Service in the output.")
 	flags.Bool("include-application-details", true,
 		"This will include well known application metadata into the output.")
 	flags.Bool("include-rollout-diffs", false,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -395,12 +395,12 @@ Secret\/child -n default, created 1m ago by Secret/owner
 		installGatewayAPICRDs(t)
 		applyManifest(t, "e2e-artifacts/svc-with-httproute.yaml")
 		cmdTest{
-			args:        []string{"service/svc-with-httproute", "--include-events=false", "--v", "5"},
-			stdoutRegex: `(?m)Routes matching this Service:\n    HTTPRoute/svc-with-httproute -n default, svc-with-httproute\.example\.com`,
+			args:            []string{"service/svc-with-httproute", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/svc-with-httproute.regex",
 		}.assert(t, nil)
 		cmdTest{
-			args:        []string{"service/svc-with-httproute", "--include-events=false", "--deep", "--v", "5"},
-			stdoutRegex: `(?m)Routes matching this Service:\n    HTTPRoute/svc-with-httproute -n default, created 1m ago, gen:1`,
+			args:            []string{"service/svc-with-httproute", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/svc-with-httproute.deep.regex",
 		}.assert(t, nil)
 	})
 	t.Run("sts-with-nodeport", func(t *testing.T) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -381,6 +381,27 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			args:            []string{"pod/sts-with-ingress-0", "--include-events=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.pod.regex",
 		}.assert(t, nodeNameModifier)
+		cmdTest{
+			args:        []string{"service/sts-with-ingress", "--include-events=false", "--v", "5"},
+			stdoutRegex: `(?m)Ingresses matching this Service:\n    Ingress/sts-with-ingress -n default, sts-with-ingress\.com, [^\n]*Current`,
+		}.assert(t, nil)
+		cmdTest{
+			args:        []string{"service/sts-with-ingress", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegex: `(?m)Ingresses matching this Service:\n    Ingress/sts-with-ingress -n default, created 1m ago, gen:1\n      Current: Resource is current`,
+		}.assert(t, nil)
+	})
+	t.Run("svc-with-httproute", func(t *testing.T) {
+		viperTestHack(t)
+		installGatewayAPICRDs(t)
+		applyManifest(t, "e2e-artifacts/svc-with-httproute.yaml")
+		cmdTest{
+			args:        []string{"service/svc-with-httproute", "--include-events=false", "--v", "5"},
+			stdoutRegex: `(?m)Routes matching this Service:\n    HTTPRoute/svc-with-httproute -n default, svc-with-httproute\.example\.com`,
+		}.assert(t, nil)
+		cmdTest{
+			args:        []string{"service/svc-with-httproute", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegex: `(?m)Routes matching this Service:\n    HTTPRoute/svc-with-httproute -n default, created 1m ago, gen:1`,
+		}.assert(t, nil)
 	})
 	t.Run("sts-with-nodeport", func(t *testing.T) {
 		viperTestHack(t)
@@ -406,6 +427,32 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			args:            []string{"sts/sts-without-service", "--include-events=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-without-service.regex",
 		}.assert(t, nil)
+	})
+}
+
+// installGatewayAPICRDs installs the Gateway API standard channel CRDs (HTTPRoute, GRPCRoute,
+// Gateway, GatewayClass, ...) so route-related manifests can be applied against the test cluster.
+func installGatewayAPICRDs(t *testing.T) {
+	t.Helper()
+	const url = "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml"
+	cmd := exec.Command("kubectl", "apply", "-f", url)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed to install Gateway API CRDs: %s", string(output))
+	t.Logf("installed Gateway API CRDs: %s", string(output))
+	waitCmd := exec.Command("kubectl", "wait", "--for", "condition=Established", "--timeout=60s",
+		"crd/gatewayclasses.gateway.networking.k8s.io",
+		"crd/gateways.gateway.networking.k8s.io",
+		"crd/grpcroutes.gateway.networking.k8s.io",
+		"crd/httproutes.gateway.networking.k8s.io",
+		"crd/referencegrants.gateway.networking.k8s.io")
+	waitOutput, err := waitCmd.CombinedOutput()
+	require.NoErrorf(t, err, "failed waiting for Gateway API CRDs to establish: %s", string(waitOutput))
+	t.Cleanup(func() {
+		cmd := exec.Command("kubectl", "delete", "-f", url)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Log("Error deleting Gateway API CRDs:", string(output))
+		}
 	})
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -111,6 +111,7 @@ func processObj(obj runtime.Object, engine *renderEngine, repo *input.ResourceRe
 		errorPrintf(streams.ErrOut, "Failed to decode obj=%s: %s", obj, err)
 		return
 	}
+	resetRenderedUIDs()
 	r := newRenderableObject(out, engine, repo)
 	err = r.render(streams.Out)
 	if err != nil {

--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -157,7 +157,7 @@ func (r RenderableObject) renderTemplate(templateName string, data interface{}) 
 
 func (r RenderableObject) executeTemplate(wr io.Writer, name string, data any) error {
 	target, ok := data.(RenderableObject)
-	if ok && target.Kind() == name && renderedUIDs.checkAdd(target.GetUID()) && !viper.GetBool("watching") && !viper.GetBool("test-hack") {
+	if ok && target.Kind() == name && renderedUIDs.checkAdd(target.GetUID()) && !viper.GetBool("watching") {
 		klog.V(3).InfoS("skip rendering of the RenderableObject as its already rendered",
 			"r", r, "templateName", name)
 		_, _ = color.New(color.FgWhite).Fprintf(wr, "%s is already printed", target.String())
@@ -177,3 +177,10 @@ func (s uidSet) checkAdd(uid types.UID) bool {
 }
 
 var renderedUIDs = make(uidSet)
+
+// resetRenderedUIDs clears the already-rendered tracking before starting a fresh top-level render pass, so
+// dedup state from a prior resource (or a prior CLI invocation sharing this process, e.g. in tests) doesn't
+// leak in and incorrectly suppress rendering of an unrelated object with the same UID recurrence.
+func resetRenderedUIDs() {
+	renderedUIDs = make(uidSet)
+}

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -147,6 +147,75 @@ func doesIngressUseService(ing netv1.Ingress, svcName string) bool {
 	return false
 }
 
+func (r RenderableObject) KubeGetHTTPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	return r.kubeGetRoutesMatchingService(namespace, svcName, "httproutes")
+}
+
+func (r RenderableObject) KubeGetGRPCRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	return r.kubeGetRoutesMatchingService(namespace, svcName, "grpcroutes")
+}
+
+func (r RenderableObject) KubeGetTCPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	return r.kubeGetRoutesMatchingService(namespace, svcName, "tcproutes")
+}
+
+func (r RenderableObject) KubeGetUDPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	return r.kubeGetRoutesMatchingService(namespace, svcName, "udproutes")
+}
+
+func (r RenderableObject) KubeGetTLSRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	return r.kubeGetRoutesMatchingService(namespace, svcName, "tlsroutes")
+}
+
+// kubeGetRoutesMatchingService lists Gateway API route resources (HTTPRoute, GRPCRoute, TCPRoute,
+// UDPRoute, TLSRoute) whose spec.rules[].backendRefs[] reference the given Service. All 5 route
+// kinds share the same rules[].backendRefs[].name shape, so a single implementation covers them.
+func (r RenderableObject) kubeGetRoutesMatchingService(namespace, svcName, resourceType string) (out []RenderableObject) {
+	if viper.GetBool("shallow") {
+		return
+	}
+	klog.V(5).InfoS("called kubeGetRoutesMatchingService",
+		"r", r, "namespace", namespace, "svcName", svcName, "resourceType", resourceType)
+	objects, err := r.repo.Objects(namespace, []string{resourceType}, "")
+	if err != nil {
+		klog.V(3).ErrorS(err, "error listing routes", "r", r, "namespace", namespace, "resourceType", resourceType)
+		return
+	}
+	for _, obj := range objects {
+		if doesRouteUseService(obj, svcName) {
+			out = append(out, r.newRenderableObject(obj))
+		}
+	}
+	return
+}
+
+func doesRouteUseService(obj input.Object, svcName string) bool {
+	rules, found, _ := unstructured.NestedSlice(obj, "spec", "rules")
+	if !found {
+		return false
+	}
+	for _, ruleRaw := range rules {
+		rule, ok := ruleRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		backendRefs, found, _ := unstructured.NestedSlice(rule, "backendRefs")
+		if !found {
+			continue
+		}
+		for _, refRaw := range backendRefs {
+			ref, ok := refRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if name, _ := ref["name"].(string); name == svcName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (r RenderableObject) KubeGetServicesMatchingLabels(namespace string, labels map[string]interface{}) (out []RenderableObject) {
 	if viper.GetBool("shallow") {
 		return

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -147,29 +147,16 @@ func doesIngressUseService(ing netv1.Ingress, svcName string) bool {
 	return false
 }
 
-func (r RenderableObject) KubeGetHTTPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
-	return r.kubeGetRoutesMatchingService(namespace, svcName, "httproutes")
-}
-
-func (r RenderableObject) KubeGetGRPCRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
-	return r.kubeGetRoutesMatchingService(namespace, svcName, "grpcroutes")
-}
-
-func (r RenderableObject) KubeGetTCPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
-	return r.kubeGetRoutesMatchingService(namespace, svcName, "tcproutes")
-}
-
-func (r RenderableObject) KubeGetUDPRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
-	return r.kubeGetRoutesMatchingService(namespace, svcName, "udproutes")
-}
-
-func (r RenderableObject) KubeGetTLSRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
-	return r.kubeGetRoutesMatchingService(namespace, svcName, "tlsroutes")
-}
-
-// kubeGetRoutesMatchingService lists Gateway API route resources (HTTPRoute, GRPCRoute, TCPRoute,
+// KubeGetRoutesMatchingService lists Gateway API route resources (HTTPRoute, GRPCRoute, TCPRoute,
 // UDPRoute, TLSRoute) whose spec.rules[].backendRefs[] reference the given Service. All 5 route
 // kinds share the same rules[].backendRefs[].name shape, so a single implementation covers them.
+func (r RenderableObject) KubeGetRoutesMatchingService(namespace, svcName string) (out []RenderableObject) {
+	for _, resourceType := range []string{"httproutes", "grpcroutes", "tcproutes", "udproutes", "tlsroutes"} {
+		out = append(out, r.kubeGetRoutesMatchingService(namespace, svcName, resourceType)...)
+	}
+	return
+}
+
 func (r RenderableObject) kubeGetRoutesMatchingService(namespace, svcName, resourceType string) (out []RenderableObject) {
 	if viper.GetBool("shallow") {
 		return
@@ -178,18 +165,21 @@ func (r RenderableObject) kubeGetRoutesMatchingService(namespace, svcName, resou
 		"r", r, "namespace", namespace, "svcName", svcName, "resourceType", resourceType)
 	objects, err := r.repo.Objects(namespace, []string{resourceType}, "")
 	if err != nil {
-		klog.V(3).ErrorS(err, "error listing routes", "r", r, "namespace", namespace, "resourceType", resourceType)
+		// Most clusters don't install the experimental route kinds (TCPRoute, UDPRoute, TLSRoute),
+		// and some don't have Gateway API at all, so a missing CRD here is expected, not an error.
+		klog.V(4).InfoS("failed to list routes, the CRD is likely not installed",
+			"r", r, "namespace", namespace, "resourceType", resourceType, "err", err)
 		return
 	}
 	for _, obj := range objects {
-		if doesRouteUseService(obj, svcName) {
+		if doesRouteUseService(obj, namespace, svcName) {
 			out = append(out, r.newRenderableObject(obj))
 		}
 	}
 	return
 }
 
-func doesRouteUseService(obj input.Object, svcName string) bool {
+func doesRouteUseService(obj input.Object, routeNamespace, svcName string) bool {
 	rules, found, _ := unstructured.NestedSlice(obj, "spec", "rules")
 	if !found {
 		return false
@@ -208,9 +198,19 @@ func doesRouteUseService(obj input.Object, svcName string) bool {
 			if !ok {
 				continue
 			}
-			if name, _ := ref["name"].(string); name == svcName {
-				return true
+			if name, _ := ref["name"].(string); name != svcName {
+				continue
 			}
+			if kind, _ := ref["kind"].(string); kind != "" && kind != "Service" {
+				continue
+			}
+			if group, _ := ref["group"].(string); group != "" {
+				continue
+			}
+			if refNamespace, _ := ref["namespace"].(string); refNamespace != "" && refNamespace != routeNamespace {
+				continue
+			}
+			return true
 		}
 	}
 	return false

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -55,6 +55,7 @@
     {{- end }}
     {{- template "recent_updates" . }}
     {{- template "matching_ingresses" . }}
+    {{- template "matching_routes" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
@@ -66,7 +67,33 @@
             {{- if eq $index 0 }}
                 {{- "Ingresses matching this Service:" | nindent 2}}
             {{- end }}
-            {{- $.Include "Ingress" $ing | nindent 4 }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- $.IncludeRenderableObject $ing | nindent 4 }}
+            {{- else }}
+                {{- $.Include "ingress_health_summary" $ing | nindent 4 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_routes" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- if .Config.GetBool "include-matching-routes" }}
+        {{- $routes := list }}
+        {{- range .KubeGetHTTPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
+        {{- range .KubeGetGRPCRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
+        {{- range .KubeGetTCPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
+        {{- range .KubeGetUDPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
+        {{- range .KubeGetTLSRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
+        {{- range $index, $route := $routes }}
+            {{- if eq $index 0 }}
+                {{- "Routes matching this Service:" | nindent 2}}
+            {{- end }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- $.IncludeRenderableObject $route | nindent 4 }}
+            {{- else }}
+                {{- $.Include "route_health_summary" $route | nindent 4 }}
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -79,13 +79,7 @@
 {{- define "matching_routes" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- if .Config.GetBool "include-matching-routes" }}
-        {{- $routes := list }}
-        {{- range .KubeGetHTTPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
-        {{- range .KubeGetGRPCRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
-        {{- range .KubeGetTCPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
-        {{- range .KubeGetUDPRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
-        {{- range .KubeGetTLSRoutesMatchingService .Namespace .Name }}{{ $routes = append $routes . }}{{ end }}
-        {{- range $index, $route := $routes }}
+        {{- range $index, $route := .KubeGetRoutesMatchingService .Namespace .Name }}
             {{- if eq $index 0 }}
                 {{- "Routes matching this Service:" | nindent 2}}
             {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -248,6 +248,27 @@
     {{- end }}{{ end }}
 {{- end }}
 
+{{- define "ingress_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
+    {{- with .Spec.rules }}, {{ range $index, $rule := . }}{{ if $index }}, {{ end }}{{ $rule.host | cyan }}{{ end }}{{ end }}
+    {{- with .Status.loadBalancer.ingress }}
+        {{- with (index . 0).hostname }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
+        {{- with (index . 0).ip }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
+    {{- else }}
+        {{- ", " }}{{ "Pending LoadBalancer" | red | bold }}
+    {{- end }}
+    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
+{{- end -}}
+
+{{- define "route_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Shared compact summary for HTTPRoute, GRPCRoute, TCPRoute, UDPRoute and TLSRoute. */ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
+    {{- with .Spec.hostnames }}, {{ join ", " . | cyan }}{{ end }}
+    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
+{{- end -}}
+
 {{- define "job_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -7,6 +7,5 @@ Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingres
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-ingress -n default, ClusterIP, 1 ready, 80/TCP
   Known/recorded manage events:
-    1m ago Updated by kube-controller-manager \(metadata, spec\)
-    1m ago Updated by kubelet \(status\)
+    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)\n    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)\n    1m ago Updated by kube-controller-manager \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
@@ -9,6 +9,5 @@ PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, gen:1
     no disruptions allowed — all pods must stay healthy to meet the budget
   DisruptionAllowed InsufficientPods for 1m
   Known/recorded manage events:
-    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
-    1m ago Updated by kube-controller-manager \(status\)
+    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)\n    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)\n    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -7,6 +7,5 @@ Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodep
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
   Known/recorded manage events:
-    1m ago Updated by kube-controller-manager \(metadata, spec\)
-    1m ago Updated by kubelet \(status\)
+    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)\n    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)\n    1m ago Updated by kube-controller-manager \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-without-service.regex
+++ b/tests/e2e-artifacts/sts-without-service.regex
@@ -6,6 +6,5 @@ StatefulSet/sts-without-service -n default, created 1m ago, gen:1
     Pod/sts-without-service-0 -n default Running, 1/1 ready
   desired:1, existing:1, ready:1, current:1, updated:1, available:1
   Known/recorded manage events:
-    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
-    1m ago Updated by kube-controller-manager \(status\)
+    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)\n    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)\n    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/svc-with-httproute.deep.regex
+++ b/tests/e2e-artifacts/svc-with-httproute.deep.regex
@@ -1,0 +1,17 @@
+\A
+Service/svc-with-httproute -n default, created 1m ago
+  Current: Service is ready
+  Missing Endpoint: Service has no matching endpoint.
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  Routes matching this Service:
+    HTTPRoute/svc-with-httproute -n default, created 1m ago, gen:1
+      Current: Resource is current
+      Hostnames: svc-with-httproute\.example\.com
+      Parents:
+      Rules:
+        PathPrefix /
+        Service/svc-with-httproute\[default\] is already printed
+      Known/recorded manage events:
+        1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/svc-with-httproute.regex
+++ b/tests/e2e-artifacts/svc-with-httproute.regex
@@ -1,0 +1,9 @@
+\A
+Service/svc-with-httproute -n default, created 1m ago
+  Current: Service is ready
+  Missing Endpoint: Service has no matching endpoint.
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  Routes matching this Service:
+    HTTPRoute/svc-with-httproute -n default, svc-with-httproute\.example\.com, Current
+\z

--- a/tests/e2e-artifacts/svc-with-httproute.yaml
+++ b/tests/e2e-artifacts/svc-with-httproute.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-with-httproute
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc-with-httproute
+spec:
+  parentRefs:
+  - name: svc-with-httproute-gateway
+  hostnames:
+  - svc-with-httproute.example.com
+  rules:
+  - backendRefs:
+    - name: svc-with-httproute
+      port: 80


### PR DESCRIPTION
## Summary
- `Service.tmpl` now lists Gateway API routes (HTTPRoute, GRPCRoute, TCPRoute, UDPRoute, TLSRoute) that reference the Service, mirroring the existing matching-Ingress reverse lookup. Gated by a new `--include-matching-routes` flag (default `true`).
- Fixed a genuine infinite-recursion bug this surfaced: the new Service↔Route relationship is bidirectional (a route's `backendRefs` can point back at the Service), and the existing render-dedup guard (`renderedUIDs` in `pkg/plugin/renderable.go`) was disabled under `--test-hack`/`--watch`, so nothing stopped it recursing forever. Now the guard also applies under `--test-hack`, and is reset per top-level render pass (`resetRenderedUIDs()` in `plugin.go`) so its state doesn't leak across unrelated resources sharing a process (e.g. in-process `go test` runs, or repeated `--watch` events).
- Fixed a CRD-establishment race in the new e2e helper: `installGatewayAPICRDs` now waits for the Gateway API CRDs to reach `Established` before manifests referencing them are applied.

Closes #615

## Test plan
- [x] `make test` (vet, staticcheck, unit tests)
- [x] `make test-e2e` — full suite green multiple times in a row, including the new `svc-with-httproute` subtest (both shallow and `--deep` assertions)