### PR TITLE
Document --local rendering behavior and e2e coverage for live-query templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,12 +224,13 @@ separate manual setup needed. Bump the pinned versions in that target periodical
 upstream stable releases; CI uses the same `make test-e2e` target, so it stays in sync
 automatically.
 
-When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.include`,
+When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.Include`,
 or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`
 (`cmd/main_test.go`) plus matching manifests/regex fixtures under `tests/e2e-artifacts/`. The
-offline golden-file tests (`TestAllArtifactsLocal*`) run with `--shallow`, which makes
-`KubeGetFirst` a no-op — they can't exercise the "found the related object" or `--deep` include
-branches, so the live e2e suite is the only place that covers them.
+offline golden-file tests (`TestAllArtifactsLocal*`) run with `--shallow` (alongside `--local`,
+since there's no live cluster to query either way), which makes `KubeGetFirst` a no-op — they
+can't exercise the "found the related object" or `--deep` include branches, so the live e2e suite
+is the only place that covers them.
 
 ### Improving The Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,13 @@ separate manual setup needed. Bump the pinned versions in that target periodical
 upstream stable releases; CI uses the same `make test-e2e` target, so it stays in sync
 automatically.
 
+When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.include`,
+or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`
+(`cmd/main_test.go`) plus matching manifests/regex fixtures under `tests/e2e-artifacts/`. The
+offline golden-file tests (`TestAllArtifactsLocal*`) run with `--shallow`, which makes
+`KubeGetFirst` a no-op — they can't exercise the "found the related object" or `--deep` include
+branches, so the live e2e suite is the only place that covers them.
+
 ### Improving The Documentation
 
 We don't yet have a comprehensive documentation, we maintain just a few Markdown files in the repo. We aim to keep the

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -110,7 +110,7 @@ Any template section that fetches related resources must respect the three rende
 
 **`--shallow`** — skip the section entirely. Some Go helpers already return an empty slice in shallow mode (e.g. `KubeGetIngressesMatchingService`); for label-based lookups, gate explicitly in the template with `if not ($.Config.GetBool "shallow")`.
 
-**`--local`** also makes `KubeGetFirst` a no-op (there's no live cluster to query), so any template calling it must degrade gracefully — typically falling back to `resource_ref` — the same way it does for `--shallow`.
+Note: `--local` runs without a live cluster, so `KubeGetFirst` calls fail to find anything there too — templates don't need to check for `--local` explicitly, they just need to handle the "not found" case (typically falling back to `resource_ref`), which the `--shallow` handling above already requires.
 
 **default** — compact single-line summaries using shared sub-templates from `common.tmpl`:
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -110,6 +110,8 @@ Any template section that fetches related resources must respect the three rende
 
 **`--shallow`** — skip the section entirely. Some Go helpers already return an empty slice in shallow mode (e.g. `KubeGetIngressesMatchingService`); for label-based lookups, gate explicitly in the template with `if not ($.Config.GetBool "shallow")`.
 
+**`--local`** also makes `KubeGetFirst` a no-op (there's no live cluster to query), so any template calling it must degrade gracefully — typically falling back to `resource_ref` — the same way it does for `--shallow`.
+
 **default** — compact single-line summaries using shared sub-templates from `common.tmpl`:
 
 | Sub-template | Example output |


### PR DESCRIPTION
## Summary
- CONVENTIONS.md's "Rendering depth" section covered `--shallow`/`--deep` but not `--local`, which also makes `KubeGetFirst` a no-op.
- CONTRIBUTING.md's e2e section didn't state that template changes touching `$.KubeGetFirst`/`$.IncludeRenderableObject`/`$.include` need coverage in `TestE2EDynamicManifests`, since the offline golden-file tests run `--shallow` and can't exercise those branches.

## Test plan
- [x] Docs-only change, no code affected