### PR TITLE
Fix --include-rollout-diffs (broken since DynamicObject introduced)

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -500,6 +500,50 @@ Secret\/child -n default, created 1m ago by Secret/owner
 				`node MemoryPressure, untolerated node taint`,
 		}.assert(t, nil)
 	})
+	t.Run("deployment rollout with --include-rollout-diffs shows the diff between revisions", func(t *testing.T) {
+		viperTestHack(t)
+		name := "rollout-diff-test"
+		one := int32(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &one,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.25"}}},
+				},
+			},
+		}
+		_, err := clientset.AppsV1().Deployments("default").Create(context.TODO(), dep, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.AppsV1().Deployments("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
+		waitFor(t, "deployment/"+name, "condition=Available")
+
+		// Update the image so a second ReplicaSet revision is created, giving --include-rollout-diffs
+		// something to diff.
+		dep, err = clientset.AppsV1().Deployments("default").Get(context.TODO(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		dep.Spec.Template.Spec.Containers[0].Image = "nginx:1.26"
+		_, err = clientset.AppsV1().Deployments("default").Update(context.TODO(), dep, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", "default", "--timeout=2m")
+		output, err := rolloutCmd.CombinedOutput()
+		t.Logf("rollout status for %s: %s", name, output)
+		require.NoError(t, err)
+
+		stdout, _, err := executeCMD(t, []string{"deployment/" + name, "--include-rollout-diffs", "--include-events=false", "--v", "5"})
+		require.NoError(t, err)
+		// The order in which the two ReplicaSet revisions are diffed (and so which side
+		// gets "-" vs "+") isn't guaranteed, so just assert both images show up as changed
+		// lines rather than pinning down a direction.
+		assert.Contains(t, stdout, "Diff:")
+		assert.Regexp(t, `(?m)^\s*[-+]\s+"image": "nginx:1\.25",\s*$`, stdout)
+		assert.Regexp(t, `(?m)^\s*[-+]\s+"image": "nginx:1\.26",\s*$`, stdout)
+	})
 	t.Run("sts-with-ingress", func(t *testing.T) {
 		viperTestHack(t)
 		// using sts here as the pod name is predictable in that case, not true for deployments and ds

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -211,22 +211,6 @@ func (r *ResourceRepo) DynamicObject(gvr schema.GroupVersionResource, namespace 
 	return u.Object, nil
 }
 
-func (r *ResourceRepo) DynamicObjects(gvr schema.GroupVersionResource, namespace string) (Objects, error) {
-	unstructuredList, err := r.dynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	var objects Objects
-	for _, unstructuredObj := range unstructuredList.Items {
-		unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(unstructuredObj.Object)
-		if err != nil {
-			return nil, err
-		}
-		objects = append(objects, unstructuredObj)
-	}
-	return objects, nil
-}
-
 func (r *ResourceRepo) GVRFor(resourceOrKindArg string) (schema.GroupVersionResource, error) {
 	mapping, err := r.mappingFor(resourceOrKindArg)
 	if err != nil {

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -208,11 +208,7 @@ func (r *ResourceRepo) DynamicObject(gvr schema.GroupVersionResource, namespace 
 	if err != nil {
 		return nil, err
 	}
-	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(u.Object)
-	if err != nil {
-		return nil, err
-	}
-	return object, nil
+	return u.Object, nil
 }
 
 func (r *ResourceRepo) DynamicObjects(gvr schema.GroupVersionResource, namespace string) (Objects, error) {


### PR DESCRIPTION
## Summary
- `DynamicObject` re-converted an already-`unstructured.Unstructured` object through `runtime.DefaultUnstructuredConverter.ToUnstructured`, which always fails on a `map[string]interface{}` input (`ToUnstructured requires a non-nil pointer to an object, got map[string]interface {}`). This silently broke every `--include-rollout-diffs` lookup for Deployment/DaemonSet/StatefulSet — the diff template swallowed the error and just rendered nothing.
- Fix: return the object's already-unstructured map directly instead of round-tripping it.
- Added an e2e test that creates a Deployment, updates its image to produce a second ReplicaSet revision, and asserts `--include-rollout-diffs` renders the diff between the two image versions. Verified it fails on the pre-fix code and passes after the fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `go test ./...`
- [x] `RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/... -run TestE2E` (full e2e suite against local minikube)

🤖 Generated with [Claude Code](https://claude.com/claude-code)