### PR TITLE
Highlight missing/broken imagePullSecrets on ImagePullBackOff/ErrImagePull (#258)

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -577,9 +577,9 @@ Secret\/child -n default, created 1m ago by Secret/owner
 		// correlation branch of the ImagePullBackOff hint (Check B).
 		viperTestHack(t)
 		applyManifest(t, "e2e-artifacts/pod-image-pull-secrets.yaml")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-missing-pull-secret")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-wrong-type-pull-secret")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-healthy-pull-secret")
+		waitForImagePullBackoff(t, "pod/e2e-pod-missing-pull-secret")
+		waitForImagePullBackoff(t, "pod/e2e-pod-wrong-type-pull-secret")
+		waitForImagePullBackoff(t, "pod/e2e-pod-healthy-pull-secret")
 
 		t.Run("pod referencing a non-existent Secret flags it and correlates with the pull failure", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-missing-pull-secret", "--include-events=false", "--v", "5"})
@@ -629,22 +629,26 @@ func waitFor(t *testing.T, resource, forParam string) {
 	require.NoError(t, err)
 }
 
-// waitForContainerWaitingReason polls until the resource's first container has a
-// state.waiting.reason set (e.g. ErrImagePull/ImagePullBackOff), since `kubectl wait`
-// doesn't support waiting for one-of-several jsonpath values.
-func waitForContainerWaitingReason(t *testing.T, resource string) {
+// waitForImagePullBackoff polls until the resource's first container reports an
+// ImagePullBackOff or ErrImagePull waiting reason. `kubectl wait` doesn't support
+// waiting for one-of-several jsonpath values, and the kubelet transiently reports
+// other reasons (e.g. ContainerCreating) before settling on the pull-failure state.
+// Transient kubectl errors (e.g. the pod not yet registered in the API server) are
+// tolerated and just retried until the deadline.
+func waitForImagePullBackoff(t *testing.T, resource string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
 		cmd := exec.Command("kubectl", "get", resource,
 			"-o", "jsonpath={.status.containerStatuses[0].state.waiting.reason}")
 		output, err := cmd.CombinedOutput()
-		require.NoError(t, err)
-		if reason := strings.TrimSpace(string(output)); reason != "" {
-			t.Logf("%s container waiting reason: %s", resource, reason)
-			return
+		if err == nil {
+			if reason := strings.TrimSpace(string(output)); reason == "ImagePullBackOff" || reason == "ErrImagePull" {
+				t.Logf("%s container waiting reason: %s", resource, reason)
+				return
+			}
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Fatalf("timed out waiting for %s to report a container waiting reason", resource)
+	t.Fatalf("timed out waiting for %s to report ImagePullBackOff/ErrImagePull", resource)
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -570,6 +570,39 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			}.assert(t, nil)
 		})
 	})
+	t.Run("pod-image-pull-secrets", func(t *testing.T) {
+		// --shallow (used by the offline golden-file tests) makes KubeGetFirst a no-op,
+		// so this e2e suite is the only place that exercises the found-secret validation
+		// branches of Pod.tmpl's imagePullSecrets check (Check A) and the "broken secrets"
+		// correlation branch of the ImagePullBackOff hint (Check B).
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/pod-image-pull-secrets.yaml")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-missing-pull-secret")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-wrong-type-pull-secret")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-healthy-pull-secret")
+
+		t.Run("pod referencing a non-existent Secret flags it and correlates with the pull failure", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-missing-pull-secret", "--include-events=false", "--v", "5"})
+			require.NoError(t, err)
+			assert.Regexp(t, `Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.`, stdout)
+			assert.Contains(t, stdout, "this Pod's imagePullSecrets have problems, see above")
+			assert.NotContains(t, stdout, "no imagePullSecrets on this Pod")
+		})
+		t.Run("pod referencing a wrong-type Secret flags it and correlates with the pull failure", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-wrong-type-pull-secret", "--include-events=false", "--v", "5"})
+			require.NoError(t, err)
+			assert.Regexp(t, `Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.`, stdout)
+			assert.Contains(t, stdout, "this Pod's imagePullSecrets have problems, see above")
+			assert.NotContains(t, stdout, "no imagePullSecrets on this Pod")
+		})
+		t.Run("pod referencing a healthy Secret shows no warnings", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-healthy-pull-secret", "--include-events=false", "--v", "5"})
+			require.NoError(t, err)
+			for _, problem := range []string{"doesn't exist", "wrong type:", "no imagePullSecrets on this Pod", "imagePullSecrets have problems"} {
+				assert.NotContains(t, stdout, problem)
+			}
+		})
+	})
 }
 
 func applyManifest(t *testing.T, filepath string) {
@@ -594,4 +627,24 @@ func waitFor(t *testing.T, resource, forParam string) {
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s: %s", resource, string(output))
 	require.NoError(t, err)
+}
+
+// waitForContainerWaitingReason polls until the resource's first container has a
+// state.waiting.reason set (e.g. ErrImagePull/ImagePullBackOff), since `kubectl wait`
+// doesn't support waiting for one-of-several jsonpath values.
+func waitForContainerWaitingReason(t *testing.T, resource string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", resource,
+			"-o", "jsonpath={.status.containerStatuses[0].state.waiting.reason}")
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+		if reason := strings.TrimSpace(string(output)); reason != "" {
+			t.Logf("%s container waiting reason: %s", resource, reason)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for %s to report a container waiting reason", resource)
 }

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -436,7 +436,7 @@
                 {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" . }}
             {{- end }}
         {{- end }}
-        {{- if and (or (eq .reason "ImagePullBackOff") (eq .reason "ErrImagePull")) (ne $.containerSpec.imagePullPolicy "Never") }}
+        {{- if and (or (eq .reason "ImagePullBackOff") (eq .reason "ErrImagePull")) (ne (get ($.containerSpec | default dict) "imagePullPolicy") "Never") }}
             {{- if not $.podImagePullSecrets }}
                 {{- "(no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)" | yellow | nindent 2 }}
             {{- else if $.podPullSecretsBroken }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -21,9 +21,29 @@
         {{- $container := .Spec.containers | default list | first | default dict }}
         {{- "Standalone POD" | red | bold | nindent 2 }}{{ if $container.stdin }}, interactive{{ end }}{{ if $container.tty }} with attached TTY{{ end }}.
     {{- end }}
-    {{- template "pod_init_containers" . }}
-    {{- template "pod_containers" . }}
-    {{- template "pod_ephemeral_containers" . }}
+    {{- $missingPullSecrets := list }}
+    {{- $podPullSecretsBroken := false }}
+    {{- range .Spec.imagePullSecrets }}
+        {{- $secretName := .name }}
+        {{- if $secretName }}
+            {{- if not ($.Config.GetBool "shallow") }}
+                {{- $secret := $.KubeGetFirst $.Namespace "Secret" $secretName }}
+                {{- if not $secret.Object }}
+                    {{- $podPullSecretsBroken = true }}
+                    {{- if not ($missingPullSecrets | has $secretName) }}
+                        {{- "Secret" | bold | nindent 2 }}/{{ $secretName }} {{ "doesn't exist" | red | bold }}, but it's referenced in Pod's imagePullSecrets.
+                        {{- $missingPullSecrets = append $missingPullSecrets $secretName }}
+                    {{- end }}
+                {{- else if not (has $secret.Object.type (list "kubernetes.io/dockerconfigjson" "kubernetes.io/dockercfg")) }}
+                    {{- $podPullSecretsBroken = true }}
+                    {{- "Secret" | bold | nindent 2 }}/{{ $secretName }} {{ printf "wrong type: %s" $secret.Object.type | red | bold }}, but it's referenced in Pod's imagePullSecrets.
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "pod_init_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
+    {{- template "pod_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
+    {{- template "pod_ephemeral_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_volumes" . }}
     {{- template "matching_services" . }}
     {{- template "recent_updates" . }}
@@ -39,38 +59,40 @@
 {{- end -}}
 
 {{- define "pod_init_containers" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- $nodeStatsSummary := $.KubeGetNodeStatsSummary (get $.Spec "nodeName") }}
+    {{- /* Expects a dict "pod" (Pod RenderableObject) "podPullSecretsBroken" (bool) */ -}}
+    {{- $pod := .pod }}
+    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
     {{- $podStatsSummary := dict }}
     {{- if $nodeStatsSummary }}
-        {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $.Metadata.uid) }}
+        {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}
     {{- end }}
-    {{- with .Status.initContainerStatuses }}
+    {{- with $pod.Status.initContainerStatuses }}
         {{- "InitContainers:" | nindent 2 }}
         {{- range $containerStatus := . }}
-            {{- $containerSpec := $.Spec.initContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
+            {{- $containerSpec := $pod.Spec.initContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
             {{- $containerKubeletStats := $podStatsSummary.containers | default list | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
-            {{- $.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec "containerStats" $containerKubeletStats "includeAllVolumes" ($.Config.GetBool "include-all-volumes") "sidecar" (eq ($containerSpec.restartPolicy | default "") "Always")) | nindent 4 }}
+            {{- $pod.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec "containerStats" $containerKubeletStats "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes") "sidecar" (eq ($containerSpec.restartPolicy | default "") "Always") "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
         {{- end }}
     {{- end }}
 {{- end }}
 
 {{- define "pod_containers" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- $defaultLogsContainer := index .Annotations "kubectl.kubernetes.io/default-logs-container" }}
-    {{- $defaultContainer := index .Annotations "kubectl.kubernetes.io/default-container" }}
-    {{- $nodeStatsSummary := $.KubeGetNodeStatsSummary (get $.Spec "nodeName") }}
+    {{- /* Expects a dict "pod" (Pod RenderableObject) "podPullSecretsBroken" (bool) */ -}}
+    {{- $pod := .pod }}
+    {{- $defaultLogsContainer := index $pod.Annotations "kubectl.kubernetes.io/default-logs-container" }}
+    {{- $defaultContainer := index $pod.Annotations "kubectl.kubernetes.io/default-container" }}
+    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
     {{- $podStatsSummary := dict }}
     {{- if $nodeStatsSummary }}
-        {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $.Metadata.uid) }}
+        {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}
     {{- end }}
-    {{- with .Status.containerStatuses }}
+    {{- with $pod.Status.containerStatuses }}
         {{- $single := eq (len .) 1 }}
         {{- "Containers:" | nindent 2 }}
-        {{- $podMetrics := $.KubeGetFirst $.Namespace "PodMetrics" $.Name }}
+        {{- $podMetrics := $pod.KubeGetFirst $pod.Namespace "PodMetrics" $pod.Name }}
         {{- $containerStatusSummaryDict := dict }}
         {{- range $containerStatus := . }}
-            {{- $containerSpec := $.Spec.containers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
+            {{- $containerSpec := $pod.Spec.containers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
             {{- $containerKubeletStats := $podStatsSummary.containers | default list | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
             {{- if ($podMetrics.Object | default dict).containers }}
                 {{- $containerMetrics := $podMetrics.Object.containers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
@@ -80,7 +102,9 @@
                                                        "containerStats" $containerKubeletStats
                                                        "defaultContainer" (eq $containerStatus.name $defaultContainer)
                                                        "defaultLogsContainer" (eq $containerStatus.name $defaultLogsContainer)
-                                                       "includeAllVolumes" ($.Config.GetBool "include-all-volumes")
+                                                       "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes")
+                                                       "podImagePullSecrets" $pod.Spec.imagePullSecrets
+                                                       "podPullSecretsBroken" $.podPullSecretsBroken
                 }}
             {{- else }}
                 {{- $containerStatusSummaryDict = dict "containerStatus" $containerStatus
@@ -88,13 +112,15 @@
                                                        "containerStats" $containerKubeletStats
                                                        "defaultContainer" (eq $containerStatus.name $defaultContainer)
                                                        "defaultLogsContainer" (eq $containerStatus.name $defaultLogsContainer)
-                                                       "includeAllVolumes" ($.Config.GetBool "include-all-volumes")
+                                                       "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes")
+                                                       "podImagePullSecrets" $pod.Spec.imagePullSecrets
+                                                       "podPullSecretsBroken" $.podPullSecretsBroken
                 }}
             {{- end }}
             {{- if $single }}
-                {{- " " }}{{- $.Include "container_status_summary" $containerStatusSummaryDict }}
+                {{- " " }}{{- $pod.Include "container_status_summary" $containerStatusSummaryDict }}
             {{- else }}
-                {{- $.Include "container_status_summary" $containerStatusSummaryDict | nindent 4 }}
+                {{- $pod.Include "container_status_summary" $containerStatusSummaryDict | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -359,6 +385,8 @@
            * containerSpec (optional): Pod.spec.containers[name=container]
            * defaultContainer (optional): Boolean
            * defaultLogsContainer (optional): Boolean
+           * podImagePullSecrets (optional): Pod.spec.imagePullSecrets
+           * podPullSecretsBroken (optional): Boolean, true if any podImagePullSecrets entry doesn't resolve to a usable Secret
         */ -}}
     {{- .containerStatus.name | bold }}{{ if .sidecar }}{{ " [sidecar]" | cyan }}{{ end }} ({{ .containerStatus.image | markYellow "latest" }}) {{ template "container_state_summary" .containerStatus.state }}
     {{- if .containerStatus.state.running }}{{ if .containerStatus.ready }} and {{ "Ready" | green }}{{ else }} but {{ "Not Ready" | red | bold }}{{ end }}{{ end }}
@@ -406,6 +434,13 @@
         {{- if eq .reason "PostStartHookError" }}
             {{- with $.containerSpec.lifecycle.postStart }}
                 {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" . }}
+            {{- end }}
+        {{- end }}
+        {{- if and (or (eq .reason "ImagePullBackOff") (eq .reason "ErrImagePull")) (ne $.containerSpec.imagePullPolicy "Never") }}
+            {{- if not $.podImagePullSecrets }}
+                {{- "(no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)" | yellow | nindent 2 }}
+            {{- else if $.podPullSecretsBroken }}
+                {{- "(this Pod's imagePullSecrets have problems, see above — that's likely why)" | yellow | nindent 2 }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -480,12 +515,13 @@
 {{- end -}}
 
 {{- define "pod_ephemeral_containers" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- with .Status.ephemeralContainerStatuses }}
+    {{- /* Expects a dict "pod" (Pod RenderableObject) "podPullSecretsBroken" (bool) */ -}}
+    {{- $pod := .pod }}
+    {{- with $pod.Status.ephemeralContainerStatuses }}
         {{- "Debug containers:" | nindent 2 }}
         {{- range $containerStatus := . }}
-            {{- $containerSpec := $.Spec.ephemeralContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
-            {{- $.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec) | nindent 4 }}
+            {{- $containerSpec := $pod.Spec.ephemeralContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
+            {{- $pod.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
             {{- with $containerSpec.targetContainerName }}
                 {{- "targeting:" | bold | nindent 6 }} {{ . | cyan }}
             {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -249,3 +249,120 @@ func TestOwnersTemplate(t *testing.T) {
 		})
 	}
 }
+
+// renderTemplateForTest mirrors checkTemplate's setup but returns the rendered string
+// directly, so callers can assert both presence and absence of substrings.
+func renderTemplateForTest(t *testing.T, templateName string, obj map[string]interface{}) string {
+	t.Helper()
+	tmpl, _ := getTemplate()
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard())
+	e.Template = *tmpl
+	r := newRenderableObject(map[string]interface{}{}, e, repo)
+	got, err := r.renderTemplate(templateName, obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	return got
+}
+
+func TestContainerStatusSummaryImagePullBackoffHintTemplate(t *testing.T) {
+	waitingImagePullBackOff := map[string]interface{}{
+		"name":  "main",
+		"image": "some-image",
+		"state": map[string]interface{}{
+			"waiting": map[string]interface{}{
+				"reason": "ImagePullBackOff",
+			},
+		},
+	}
+	tests := []struct {
+		name            string
+		obj             map[string]interface{}
+		wantContains    string
+		wantNotContains string
+	}{
+		{
+			name: "no imagePullSecrets on the Pod hints at likely cause",
+			obj: map[string]interface{}{
+				"containerStatus": waitingImagePullBackOff,
+				"containerSpec":   map[string]interface{}{},
+			},
+			wantContains: "no imagePullSecrets on this Pod",
+		}, {
+			name: "imagePullSecrets present and healthy shows no hint",
+			obj: map[string]interface{}{
+				"containerStatus":      waitingImagePullBackOff,
+				"containerSpec":        map[string]interface{}{},
+				"podImagePullSecrets":  []interface{}{map[string]interface{}{"name": "some-secret"}},
+				"podPullSecretsBroken": false,
+			},
+			wantNotContains: "imagePullSecrets",
+		}, {
+			name: "imagePullSecrets present but broken correlates with the pull failure",
+			obj: map[string]interface{}{
+				"containerStatus":      waitingImagePullBackOff,
+				"containerSpec":        map[string]interface{}{},
+				"podImagePullSecrets":  []interface{}{map[string]interface{}{"name": "some-secret"}},
+				"podPullSecretsBroken": true,
+			},
+			wantContains: "this Pod's imagePullSecrets have problems",
+		}, {
+			name: "imagePullPolicy Never suppresses the hint even with no imagePullSecrets",
+			obj: map[string]interface{}{
+				"containerStatus": waitingImagePullBackOff,
+				"containerSpec":   map[string]interface{}{"imagePullPolicy": "Never"},
+			},
+			wantNotContains: "imagePullSecrets",
+		}, {
+			name: "unrelated waiting reason shows no hint",
+			obj: map[string]interface{}{
+				"containerStatus": map[string]interface{}{
+					"name":  "main",
+					"image": "some-image",
+					"state": map[string]interface{}{
+						"waiting": map[string]interface{}{
+							"reason": "CrashLoopBackOff",
+						},
+					},
+				},
+				"containerSpec": map[string]interface{}{},
+			},
+			wantNotContains: "imagePullSecrets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderTemplateForTest(t, "container_status_summary", tt.obj)
+			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
+				t.Errorf("got = %q, want contains %q", got, tt.wantContains)
+			}
+			if tt.wantNotContains != "" && strings.Contains(got, tt.wantNotContains) {
+				t.Errorf("got = %q, want not contains %q", got, tt.wantNotContains)
+			}
+		})
+	}
+}
+
+func TestPodImagePullSecretMissingTemplate(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "some-pod",
+			"namespace": "test",
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "main", "image": "some-image"},
+			},
+			"imagePullSecrets": []interface{}{
+				map[string]interface{}{"name": "does-not-exist"},
+			},
+		},
+		"status": map[string]interface{}{},
+	}
+	checkTemplate(t, "Pod", obj, "Secret/does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets.", true)
+}

--- a/tests/artifacts/pod-ephemeral-imagepullbackoff.out
+++ b/tests/artifacts/pod-ephemeral-imagepullbackoff.out
@@ -1,0 +1,10 @@
+
+Pod/pod-ephemeral-imagepullbackoff -n default, created 1m ago, gen:2, started after 1m Running BestEffort
+  Current: Pod is Ready
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD.
+  Containers: main (nginx:alpine) Running for 1m and Ready
+  Debug containers:
+    debug-shell (this-debug-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-debug-image-doesnt-exist"
+      (no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)
+      targeting: main

--- a/tests/artifacts/pod-ephemeral-imagepullbackoff.yaml
+++ b/tests/artifacts/pod-ephemeral-imagepullbackoff.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:19:32Z"
+  generation: 2
+  name: pod-ephemeral-imagepullbackoff
+  namespace: default
+  resourceVersion: "183290"
+  uid: 28c49f14-9a2b-4db1-a591-7f7fffbd66bf
+spec:
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  ephemeralContainers:
+  - command:
+    - sh
+    - -c
+    - sleep 3600
+    image: this-debug-image-doesnt-exist
+    imagePullPolicy: Always
+    name: debug-shell
+    resources: {}
+    targetContainerName: main
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  nodeName: minikube
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:20:12Z"
+    observedGeneration: 2
+    status: "True"
+    type: PodReadyToStartContainers
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:19:38Z"
+    observedGeneration: 2
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:20:12Z"
+    observedGeneration: 2
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:20:12Z"
+    observedGeneration: 2
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:19:37Z"
+    observedGeneration: 2
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: docker://617d76fbb0815174406655abe6abbfd73183d729e5d1dde7034c8de4e8232142
+    image: nginx:alpine
+    imageID: docker-pullable://nginx@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa
+    lastState: {}
+    name: main
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2026-06-28T21:20:11Z"
+  ephemeralContainerStatuses:
+  - image: this-debug-image-doesnt-exist
+    imageID: ""
+    lastState: {}
+    name: debug-shell
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      waiting:
+        message: Back-off pulling image "this-debug-image-doesnt-exist"
+        reason: ImagePullBackOff
+  hostIP: 192.168.49.2
+  hostIPs:
+  - ip: 192.168.49.2
+  observedGeneration: 2
+  phase: Running
+  podIP: 10.244.0.36
+  podIPs:
+  - ip: 10.244.0.36
+  qosClass: BestEffort
+  startTime: "2026-06-28T21:19:38Z"

--- a/tests/artifacts/pod-imagepullbackoff-never-policy.out
+++ b/tests/artifacts/pod-imagepullbackoff-never-policy.out
@@ -1,0 +1,9 @@
+
+Pod/backoff-never-policy -n test1, created 1m ago Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [main] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [main] for 1m
+  Standalone POD.
+  Containers: main (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"

--- a/tests/artifacts/pod-imagepullbackoff-never-policy.yaml
+++ b/tests/artifacts/pod-imagepullbackoff-never-policy.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-26T23:39:52Z"
+  name: backoff-never-policy
+  namespace: test1
+  resourceVersion: "347870"
+  uid: fa2831ed-9234-415c-8da0-287e9eaa7560
+spec:
+  containers:
+  - image: this-image-doesnt-exist
+    imagePullPolicy: Never
+    name: main
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    message: 'containers with unready status: [main]'
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    message: 'containers with unready status: [main]'
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - image: this-image-doesnt-exist
+    imageID: ""
+    lastState: {}
+    name: main
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      waiting:
+        message: Back-off pulling image "this-image-doesnt-exist"
+        reason: ImagePullBackOff
+  hostIP: 192.168.99.102
+  phase: Pending
+  podIP: 172.17.0.4
+  podIPs:
+  - ip: 172.17.0.4
+  qosClass: BestEffort
+  startTime: "2026-06-26T23:39:52Z"

--- a/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
+++ b/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
@@ -1,0 +1,11 @@
+
+Pod/backoff-with-valid-secret -n test1, created 1m ago Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: [main] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: [main] for 1m
+  Standalone POD.
+  Containers: main (private-registry.example.com/some/image:latest) Waiting ImagePullBackOff: Back-off pulling image "private-registry.example.com/some/image:latest"
+
+Secret/registry-creds -n test1, created 1m ago

--- a/tests/artifacts/pod-imagepullbackoff-with-valid-secret.yaml
+++ b/tests/artifacts/pod-imagepullbackoff-with-valid-secret.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-26T23:39:52Z"
+  name: backoff-with-valid-secret
+  namespace: test1
+  resourceVersion: "347869"
+  uid: fa2831ed-9234-415c-8da0-287e9eaa755f
+spec:
+  containers:
+  - image: private-registry.example.com/some/image:latest
+    imagePullPolicy: Always
+    name: main
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  imagePullSecrets:
+  - name: registry-creds
+  nodeName: minikube
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    message: 'containers with unready status: [main]'
+    reason: ContainersNotReady
+    status: "False"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    message: 'containers with unready status: [main]'
+    reason: ContainersNotReady
+    status: "False"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-26T23:39:52Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - image: private-registry.example.com/some/image:latest
+    imageID: ""
+    lastState: {}
+    name: main
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      waiting:
+        message: Back-off pulling image "private-registry.example.com/some/image:latest"
+        reason: ImagePullBackOff
+  hostIP: 192.168.99.102
+  phase: Pending
+  podIP: 172.17.0.4
+  podIPs:
+  - ip: 172.17.0.4
+  qosClass: BestEffort
+  startTime: "2026-06-26T23:39:52Z"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: "2026-06-26T23:39:52Z"
+  name: registry-creds
+  namespace: test1
+  resourceVersion: "2882"
+  uid: b435653a-2de9-4020-a816-f4e16013a016
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319

--- a/tests/artifacts/pod-non-existing-image.out
+++ b/tests/artifacts/pod-non-existing-image.out
@@ -6,3 +6,4 @@ Pod/missing-image-755c8c54f7-26v4c -n test1, created 1m ago by ReplicaSet/missin
     Ready ContainersNotReady, containers with unready status: [missing-image] for 1m
     ContainersReady ContainersNotReady, containers with unready status: [missing-image] for 1m
   Containers: missing-image (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"
+  (no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)

--- a/tests/e2e-artifacts/pod-image-pull-secrets.yaml
+++ b/tests/e2e-artifacts/pod-image-pull-secrets.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-pull-secret-wrong-type
+  namespace: default
+type: Opaque
+data:
+  foo: aGVsbG8=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-pull-secret-healthy
+  namespace: default
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-missing-pull-secret
+  namespace: default
+spec:
+  imagePullSecrets:
+  - name: e2e-pull-secret-does-not-exist
+  containers:
+  - name: main
+    image: registry.invalid.example/e2e-status-tests/does-not-exist:latest
+    imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-wrong-type-pull-secret
+  namespace: default
+spec:
+  imagePullSecrets:
+  - name: e2e-pull-secret-wrong-type
+  containers:
+  - name: main
+    image: registry.invalid.example/e2e-status-tests/does-not-exist:latest
+    imagePullPolicy: Always
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-healthy-pull-secret
+  namespace: default
+spec:
+  imagePullSecrets:
+  - name: e2e-pull-secret-healthy
+  containers:
+  - name: main
+    image: registry.invalid.example/e2e-status-tests/does-not-exist:latest
+    imagePullPolicy: Always


### PR DESCRIPTION
## Summary
- Flags a Pod's `imagePullSecrets` entries that reference a missing or wrong-typed Secret (mirrors the Ingress/Gateway TLS secret validation shape).
- Adds a yellow contextual hint on `ImagePullBackOff`/`ErrImagePull` pointing at missing/broken `imagePullSecrets` as a likely (not certain) cause, since node-level credential providers can supply pull credentials with zero `imagePullSecrets` present.
- Skips the hint when `imagePullPolicy: Never`, since no registry pull is ever attempted in that case.

Resolves #258.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (217 tests, offline)
- [x] New golden fixtures: hint suppressed with a valid pull secret present, hint suppressed under `imagePullPolicy: Never`, threading verified through ephemeral containers
- [x] New unit tests for the hint logic and one Check-A branch via an unconfigured fake client
- [x] New e2e subtest (`pod-image-pull-secrets`) covering the found-secret validation branches (missing Secret, wrong-typed Secret, healthy Secret) against a live cluster, since those `KubeGetFirst` branches can't be exercised under the golden-fixture harness's `--shallow` mode