### PR TITLE
Surface Node health when rendering a Pod or its owning workload

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/bergerx/kubectl-status/pkg/plugin"
@@ -34,6 +36,57 @@ type cmdTest struct {
 	stderrRegex     string // Regex
 	stderrEqual     string // Exact
 	wantErr         string // Contains
+}
+
+// createBadNode creates a synthetic Node (no real kubelet backs it) that's cordoned, tainted,
+// and reporting NotReady/MemoryPressure -- everything pod_node_problems/pod_node_problem_flags
+// are meant to surface. It registers cleanup and returns the Node's name.
+func createBadNode(t *testing.T, clientset *kubernetes.Clientset) string {
+	t.Helper()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kubectl-status-test-bad-node-",
+		},
+		Spec: corev1.NodeSpec{
+			Unschedulable: true,
+			Taints: []corev1.Taint{
+				{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+	node, err := clientset.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		clientset.CoreV1().Nodes().Delete(context.TODO(), node.Name, metav1.DeleteOptions{})
+	})
+	// The real node-lifecycle-controller starts reconciling this Node as soon as it's created
+	// (e.g. adding its own NotReady taint), racing our status update -- retry on conflict.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		latest.Status.Conditions = []corev1.NodeCondition{
+			{
+				Type:               corev1.NodeReady,
+				Status:             corev1.ConditionFalse,
+				Reason:             "KubeletNotReady",
+				Message:            "kubelet is not ready",
+				LastTransitionTime: metav1.Now(),
+			},
+			{
+				Type:               corev1.NodeMemoryPressure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "KubeletHasInsufficientMemory",
+				Message:            "kubelet has insufficient memory available",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		_, err = clientset.CoreV1().Nodes().UpdateStatus(context.TODO(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err)
+	return node.Name
 }
 
 func nodeNameModifier(stdout string) string {
@@ -371,6 +424,81 @@ Secret\/child -n default, created 1m ago by Secret/owner
 `,
 		}
 		test.assert(t, nil) // to update the out files check /tests/artifacts/README.md
+	})
+	t.Run("pod on a cordoned node with an untolerated taint and a bad condition", func(t *testing.T) {
+		viperTestHack(t)
+		nodeName := createBadNode(t, clientset)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-on-bad-node",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				NodeName:   nodeName,
+				Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
+			},
+		}
+		_, err := clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args: []string{"pod/pod-on-bad-node", "--include-events=false", "--v", "5"},
+			stdoutRegex: `(?ms)` +
+				`Node/` + nodeName + ` cordoned \(unschedulable\)\n` +
+				`.*Ready KubeletNotReady, kubelet is not ready.*\n` +
+				`.*MemoryPressure KubeletHasInsufficientMemory, kubelet has insufficient memory available.*\n` +
+				`.*taint dedicated=gpu:NoSchedule \(not tolerated\)`,
+		}.assert(t, nil)
+	})
+	t.Run("workload's matching pod on a cordoned node surfaces a compact node-problem flag", func(t *testing.T) {
+		viperTestHack(t)
+		nodeName := createBadNode(t, clientset)
+
+		// The Pod's spec.nodeName is set directly at creation, bypassing the scheduler, so it
+		// never actually runs -- ReplicaSet.tmpl's selector-based pod lookup only needs matching
+		// labels, not real ownership, to include it in the health summary.
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-on-bad-node-for-rs",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "kubectl-status-test-bad-rs"},
+			},
+			Spec: corev1.PodSpec{
+				NodeName:   nodeName,
+				Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
+			},
+		}
+		_, err := clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		one := int32(1)
+		rs := &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bad-rs",
+				Namespace: "default",
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: &one,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "kubectl-status-test-bad-rs"}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "kubectl-status-test-bad-rs"}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "busybox"}}},
+				},
+			},
+		}
+		_, err = clientset.AppsV1().ReplicaSets("default").Create(context.TODO(), rs, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.AppsV1().ReplicaSets("default").Delete(context.TODO(), rs.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args: []string{"rs/bad-rs", "--include-events=false", "--v", "5"},
+			stdoutRegex: `(?ms)` +
+				`Pod/pod-on-bad-node-for-rs -n default[^\n]*, node cordoned, node NotReady, ` +
+				`node MemoryPressure, untolerated node taint`,
+		}.assert(t, nil)
 	})
 	t.Run("sts-with-ingress", func(t *testing.T) {
 		viperTestHack(t)

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -83,6 +83,7 @@ func funcMap() template.FuncMap {
 		"forOrSince":                forOrSince,
 		"relativeTime":              relativeTime,
 		"labelSelector":             labelSelector,
+		"taintsNotToleratedByPod":   taintsNotToleratedByPod,
 		"cronNextTime":              cronNextTime,
 		"parseTLSSecretCertificate": parseTLSSecretCertificate,
 		"certificatesInSecret":      certificatesInSecret,
@@ -460,6 +461,67 @@ func labelSelector(s map[string]interface{}) string {
 		return fmt.Sprintf("%v", s)
 	}
 	return metav1.FormatLabelSelector(ls)
+}
+
+// tolerationMatchesTaint reports whether a single toleration covers a single taint, following
+// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
+func tolerationMatchesTaint(toleration, taint map[string]interface{}) bool {
+	if effect, _ := toleration["effect"].(string); effect != "" {
+		taintEffect, _ := taint["effect"].(string)
+		if effect != taintEffect {
+			return false
+		}
+	}
+	key, _ := toleration["key"].(string)
+	operator, _ := toleration["operator"].(string)
+	if operator == "" {
+		operator = "Equal"
+	}
+	taintKey, _ := taint["key"].(string)
+	switch operator {
+	case "Exists":
+		return key == "" || key == taintKey
+	case "Equal":
+		if key != taintKey {
+			return false
+		}
+		value, _ := toleration["value"].(string)
+		taintValue, _ := taint["value"].(string)
+		return value == taintValue
+	default:
+		return false
+	}
+}
+
+// taintsNotToleratedByPod returns the subset of nodeTaints that block scheduling or trigger
+// eviction (NoSchedule/NoExecute) and aren't covered by any of the pod's tolerations.
+// PreferNoSchedule is a soft preference, not a blocker, and is intentionally excluded.
+func taintsNotToleratedByPod(nodeTaints, tolerations []interface{}) (result []interface{}) {
+	for _, t := range nodeTaints {
+		taint, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		effect, _ := taint["effect"].(string)
+		if effect != "NoSchedule" && effect != "NoExecute" {
+			continue
+		}
+		tolerated := false
+		for _, tol := range tolerations {
+			toleration, ok := tol.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if tolerationMatchesTaint(toleration, taint) {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			result = append(result, taint)
+		}
+	}
+	return result
 }
 
 // parseTLSSecretCertificate inspects a Secret expected to be type kubernetes.io/tls and

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -163,6 +163,86 @@ func TestSortMapListByKeysValueIsStableOnTies(t *testing.T) {
 	}
 }
 
+func TestTaintsNotToleratedByPod(t *testing.T) {
+	noSchedule := map[string]interface{}{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}
+	noExecute := map[string]interface{}{"key": "node.kubernetes.io/not-ready", "effect": "NoExecute"}
+	preferNoSchedule := map[string]interface{}{"key": "spot", "effect": "PreferNoSchedule"}
+
+	tests := []struct {
+		name        string
+		nodeTaints  []interface{}
+		tolerations []interface{}
+		want        []interface{}
+	}{
+		{
+			name:        "no taints",
+			nodeTaints:  nil,
+			tolerations: nil,
+			want:        nil,
+		},
+		{
+			name:        "PreferNoSchedule is never a blocker",
+			nodeTaints:  []interface{}{preferNoSchedule},
+			tolerations: nil,
+			want:        nil,
+		},
+		{
+			name:        "untolerated NoSchedule blocks",
+			nodeTaints:  []interface{}{noSchedule},
+			tolerations: nil,
+			want:        []interface{}{noSchedule},
+		},
+		{
+			name:       "Equal toleration with matching key/value tolerates",
+			nodeTaints: []interface{}{noSchedule},
+			tolerations: []interface{}{
+				map[string]interface{}{"key": "dedicated", "operator": "Equal", "value": "gpu", "effect": "NoSchedule"},
+			},
+			want: nil,
+		},
+		{
+			name:       "Equal toleration with mismatched value does not tolerate",
+			nodeTaints: []interface{}{noSchedule},
+			tolerations: []interface{}{
+				map[string]interface{}{"key": "dedicated", "operator": "Equal", "value": "cpu", "effect": "NoSchedule"},
+			},
+			want: []interface{}{noSchedule},
+		},
+		{
+			name:       "Exists toleration with matching key tolerates regardless of value",
+			nodeTaints: []interface{}{noSchedule},
+			tolerations: []interface{}{
+				map[string]interface{}{"key": "dedicated", "operator": "Exists", "effect": "NoSchedule"},
+			},
+			want: nil,
+		},
+		{
+			name:       "Exists toleration with empty key tolerates everything of that effect",
+			nodeTaints: []interface{}{noExecute},
+			tolerations: []interface{}{
+				map[string]interface{}{"operator": "Exists", "effect": "NoExecute"},
+			},
+			want: nil,
+		},
+		{
+			name:       "toleration with wrong effect does not tolerate",
+			nodeTaints: []interface{}{noSchedule},
+			tolerations: []interface{}{
+				map[string]interface{}{"key": "dedicated", "operator": "Equal", "value": "gpu", "effect": "NoExecute"},
+			},
+			want: []interface{}{noSchedule},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := taintsNotToleratedByPod(tt.nodeTaints, tt.tolerations)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("taintsNotToleratedByPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAgoSuffix(t *testing.T) {
 	viper.Set("absolute-time", false)
 	if got := agoSuffix(); got != " ago" {

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -41,6 +41,27 @@
             {{- end }}
         {{- end }}
     {{- end }}
+    {{- if and .Status.active (not ($.Config.GetBool "shallow")) }}
+        {{- /* A Job's own status has no signal for "why hasn't this started" -- only its Pods do.
+               pod_health_summary carries the Node-side hint (cordoned/tainted/unhealthy node),
+               which is usually the answer for a Pod stuck Pending. */ -}}
+        {{- $pendingPods := list }}
+        {{- range $.KubeGetByLabelsMap $.Namespace "pods" (dict "job-name" .Name) }}
+            {{- if eq .Status.phase "Pending" }}
+                {{- $pendingPods = append $pendingPods . }}
+            {{- end }}
+        {{- end }}
+        {{- with $pendingPods }}
+            {{- "Pending pods" | yellow | bold | nindent 2 }}:
+            {{- range . }}
+                {{- if $.Config.GetBool "deep" }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- else }}
+                    {{- $.Include "pod_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
     {{- template "conditions_summary" . }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -5,6 +5,7 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "application_details" . }}
     {{- .Include "pod_conditions_summary" . | nindent 2 }}
+    {{- template "pod_node_problems" . }}
     {{- $secCtx := .Spec.securityContext | default dict }}
     {{- $seccomp := index $secCtx "seccompProfile" | default dict }}
     {{- if eq (index $seccomp "type" | default "") "Unconfined" }}
@@ -57,6 +58,44 @@
     {{- with .Status.qosClass }} {{ if ($.Object | default dict).inline }}{{ . }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}
     {{- with .Status.message }}, message: {{ . }}{{ end }}
 {{- end -}}
+
+{{- define "pod_node_problems" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects the Pod RenderableObject. Fetches the Node this Pod is (or would be) scheduled
+           to and surfaces only what explains trouble with this Pod: unhealthy conditions,
+           cordoned/unschedulable state, and taints this Pod doesn't tolerate. Full Node capacity,
+           labels, etc. are intentionally omitted here -- see Node.tmpl for the complete render. */ -}}
+    {{- $nodeName := get .Spec "nodeName" }}
+    {{- if $nodeName }}
+        {{- $node := .KubeGetFirst "" "Node" $nodeName }}
+        {{- if $node.Object }}
+            {{- if .Config.GetBool "deep" }}
+                {{- "Node:" | bold | nindent 2 }}
+                {{- .IncludeRenderableObject $node | nindent 4 }}
+            {{- else }}
+                {{- $unhealthy := list }}
+                {{- range $node.StatusConditions }}
+                    {{- if not (isStatusConditionHealthy .) }}
+                        {{- $unhealthy = append $unhealthy . }}
+                    {{- end }}
+                {{- end }}
+                {{- $blockingTaints := taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}
+                {{- $cordoned := $node.Spec.unschedulable }}
+                {{- if or $unhealthy $blockingTaints $cordoned }}
+                    {{- "Node/" | bold | nindent 2 }}{{ $nodeName | cyan }}
+                    {{- if $cordoned }} {{ "cordoned (unschedulable)" | red | bold }}{{ end }}
+                    {{- range $unhealthy }}
+                        {{- $.Include "condition_summary" . | nindent 4 }}
+                    {{- end }}
+                    {{- range $blockingTaints }}
+                        {{- $val := "" }}{{ with .value }}{{ $val = printf "=%s" . }}{{ end }}
+                        {{- printf "taint %s%s:%s (not tolerated)" .key $val .effect | red | bold | nindent 4 }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
 
 {{- define "pod_init_containers" }}
     {{- /* Expects a dict "pod" (Pod RenderableObject) "podPullSecretsBroken" (bool) */ -}}

--- a/pkg/plugin/templates/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/ReplicaSet.tmpl
@@ -5,6 +5,7 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
+    {{- template "selector_with_health_summary" . }}
     {{- /* Where there is no readyReplicas, STS doesn't have that fields at all,
            and apparantly the numbers are parsed as float 64, so used 0.0 rather then 0 */ -}}
     {{- $injectedStatus := .Status }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -218,6 +218,39 @@
         {{- if .ready }}{{ $ready = add1 $ready }}{{ end }}
     {{- end }}
     {{- if $total }}, {{ if lt $ready $total }}{{ printf "%d/%d" $ready $total | red | bold }}{{ else }}{{ printf "%d/%d" $ready $total | green }}{{ end }} ready{{ end }}
+    {{- $nodeProblems := .Include "pod_node_problem_flags" . }}
+    {{- with $nodeProblems }}, {{ . }}{{ end }}
+{{- end }}
+
+{{- define "pod_node_problem_flags" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects the Pod RenderableObject. Returns a compact, comma-joined inline fragment (no
+           leading separator) naming Node-side problems that explain trouble with this Pod --
+           unhealthy conditions, cordoned state, untolerated taints -- or "" when there's nothing
+           to report. Used where a single-line-per-pod summary is needed; see "pod_node_problems"
+           in Pod.tmpl for the fuller per-condition block used on the Pod's own render. */ -}}
+    {{- $nodeName := get .Spec "nodeName" }}
+    {{- if $nodeName }}
+        {{- $node := .KubeGetFirst "" "Node" $nodeName }}
+        {{- if $node.Object }}
+            {{- $flags := list }}
+            {{- if $node.Spec.unschedulable }}{{ $flags = append $flags ("node cordoned" | red | bold) }}{{ end }}
+            {{- range $node.StatusConditions }}
+                {{- if not (isStatusConditionHealthy .) }}
+                    {{- /* Bare condition types read "abnormal-true" (e.g. MemoryPressure), except
+                           Ready, which is "normal-true" -- name that one explicitly so plain-text
+                           output doesn't read as healthy when it isn't. */ -}}
+                    {{- $label := .type }}
+                    {{- if eq $label "Ready" }}{{ $label = "NotReady" }}{{ end }}
+                    {{- $flags = append $flags (printf "node %s" $label | red | bold) }}
+                {{- end }}
+            {{- end }}
+            {{- if taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}
+                {{- $flags = append $flags ("untolerated node taint" | red | bold) }}
+            {{- end }}
+            {{- join ", " $flags }}
+        {{- end }}
+    {{- end }}
 {{- end }}
 
 {{- define "service_health_summary" }}

--- a/tests/artifacts/rs-all-replicas-ready.out
+++ b/tests/artifacts/rs-all-replicas-ready.out
@@ -1,3 +1,4 @@
 
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:1
   Current: ReplicaSet is available. Replicas: 3
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment

--- a/tests/artifacts/rs-no-ready-replicas.out
+++ b/tests/artifacts/rs-no-ready-replicas.out
@@ -2,4 +2,5 @@
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:1
   InProgress: Available: 0/3
     Reconciling: LessAvailable, Available: 0/3
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment
   Outage: ReplicaSet has no Ready replicas.

--- a/tests/artifacts/rs-non-existing-image.out
+++ b/tests/artifacts/rs-non-existing-image.out
@@ -2,4 +2,5 @@
 ReplicaSet/missing-image-755c8c54f7 -n test1, created 1m ago by Deployment/missing-image, gen:1
   InProgress: Available: 0/1
     Reconciling: LessAvailable, Available: 0/1
+  Selector: pod-template-hash=755c8c54f7,run=missing-image
   Outage: ReplicaSet has no Ready replicas.

--- a/tests/artifacts/rs-not-all-replicas-ready.out
+++ b/tests/artifacts/rs-not-all-replicas-ready.out
@@ -2,3 +2,4 @@
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:1
   InProgress: Available: 1/3
     Reconciling: LessAvailable, Available: 1/3
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment

--- a/tests/artifacts/rs-ongoing-rollout.out
+++ b/tests/artifacts/rs-ongoing-rollout.out
@@ -1,4 +1,5 @@
 
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:2
   Current: ReplicaSet is available. Replicas: 2
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment
   Ongoing rollout, check Owner Reference resources.

--- a/tests/artifacts/rs-replicas-0.out
+++ b/tests/artifacts/rs-replicas-0.out
@@ -2,4 +2,5 @@
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:1
   InProgress: Labelled: 0/3
     Reconciling: LessLabelled, Labelled: 0/3
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment
   Outage: ReplicaSet has no Ready replicas.

--- a/tests/artifacts/rs-superseeded.out
+++ b/tests/artifacts/rs-superseeded.out
@@ -1,4 +1,5 @@
 
 ReplicaSet/httpbin-deployment-79f6dfbb9 -n test1, created 1m ago by Deployment/httpbin-deployment, gen:4
   Current: ReplicaSet is available. Replicas: 0
+  Selector: pod-template-hash=79f6dfbb9,run=httpbin-deployment
   Old: This ReplicaSet is likely replaced by a new one, check Owner Reference resources.


### PR DESCRIPTION
## Summary

A Pod's own status can't explain why it's `Pending` on an unschedulable node, why it might get evicted (`MemoryPressure`/`DiskPressure`/`PIDPressure`), or why a taint is blocking it — that only lives on the Node object, which no template fetched before. This adds a compact, opinionated hint fetched via `KubeGetFirst`, following the existing "fetch related objects that explain state" pattern (same as the kubelet stats fetch already done for Pods).

- **`Pod.tmpl`**: new `pod_node_problems` block — cordoned state, unhealthy conditions, untolerated taints in compact mode; full Node render under `--deep`.
- **`common.tmpl`**: `pod_node_problem_flags`, a terse inline variant wired into `pod_health_summary`, so the same signal shows up when a workload lists its pods (`Selector:` block), not just on the Pod's own render.
- **`ReplicaSet.tmpl`**: added the `selector_with_health_summary` call it was missing — Deployment/StatefulSet/DaemonSet already had it, RS didn't list its pods at all.
- **`Job.tmpl`**: added a "Pending pods" section — Job previously only surfaced `Failed` pods, so a pod stuck `Pending` because of a bad node was invisible.
- **Go**: `taintsNotToleratedByPod` — proper taint/toleration matching (`Equal`/`Exists` operators, `NoSchedule`/`NoExecute` only; `PreferNoSchedule` is a soft preference and intentionally excluded).

## Test coverage — and a gap I want reviewers to weigh in on

I added two live-cluster e2e subtests (`cmd/main_test.go`), both using a synthetic cordoned/tainted/`NotReady` Node created imperatively via the client (not the usual `tests/e2e-artifacts/*.yaml` + `.regex` fixture pattern, because that pattern assumes a real, already-healthy node — a synthetic *unhealthy* node needs `clientset.Create()`/`UpdateStatus()`, and even then the real node-lifecycle-controller races to reconcile it, which is why there's a `retry.RetryOnConflict` in the test helper):

1. **Pod, queried directly** — exercises the `pod_node_problems` block form.
2. **ReplicaSet, matching pod on the bad node** — exercises the shared `pod_health_summary` → `pod_node_problem_flags` inline path.

**What that does *not* cover, and why:**

- **Deployment / StatefulSet / DaemonSet**: no dedicated e2e test. My reasoning was that all three reach pod rendering through the exact same shared code the ReplicaSet test already exercises (`selector_with_health_summary` → `pod_health_summary` → `pod_node_problem_flags`), with zero per-kind branching in that chain — the only difference is a one-line template call, which I spot-checked by hand against a live Deployment (output pasted below) but didn't lock in as an automated test. If you think each kind should get its own test regardless of shared code, I can add them — push back if the proxy isn't good enough for you.
- **Job**: this one I'm less comfortable with. Job has bespoke logic (the new "Pending pods" loop isn't shared with the other workloads, since Job has no `.spec.selector`), and I only verified it by hand, not automated. This is a real coverage gap I didn't get back to, not a considered trade-off — I'm inclined to add it before merge, but flagging it here in case there's a reason (or existing convention) I'm missing for why Job pods aren't otherwise covered live.
- **CronJob**: not touched — compact mode only ever shows `job_health_summary` (one-liner, no pod detail) for its Jobs, so it doesn't reach pod-level rendering in compact mode at all; `--deep` inherits whatever Job coverage exists.

Manual verification of the Deployment case (since removed from the test cluster, not automated):
```
Selector: app=demo-bad
    Pod/demo-bad-pod -n default Pending, node cordoned, node NotReady, node MemoryPressure, untolerated node taint
```

## Test plan
- [x] `go test ./...` (offline suite, includes new `taintsNotToleratedByPod` unit tests and updated `rs-*.out` golden files for ReplicaSet's new `Selector:` line)
- [x] `make test-e2e` equivalent (`RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/... -run TestE2EDynamicManifests`) — full suite passes, including the two new subtests
- [x] `gofmt`, `go vet`
- [ ] Reviewer call on the Deployment/STS/DaemonSet proxy-coverage and Job gap noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)