### PR TITLE
Expand Service template with traffic policy, session affinity, and ExternalName support

### DIFF
--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -12,8 +12,9 @@
             {{- if $index }}, {{ end }}{{ with $port.nodePort }}{{ . | toString | cyan }}{{ else }}{{ "auto" | yellow }}{{ end }}{{ with $port.name }} ({{ . }}){{ end }}
         {{- end }}
     {{- end }}
+    {{- $slices := list }}
     {{- if ne .Spec.type "ExternalName" }}
-        {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
+        {{- $slices = .KubeGetEndpointSlicesForService .Namespace .Name }}
         {{- if $slices }}
             {{- if hasKey (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" -}}
                 , last endpoint change was {{ index (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" | colorAgo }}{{ agoSuffix }}
@@ -26,7 +27,6 @@
     {{- if eq .Spec.type "ExternalName" }}
   {{ "ExternalName" | bold }}: DNS CNAME to {{ .Spec.externalName | cyan }} (no cluster endpoints)
     {{- else }}
-        {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
         {{- $hasAnyEndpoints := false }}
         {{- $hasReadyEndpoints := false }}
         {{- range $slices }}

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -12,52 +12,94 @@
             {{- if $index }}, {{ end }}{{ with $port.nodePort }}{{ . | toString | cyan }}{{ else }}{{ "auto" | yellow }}{{ end }}{{ with $port.name }} ({{ . }}){{ end }}
         {{- end }}
     {{- end }}
-    {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
-    {{- if $slices }}
-        {{- if hasKey (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" -}}
-            , last endpoint change was {{ index (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" | colorAgo }}{{ agoSuffix }}
+    {{- if ne .Spec.type "ExternalName" }}
+        {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
+        {{- if $slices }}
+            {{- if hasKey (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" -}}
+                , last endpoint change was {{ index (index $slices 0).Annotations "endpoints.kubernetes.io/last-change-trigger-time" | colorAgo }}{{ agoSuffix }}
+            {{- end}}
         {{- end}}
-    {{- end}}
+    {{- end }}
     {{- template "kstatus_summary" . }}
     {{- template "application_details" . }}
-    {{- $hasAnyEndpoints := false }}
-    {{- $hasReadyEndpoints := false }}
-    {{- range $slices }}
-        {{- range (.Object.endpoints | default list) }}
-            {{- $hasAnyEndpoints = true }}
-            {{- if or (not (hasKey (.conditions | default dict) "ready")) .conditions.ready }}{{- $hasReadyEndpoints = true }}{{- end }}
-        {{- end }}
-    {{- end }}
-    {{- if not $slices }}
-  {{ "Missing Endpoint" | red | bold }}: Service has no matching endpoint.
-    {{- else if not $hasAnyEndpoints }}
-  {{ "No matching pods" | red | bold }}: Service selector either doesn't match any Pods or the Service's targetPort doesn't match the Pod's port.
+    {{- template "service_traffic_config" . }}
+    {{- if eq .Spec.type "ExternalName" }}
+  {{ "ExternalName" | bold }}: DNS CNAME to {{ .Spec.externalName | cyan }} (no cluster endpoints)
     {{- else }}
+        {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
+        {{- $hasAnyEndpoints := false }}
+        {{- $hasReadyEndpoints := false }}
         {{- range $slices }}
-            {{- $ports := .Object.ports }}
             {{- range (.Object.endpoints | default list) }}
-                {{- if or (not (hasKey (.conditions | default dict) "ready")) .conditions.ready }}
-  Ready: {{ template "endpoint_slice_endpoint" (dict "endpoint" . "ports" $ports) }}
-                {{- end }}
+                {{- $hasAnyEndpoints = true }}
+                {{- if or (not (hasKey (.conditions | default dict) "ready")) .conditions.ready }}{{- $hasReadyEndpoints = true }}{{- end }}
             {{- end }}
         {{- end }}
-        {{- if not $hasReadyEndpoints }}
+        {{- if not $slices }}
+  {{ "Missing Endpoint" | red | bold }}: Service has no matching endpoint.
+        {{- else if not $hasAnyEndpoints }}
+  {{ "No matching pods" | red | bold }}: Service selector either doesn't match any Pods or the Service's targetPort doesn't match the Pod's port.
+        {{- else }}
+            {{- range $slices }}
+                {{- $ports := .Object.ports }}
+                {{- range (.Object.endpoints | default list) }}
+                    {{- if or (not (hasKey (.conditions | default dict) "ready")) .conditions.ready }}
+  Ready: {{ template "endpoint_slice_endpoint" (dict "endpoint" . "ports" $ports) }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+            {{- if not $hasReadyEndpoints }}
   {{ "Outage" | red | bold }}: This service doesn't match any Ready pods.
-        {{- end }}
-        {{- range $slices }}
-            {{- $ports := .Object.ports }}
-            {{- range (.Object.endpoints | default list) }}
-                {{- if and (hasKey (.conditions | default dict) "ready") (not .conditions.ready) }}
+            {{- end }}
+            {{- range $slices }}
+                {{- $ports := .Object.ports }}
+                {{- range (.Object.endpoints | default list) }}
+                    {{- if and (hasKey (.conditions | default dict) "ready") (not .conditions.ready) }}
   {{ "NotReady" | red | bold }}: {{ template "endpoint_slice_endpoint" (dict "endpoint" . "ports" $ports) }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
+    {{- template "conditions_summary" . }}
     {{- template "recent_updates" . }}
     {{- template "matching_ingresses" . }}
     {{- template "matching_routes" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
+{{- end -}}
+
+{{- define "service_traffic_config" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- $etp := .Spec.externalTrafficPolicy | default "Cluster" }}
+    {{- $itp := .Spec.internalTrafficPolicy | default "Cluster" }}
+    {{- $showEtp := ne $etp "Cluster" }}
+    {{- $showItp := ne $itp "Cluster" }}
+    {{- if or $showEtp $showItp }}
+        {{- "Traffic policy" | bold | nindent 2 }}:
+        {{- if $showEtp }} external={{ $etp | cyan }}{{ with .Spec.healthCheckNodePort }} (healthCheckNodePort:{{ . | toString | cyan }}){{ end }}{{ end }}
+        {{- if and $showEtp $showItp }},{{ end }}
+        {{- if $showItp }} internal={{ $itp | cyan }}{{ end }}
+    {{- end }}
+    {{- if eq .Spec.sessionAffinity "ClientIP" }}
+        {{- "Session affinity" | bold | nindent 2 }}: {{ "ClientIP" | cyan }}
+        {{- with .Spec.sessionAffinityConfig.clientIP.timeoutSeconds }} (timeout {{ . | toString | cyan }}s){{ end }}
+    {{- end }}
+    {{- with .Spec.loadBalancerSourceRanges }}
+        {{- "Source ranges" | bold | nindent 2 }}: {{ join ", " . | cyan }}
+    {{- end }}
+    {{- with .Spec.externalIPs }}
+        {{- "External IPs" | bold | nindent 2 }}: {{ join ", " . | cyan }}
+    {{- end }}
+    {{- with .Spec.loadBalancerClass }}
+        {{- "LoadBalancer class" | bold | nindent 2 }}: {{ . | cyan }}
+    {{- end }}
+    {{- with .Spec.trafficDistribution }}
+        {{- "Traffic distribution" | bold | nindent 2 }}: {{ . | cyan }}
+    {{- end }}
+    {{- if .Spec.publishNotReadyAddresses }}
+        {{- "Publishes not-ready addresses" | yellow | nindent 2 }}: endpoints are included before passing readiness checks.
+    {{- end }}
 {{- end -}}
 
 {{- define "matching_ingresses" }}

--- a/tests/artifacts/service-advanced-traffic-config.out
+++ b/tests/artifacts/service-advanced-traffic-config.out
@@ -1,0 +1,11 @@
+
+Service/svc-advanced-traffic-config -n kubectl-status-svc-test, created 1m ago
+  Current: Service is ready
+  Traffic policy: external=Local (healthCheckNodePort:32501), internal=Local
+  Session affinity: ClientIP (timeout 10800s)
+  Source ranges: 10.0.0.0/8, 172.16.0.0/12
+  External IPs: 203.0.113.10
+  LoadBalancer class: example.com/custom-lb
+  Traffic distribution: PreferSameZone
+  Publishes not-ready addresses: endpoints are included before passing readiness checks.
+  Missing Endpoint: Service has no matching endpoint.

--- a/tests/artifacts/service-advanced-traffic-config.yaml
+++ b/tests/artifacts/service-advanced-traffic-config.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"svc-advanced-traffic-config","namespace":"kubectl-status-svc-test"},"spec":{"externalIPs":["203.0.113.10"],"externalTrafficPolicy":"Local","internalTrafficPolicy":"Local","loadBalancerClass":"example.com/custom-lb","loadBalancerSourceRanges":["10.0.0.0/8","172.16.0.0/12"],"ports":[{"port":80,"targetPort":80}],"publishNotReadyAddresses":true,"selector":{"app":"svc-advanced-traffic-config"},"sessionAffinity":"ClientIP","sessionAffinityConfig":{"clientIP":{"timeoutSeconds":10800}},"trafficDistribution":"PreferSameZone","type":"LoadBalancer"}}
+  creationTimestamp: "2026-07-06T15:21:33Z"
+  name: svc-advanced-traffic-config
+  namespace: kubectl-status-svc-test
+  resourceVersion: "133727"
+  uid: f41c1c64-bded-44be-a235-0a336bc41870
+spec:
+  allocateLoadBalancerNodePorts: true
+  clusterIP: 10.96.133.65
+  clusterIPs:
+  - 10.96.133.65
+  externalIPs:
+  - 203.0.113.10
+  externalTrafficPolicy: Local
+  healthCheckNodePort: 32501
+  internalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  loadBalancerClass: example.com/custom-lb
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  ports:
+  - nodePort: 30321
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  publishNotReadyAddresses: true
+  selector:
+    app: svc-advanced-traffic-config
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
+  trafficDistribution: PreferSameZone
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/tests/artifacts/service-externalname.out
+++ b/tests/artifacts/service-externalname.out
@@ -1,0 +1,4 @@
+
+Service/svc-externalname -n kubectl-status-svc-test, created 1m ago
+  Current: Service is ready
+  ExternalName: DNS CNAME to example.database.svc.cluster.local (no cluster endpoints)

--- a/tests/artifacts/service-externalname.yaml
+++ b/tests/artifacts/service-externalname.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{},"name":"svc-externalname","namespace":"kubectl-status-svc-test"},"spec":{"externalName":"example.database.svc.cluster.local","type":"ExternalName"}}
+  creationTimestamp: "2026-07-06T15:21:14Z"
+  name: svc-externalname
+  namespace: kubectl-status-svc-test
+  resourceVersion: "133692"
+  uid: a7b48d78-fb95-4972-bba5-fb900fd47cd8
+spec:
+  externalName: example.database.svc.cluster.local
+  sessionAffinity: None
+  type: ExternalName
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Summary
- Service.tmpl has existed for a long time but only covered the basic ClusterIP/NodePort/LoadBalancer endpoint cases, ignoring most non-default spec fields.
- Add a `service_traffic_config` section covering external/internal traffic policy (+ healthCheckNodePort), session affinity (+ timeout), load balancer source ranges, external IPs, load balancer class, traffic distribution, and publishNotReadyAddresses — each only shown when it deviates from the Kubernetes default.
- Add dedicated `ExternalName` type handling: skip pointless endpoint-slice lookups and render a DNS CNAME line instead of "Missing Endpoint".
- Add the previously-missing `conditions_summary` bookend section.

## Test plan
- [x] New live-cluster artifacts: `service-externalname.{yaml,out}`, `service-advanced-traffic-config.{yaml,out}` (generated from real minikube Service resources)
- [x] `make test` passes (vet, staticcheck, full `go test ./...`, including golden-file `TestAllArtifactsLocal`)
- [x] Verified no regressions in existing Service golden-file artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)