### PR TITLE
Cache per-node kubelet stats and generic object lookups within a render

### DIFF
--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -141,6 +141,9 @@ func (r *ResourceRepo) Objects(namespace string, args []string, labelSelector st
 		return entry.objects, entry.err
 	}
 	unstructuredObjects, err := r.objectsUncached(namespace, args, labelSelector)
+	if r.objectsCache == nil {
+		r.objectsCache = make(map[string]objectsCacheEntry)
+	}
 	r.objectsCache[cacheKey] = objectsCacheEntry{objects: unstructuredObjects, err: err}
 	return unstructuredObjects, err
 }
@@ -314,6 +317,9 @@ func (r *ResourceRepo) EndpointSlices(namespace string) (*discoveryv1.EndpointSl
 		return entry.list, entry.err
 	}
 	list, err := r.kubernetesClientSet.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{})
+	if r.endpointSlicesCache == nil {
+		r.endpointSlicesCache = make(map[string]endpointSlicesCacheEntry)
+	}
 	r.endpointSlicesCache[namespace] = endpointSlicesCacheEntry{list: list, err: err}
 	return list, err
 }
@@ -326,6 +332,9 @@ func (r *ResourceRepo) KubeGetNodeStatsSummary(nodeName string) (Object, error) 
 		return entry.summary, entry.err
 	}
 	nodeStatsSummary, err := r.kubeGetNodeStatsSummaryUncached(nodeName)
+	if r.nodeStatsSummaryCache == nil {
+		r.nodeStatsSummaryCache = make(map[string]nodeStatsSummaryCacheEntry)
+	}
 	r.nodeStatsSummaryCache[nodeName] = nodeStatsSummaryCacheEntry{summary: nodeStatsSummary, err: err}
 	return nodeStatsSummary, err
 }

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -65,16 +65,37 @@ func NewResourceRepo(factory util.Factory) (*ResourceRepo, error) {
 		return nil, err
 	}
 	return &ResourceRepo{
-		f:                   factory,
-		dynamicClient:       dynamicClient,
-		kubernetesClientSet: kubernetesClientSet,
+		f:                     factory,
+		dynamicClient:         dynamicClient,
+		kubernetesClientSet:   kubernetesClientSet,
+		nodeStatsSummaryCache: make(map[string]nodeStatsSummaryCacheEntry),
+		objectsCache:          make(map[string]objectsCacheEntry),
+		endpointSlicesCache:   make(map[string]endpointSlicesCacheEntry),
 	}, nil
 }
 
 type ResourceRepo struct {
-	f                   util.Factory
-	dynamicClient       dynamic.Interface
-	kubernetesClientSet *kubernetes.Clientset
+	f                     util.Factory
+	dynamicClient         dynamic.Interface
+	kubernetesClientSet   *kubernetes.Clientset
+	nodeStatsSummaryCache map[string]nodeStatsSummaryCacheEntry
+	objectsCache          map[string]objectsCacheEntry
+	endpointSlicesCache   map[string]endpointSlicesCacheEntry
+}
+
+type nodeStatsSummaryCacheEntry struct {
+	summary Object
+	err     error
+}
+
+type objectsCacheEntry struct {
+	objects Objects
+	err     error
+}
+
+type endpointSlicesCacheEntry struct {
+	list *discoveryv1.EndpointSliceList
+	err  error
 }
 
 func (r *ResourceRepo) newBaseBuilder() *resource.Builder {
@@ -115,6 +136,16 @@ func (r *ResourceRepo) CLIQueryResults(args []string) *resource.Result {
 }
 
 func (r *ResourceRepo) Objects(namespace string, args []string, labelSelector string) (Objects, error) {
+	cacheKey := strings.Join([]string{namespace, strings.Join(args, "\x1f"), labelSelector}, "\x1e")
+	if entry, ok := r.objectsCache[cacheKey]; ok {
+		return entry.objects, entry.err
+	}
+	unstructuredObjects, err := r.objectsUncached(namespace, args, labelSelector)
+	r.objectsCache[cacheKey] = objectsCacheEntry{objects: unstructuredObjects, err: err}
+	return unstructuredObjects, err
+}
+
+func (r *ResourceRepo) objectsUncached(namespace string, args []string, labelSelector string) (Objects, error) {
 	builder := r.newBaseBuilder().
 		NamespaceParam(namespace).
 		ResourceTypeOrNameArgs(true, args...).
@@ -279,13 +310,27 @@ func (r *ResourceRepo) Service(namespace, name string) (*corev1.Service, error) 
 }
 
 func (r *ResourceRepo) EndpointSlices(namespace string) (*discoveryv1.EndpointSliceList, error) {
-	return r.kubernetesClientSet.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{})
+	if entry, ok := r.endpointSlicesCache[namespace]; ok {
+		return entry.list, entry.err
+	}
+	list, err := r.kubernetesClientSet.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{})
+	r.endpointSlicesCache[namespace] = endpointSlicesCacheEntry{list: list, err: err}
+	return list, err
 }
 
 // KubeGetNodeStatsSummary returns this structure
 // > kubectl get --raw /api/v1/nodes/{nodeName}/proxy/stats/summary
 // The endpoint that this function uses will be disabled soon: https://github.com/kubernetes/kubernetes/issues/68522
 func (r *ResourceRepo) KubeGetNodeStatsSummary(nodeName string) (Object, error) {
+	if entry, ok := r.nodeStatsSummaryCache[nodeName]; ok {
+		return entry.summary, entry.err
+	}
+	nodeStatsSummary, err := r.kubeGetNodeStatsSummaryUncached(nodeName)
+	r.nodeStatsSummaryCache[nodeName] = nodeStatsSummaryCacheEntry{summary: nodeStatsSummary, err: err}
+	return nodeStatsSummary, err
+}
+
+func (r *ResourceRepo) kubeGetNodeStatsSummaryUncached(nodeName string) (Object, error) {
 	getBytes, err := r.kubernetesClientSet.CoreV1().RESTClient().Get().
 		Resource("nodes").
 		SubResource("proxy").


### PR DESCRIPTION
## Summary
- `status pods` was issuing many redundant dynamic API calls: `KubeGetNodeStatsSummary` was fetched 3x per pod (once each from `Pod.tmpl`'s init-containers, containers, and volumes sections), and the generic `Objects()`/`FirstObject()` lookup path plus `EndpointSlices()` re-fetched identical Node/Namespace/EndpointSlice data once per pod even though it's constant within a single invocation.
- Added simple per-invocation memoization on the already-shared `*ResourceRepo` instance for `KubeGetNodeStatsSummary`, `Objects()` (keyed by namespace/args/selector), and `EndpointSlices()` (keyed by namespace).
- For a 7-pod/1-node namespace, this cuts total dynamic requests from 70 to 16, with the biggest win on `stats/summary` (21 -> 1).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (237 passed)
- [x] Verified byte-identical rendered output before/after for `pods`, `deployments`, `replicasets`, `services`, `nodes`, `endpointslices`, `persistentvolumeclaims` against a live minikube cluster
- [x] Confirmed request-count reduction via `-v=8` verbose client-go logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)