### PR TITLE
Add real content to ResourceQuota template

### DIFF
--- a/pkg/plugin/templates/ResourceQuota.tmpl
+++ b/pkg/plugin/templates/ResourceQuota.tmpl
@@ -8,23 +8,26 @@
     {{- with .Spec.scopes }}
         {{- "Scopes" | bold | nindent 2 }}: {{ join ", " . | cyan }}
     {{- end }}
-    {{- with .Spec.scopeSelector.matchExpressions }}
-        {{- "Scope selector" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- printf "%s %s" .scopeName .operator | nindent 4 }}
-            {{- with .values }} {{ join "," . | cyan }}{{ end }}
+    {{- with .Spec.scopeSelector }}
+        {{- with .matchExpressions }}
+            {{- "Scope selector" | bold | nindent 2 }}:
+            {{- range . }}
+                {{- printf "%s %s" .scopeName .operator | nindent 4 }}
+                {{- with .values }} {{ join "," . | cyan }}{{ end }}
+            {{- end }}
         {{- end }}
     {{- end }}
-    {{- $hard := .Status.hard | default dict }}
-    {{- $used := .Status.used | default dict }}
+    {{- $status := .Status | default dict }}
+    {{- $hard := $status.hard | default dict }}
+    {{- $used := $status.used | default dict }}
     {{- with $hard }}
         {{- $lines := list }}
         {{- range $key, $hardStr := . }}
             {{- $usedStr := index $used $key | default "0" }}
-            {{- $hardVal := $hardStr | quantityToFloat64 }}
-            {{- $usedVal := $usedStr | quantityToFloat64 }}
+            {{- $hardVal := $hardStr | toString | quantityToFloat64 }}
+            {{- $usedVal := $usedStr | toString | quantityToFloat64 }}
             {{- $valStr := "" }}
-            {{- if or (hasSuffix "memory" $key) (hasSuffix "storage" $key) }}
+            {{- if or (hasSuffix "memory" $key) (hasSuffix "storage" $key) (contains "hugepages" $key) }}
                 {{- $valStr = printf "%s/%s" ($usedVal | humanizeSI "B") ($hardVal | humanizeSI "B") }}
             {{- else }}
                 {{- $valStr = printf "%s/%s" ($usedVal | printf "%g") ($hardVal | printf "%g") }}

--- a/pkg/plugin/templates/ResourceQuota.tmpl
+++ b/pkg/plugin/templates/ResourceQuota.tmpl
@@ -1,11 +1,45 @@
 {{- define "ResourceQuota" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: v1, Kind=ResourceQuota */ -}}
     {{- template "status_summary_line" . }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
-    {{- $hard := .Status.hard }}
-    {{- range $key, $value := .Status.used }}
-        {{- $key | nindent 2 }}: {{ $value }}/{{ index $hard $key }}
+    {{- template "observed_generation_summary" . }}
+    {{- with .Spec.scopes }}
+        {{- "Scopes" | bold | nindent 2 }}: {{ join ", " . | cyan }}
+    {{- end }}
+    {{- with .Spec.scopeSelector.matchExpressions }}
+        {{- "Scope selector" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- printf "%s %s" .scopeName .operator | nindent 4 }}
+            {{- with .values }} {{ join "," . | cyan }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- $hard := .Status.hard | default dict }}
+    {{- $used := .Status.used | default dict }}
+    {{- with $hard }}
+        {{- $lines := list }}
+        {{- range $key, $hardStr := . }}
+            {{- $usedStr := index $used $key | default "0" }}
+            {{- $hardVal := $hardStr | quantityToFloat64 }}
+            {{- $usedVal := $usedStr | quantityToFloat64 }}
+            {{- $valStr := "" }}
+            {{- if or (hasSuffix "memory" $key) (hasSuffix "storage" $key) }}
+                {{- $valStr = printf "%s/%s" ($usedVal | humanizeSI "B") ($hardVal | humanizeSI "B") }}
+            {{- else }}
+                {{- $valStr = printf "%s/%s" ($usedVal | printf "%g") ($hardVal | printf "%g") }}
+            {{- end }}
+            {{- if gt $hardVal 0.0 }}{{- $valStr = printf "%s[%s]" $valStr (percent $usedVal $hardVal | colorPercent "%.0f%%") }}{{- end }}
+            {{- $lines = append $lines (printf "%s: %s" $key $valStr) }}
+        {{- end }}
+        {{- if eq (len $lines) 1 }}
+            {{- "Quota" | bold | nindent 2 }}: {{ index $lines 0 }}
+        {{- else }}
+            {{- "Quota" | bold | nindent 2 }}:
+            {{- range $lines }}
+                {{- . | nindent 4 }}
+            {{- end }}
+        {{- end }}
     {{- end }}
     {{- template "application_details" . }}
     {{- template "recent_updates" . }}

--- a/tests/artifacts/resourcequota-besteffort.out
+++ b/tests/artifacts/resourcequota-besteffort.out
@@ -1,0 +1,5 @@
+
+ResourceQuota/besteffort-quota -n rq-test, created 1m ago
+  Current: Resource is current
+  Scopes: BestEffort
+  Quota: pods: 0/5[0%]

--- a/tests/artifacts/resourcequota-besteffort.yaml
+++ b/tests/artifacts/resourcequota-besteffort.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ResourceQuota","metadata":{"annotations":{},"name":"besteffort-quota","namespace":"rq-test"},"spec":{"hard":{"pods":"5"},"scopes":["BestEffort"]}}
+  creationTimestamp: "2026-07-05T22:09:29Z"
+  name: besteffort-quota
+  namespace: rq-test
+  resourceVersion: "78223"
+  uid: b10ff231-16b9-431e-b2b6-eae395a155fc
+spec:
+  hard:
+    pods: "5"
+  scopes:
+  - BestEffort
+status:
+  hard:
+    pods: "5"
+  used:
+    pods: "0"

--- a/tests/artifacts/resourcequota-compute.out
+++ b/tests/artifacts/resourcequota-compute.out
@@ -1,0 +1,12 @@
+
+ResourceQuota/compute-quota -n rq-test, created 1m ago
+  Current: Resource is current
+  Quota:
+    configmaps: 1/10[10%]
+    limits.cpu: 1/4[25%]
+    limits.memory: 536.8MB/4.2GB[12%]
+    persistentvolumeclaims: 0/4[0%]
+    pods: 1/10[10%]
+    requests.cpu: 0.5/2[25%]
+    requests.memory: 268.4MB/2.1GB[12%]
+    services.loadbalancers: 0/1[0%]

--- a/tests/artifacts/resourcequota-compute.yaml
+++ b/tests/artifacts/resourcequota-compute.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ResourceQuota","metadata":{"annotations":{},"name":"compute-quota","namespace":"rq-test"},"spec":{"hard":{"configmaps":"10","limits.cpu":"4","limits.memory":"4Gi","persistentvolumeclaims":"4","pods":"10","requests.cpu":"2","requests.memory":"2Gi","services.loadbalancers":"1"}}}
+  creationTimestamp: "2026-07-05T22:09:08Z"
+  name: compute-quota
+  namespace: rq-test
+  resourceVersion: "78192"
+  uid: 571c4e61-6703-43ac-bb31-6e83ffc0cc34
+spec:
+  hard:
+    configmaps: "10"
+    limits.cpu: "4"
+    limits.memory: 4Gi
+    persistentvolumeclaims: "4"
+    pods: "10"
+    requests.cpu: "2"
+    requests.memory: 2Gi
+    services.loadbalancers: "1"
+status:
+  hard:
+    configmaps: "10"
+    limits.cpu: "4"
+    limits.memory: 4Gi
+    persistentvolumeclaims: "4"
+    pods: "10"
+    requests.cpu: "2"
+    requests.memory: 2Gi
+    services.loadbalancers: "1"
+  used:
+    configmaps: "1"
+    limits.cpu: "1"
+    limits.memory: 512Mi
+    persistentvolumeclaims: "0"
+    pods: "1"
+    requests.cpu: 500m
+    requests.memory: 256Mi
+    services.loadbalancers: "0"

--- a/tests/artifacts/resourcequota-scoped.out
+++ b/tests/artifacts/resourcequota-scoped.out
@@ -1,0 +1,6 @@
+
+ResourceQuota/scoped-quota -n rq-test, created 1m ago
+  Current: Resource is current
+  Scope selector:
+    PriorityClass In high-priority
+  Quota: pods: 0/3[0%]

--- a/tests/artifacts/resourcequota-scoped.yaml
+++ b/tests/artifacts/resourcequota-scoped.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ResourceQuota","metadata":{"annotations":{},"name":"scoped-quota","namespace":"rq-test"},"spec":{"hard":{"pods":"3"},"scopeSelector":{"matchExpressions":[{"operator":"In","scopeName":"PriorityClass","values":["high-priority"]}]}}}
+  creationTimestamp: "2026-07-05T22:09:09Z"
+  name: scoped-quota
+  namespace: rq-test
+  resourceVersion: "78198"
+  uid: c78a0adc-e9f7-45ff-a32d-51072fb77600
+spec:
+  hard:
+    pods: "3"
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - high-priority
+status:
+  hard:
+    pods: "3"
+  used:
+    pods: "0"


### PR DESCRIPTION
## Summary
- Replace the ResourceQuota template stub with a real render: hard/used usage per resource with percentage (colored yellow/red/bold-red as it approaches exhaustion), `spec.scopes`, and `spec.scopeSelector`
- Collapse the quota list to a single line when only one resource is tracked, per the single-item-list convention
- Fixes #179

## Test plan
- [x] `make test` passes
- [x] Verified against live minikube instances: plain hard/used quota, `scopes: [BestEffort]`, and `scopeSelector` cases
- [x] Verified color thresholds with `--color=always`
- [x] Added golden artifacts: `resourcequota-compute`, `resourcequota-scoped`, `resourcequota-besteffort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)