### PR TITLE
Show terminal-state and recently-restarted container logs in Pod status

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -788,6 +788,34 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			}
 		})
 	})
+	t.Run("pod-container-logs", func(t *testing.T) {
+		// --shallow (used by the offline golden-file tests) makes KubeGetContainerLogs a
+		// no-op, so this e2e suite is the only place that exercises real log fetching: a
+		// terminated init container with output (current-state logs), a terminated init
+		// container with no output (yellow "no logs to show"), a crashlooping regular
+		// container that has recently restarted (previous-instance logs), and a healthy
+		// sidecar plus a healthy regular container that should show neither.
+		//
+		// withinLastHour compares real container timestamps against nowFunc, so the
+		// suite-wide fixed clock (testHack, frozen at 2026-06-30) has to be swapped for the
+		// real wall clock for this render, or a live restart looks like it happened in the
+		// future and never matches.
+		viperTestHack(t)
+		plugin.SetNowFunc(time.Now)
+		t.Cleanup(func() {
+			plugin.SetNowFunc(func() time.Time { return time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC) })
+		})
+		applyManifest(t, "e2e-artifacts/pod-container-logs.yaml")
+		// Wait for a stable Waiting(CrashLoopBackOff) state rather than just restartCount > 0:
+		// the container's current state otherwise flips between Waiting and Terminated(Error)
+		// as the kubelet retries, which would make the golden regex flaky.
+		waitForContainerWaitingReason(t, "pod/e2e-pod-container-logs", "crasher", "CrashLoopBackOff")
+
+		cmdTest{
+			args:            []string{"pod/e2e-pod-container-logs", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-container-logs.regex",
+		}.assert(t, nil)
+	})
 	t.Run("node correctly resolves pod metrics for pods in multiple namespaces via the batched PodMetrics lookup", func(t *testing.T) {
 		// Node.tmpl loops over every pod on the node (KubeGetNonTerminatedPodsOnNode) and looks
 		// up each one's PodMetrics via KubeGetPodMetrics, which fetches metrics.k8s.io once for
@@ -874,6 +902,28 @@ func waitForImagePullBackoff(t *testing.T, resource string) {
 		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("timed out waiting for %s to report ImagePullBackOff/ErrImagePull", resource)
+}
+
+// waitForContainerRestart polls until the named container in the resource reports a
+// restartCount greater than zero.
+// waitForContainerWaitingReason polls until the named container in the resource reports the
+// given waiting-state reason. Used instead of a plain restart-count check because a crashlooping
+// container's current state flips between Waiting(CrashLoopBackOff) and Terminated(Error) as the
+// kubelet retries, so waiting for a stable, specific state avoids a flaky render.
+func waitForContainerWaitingReason(t *testing.T, resource, containerName, reason string) {
+	t.Helper()
+	jsonpath := fmt.Sprintf(`{.status.containerStatuses[?(@.name=="%s")].state.waiting.reason}`, containerName)
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", resource, "-o", "jsonpath="+jsonpath)
+		output, err := cmd.CombinedOutput()
+		if err == nil && strings.TrimSpace(string(output)) == reason {
+			t.Logf("%s container %s reached waiting reason %s", resource, containerName, reason)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for %s container %s to report waiting reason %s", resource, containerName, reason)
 }
 
 // waitForPodMetrics polls the metrics.k8s.io API directly until it has scraped data for the

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -286,10 +286,11 @@ func (r *ResourceRepo) PodContainerLogs(namespace, podName, containerName string
 	// as the body (instead of a proper HTTP error) when the requested container instance's
 	// logs are no longer available (e.g. garbage collected). Surface that as an error rather
 	// than as log content.
-	if strings.HasPrefix(string(data), "unable to retrieve container logs for ") {
-		return "", fmt.Errorf("%s", strings.TrimSpace(string(data)))
+	logs := string(data)
+	if strings.HasPrefix(logs, "unable to retrieve container logs for ") {
+		return "", fmt.Errorf("%s", strings.TrimSpace(logs))
 	}
-	return string(data), nil
+	return logs, nil
 }
 
 func (r *ResourceRepo) DynamicObject(gvr schema.GroupVersionResource, namespace string, name string) (Object, error) {

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -269,6 +269,29 @@ func (r *ResourceRepo) ObjectEvents(u *unstructured.Unstructured) (*corev1.Event
 	return eventList, nil
 }
 
+// PodContainerLogs returns up to tailLines lines of log output for the named container in the
+// named pod. When previous is true it fetches logs from the container's previous (terminated)
+// instance, equivalent to `kubectl logs --previous`.
+func (r *ResourceRepo) PodContainerLogs(namespace, podName, containerName string, previous bool, tailLines int64) (string, error) {
+	opts := &corev1.PodLogOptions{
+		Container: containerName,
+		Previous:  previous,
+		TailLines: &tailLines,
+	}
+	data, err := r.kubernetesClientSet.CoreV1().Pods(namespace).GetLogs(podName, opts).DoRaw(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	// Some container runtimes/kubelet versions respond 200 OK with this plain-text message
+	// as the body (instead of a proper HTTP error) when the requested container instance's
+	// logs are no longer available (e.g. garbage collected). Surface that as an error rather
+	// than as log content.
+	if strings.HasPrefix(string(data), "unable to retrieve container logs for ") {
+		return "", fmt.Errorf("%s", strings.TrimSpace(string(data)))
+	}
+	return string(data), nil
+}
+
 func (r *ResourceRepo) DynamicObject(gvr schema.GroupVersionResource, namespace string, name string) (Object, error) {
 	u, err := r.dynamicClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -364,6 +364,25 @@ func (r RenderableObject) KubeGetNodeMetrics(name string) RenderableObject {
 	return r.newRenderableObject(nil)
 }
 
+// KubeGetContainerLogs returns up to tailLines lines of log output for the named container in the
+// named pod. When previous is true it fetches logs from the container's previous (terminated)
+// instance, equivalent to `kubectl logs --previous`. Returns an empty string if there are no logs
+// or the fetch fails.
+func (r RenderableObject) KubeGetContainerLogs(namespace, podName, containerName string, previous bool, tailLines int) string {
+	if viper.GetBool("shallow") {
+		return ""
+	}
+	klog.V(5).InfoS("called KubeGetContainerLogs",
+		"namespace", namespace, "podName", podName, "containerName", containerName, "previous", previous)
+	logs, err := r.repo.PodContainerLogs(namespace, podName, containerName, previous, int64(tailLines))
+	if err != nil {
+		klog.V(3).ErrorS(err, "failed to get container logs",
+			"namespace", namespace, "podName", podName, "containerName", containerName, "previous", previous)
+		return ""
+	}
+	return strings.TrimRight(logs, "\n")
+}
+
 // KubeGetNonTerminatedPodsOnNode returns details of all pods which are not in terminal status
 func (r RenderableObject) KubeGetNonTerminatedPodsOnNode(nodeName string) (podList []RenderableObject) {
 	if viper.GetBool("shallow") {

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -416,7 +416,7 @@ func withinLastHour(kubeDate interface{}) bool {
 	if !ok || s == "" {
 		return false
 	}
-	t, err := time.ParseInLocation("2006-01-02T15:04:05Z", s, time.UTC)
+	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		return false
 	}

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -85,6 +85,7 @@ func funcMap() template.FuncMap {
 		"labelSelector":             labelSelector,
 		"taintsNotToleratedByPod":   taintsNotToleratedByPod,
 		"cronNextTime":              cronNextTime,
+		"withinLastHour":            withinLastHour,
 		"parseTLSSecretCertificate": parseTLSSecretCertificate,
 		"certificatesInSecret":      certificatesInSecret,
 	}
@@ -408,6 +409,19 @@ func forOrSince() string {
 		return "since"
 	}
 	return "for"
+}
+
+func withinLastHour(kubeDate interface{}) bool {
+	s, ok := kubeDate.(string)
+	if !ok || s == "" {
+		return false
+	}
+	t, err := time.ParseInLocation("2006-01-02T15:04:05Z", s, time.UTC)
+	if err != nil {
+		return false
+	}
+	d := nowFunc().Sub(t)
+	return d >= 0 && d < time.Hour
 }
 
 func relativeTime(kubeDate string) string {

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -110,7 +110,7 @@
         {{- range $containerStatus := . }}
             {{- $containerSpec := $pod.Spec.initContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
             {{- $containerKubeletStats := $podStatsSummary.containers | default list | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
-            {{- $pod.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec "containerStats" $containerKubeletStats "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes") "sidecar" (eq ($containerSpec.restartPolicy | default "") "Always") "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
+            {{- $pod.Include "container_status_summary" (dict "pod" $pod "containerStatus" $containerStatus "containerSpec" $containerSpec "containerStats" $containerKubeletStats "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes") "sidecar" (eq ($containerSpec.restartPolicy | default "") "Always") "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
         {{- end }}
     {{- end }}
 {{- end }}
@@ -135,7 +135,8 @@
             {{- $containerKubeletStats := $podStatsSummary.containers | default list | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
             {{- if ($podMetrics.Object | default dict).containers }}
                 {{- $containerMetrics := $podMetrics.Object.containers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
-                {{- $containerStatusSummaryDict = dict "containerStatus" $containerStatus
+                {{- $containerStatusSummaryDict = dict "pod" $pod
+                                                       "containerStatus" $containerStatus
                                                        "containerMetrics" $containerMetrics
                                                        "containerSpec" $containerSpec
                                                        "containerStats" $containerKubeletStats
@@ -146,7 +147,8 @@
                                                        "podPullSecretsBroken" $.podPullSecretsBroken
                 }}
             {{- else }}
-                {{- $containerStatusSummaryDict = dict "containerStatus" $containerStatus
+                {{- $containerStatusSummaryDict = dict "pod" $pod
+                                                       "containerStatus" $containerStatus
                                                        "containerSpec" $containerSpec
                                                        "containerStats" $containerKubeletStats
                                                        "defaultContainer" (eq $containerStatus.name $defaultContainer)
@@ -419,6 +421,7 @@
 
 {{- define "container_status_summary" }}
     {{- /* Expects to get a map with these keys (and also their initContainer counterparts):
+           * pod (required): Pod RenderableObject, used to fetch logs
            * containerStatus (required): Pod.status.containerStatuses[name=container]
            * containerMetrics (optional): PodMetrics.containers[name=container]
            * containerSpec (optional): Pod.spec.containers[name=container]
@@ -446,6 +449,28 @@
     {{- if .containerMetrics }}{{ if .containerMetrics.usage.cpu }}{{ "usage" | nindent 2 }} {{ template "container_usage" . }}{{ end }}{{ end }}
     {{- with .containerStatus.lastState }}
         {{- "previously:" | yellow | nindent 2 }} {{ template "container_state_summary" . }}
+    {{- end }}
+    {{- with .containerStatus.state.terminated }}
+        {{- if and .startedAt (not ($.pod.Config.GetBool "shallow")) }}
+            {{- $logs := $.pod.KubeGetContainerLogs $.pod.Namespace $.pod.Name $.containerStatus.name false 20 }}
+            {{- if $logs }}
+                {{- "Last 20 lines of logs:" | bold | nindent 2 }}
+                {{- $logs | nindent 4 }}
+            {{- else }}
+                {{- ", " }}{{ "has no logs" | yellow }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with .containerStatus.lastState.terminated }}
+        {{- if and (withinLastHour .finishedAt) (not ($.pod.Config.GetBool "shallow")) }}
+            {{- $logs := $.pod.KubeGetContainerLogs $.pod.Namespace $.pod.Name $.containerStatus.name true 20 }}
+            {{- if $logs }}
+                {{- "Last 20 lines of logs from previous instance (restarted within last hour):" | bold | nindent 2 }}
+                {{- $logs | nindent 4 }}
+            {{- else }}
+                {{- ", " }}{{ "has no previous logs" | yellow }}
+            {{- end }}
+        {{- end }}
     {{- end }}
     {{- $runningNotReady := and .containerStatus.state.running (not .containerStatus.ready) }}
     {{- $hasRestarts := gt (.containerStatus.restartCount | int) 0 }}
@@ -560,7 +585,7 @@
         {{- "Debug containers:" | nindent 2 }}
         {{- range $containerStatus := . }}
             {{- $containerSpec := $pod.Spec.ephemeralContainers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
-            {{- $pod.Include "container_status_summary" (dict "containerStatus" $containerStatus "containerSpec" $containerSpec "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
+            {{- $pod.Include "container_status_summary" (dict "pod" $pod "containerStatus" $containerStatus "containerSpec" $containerSpec "podImagePullSecrets" $pod.Spec.imagePullSecrets "podPullSecretsBroken" $.podPullSecretsBroken) | nindent 4 }}
             {{- with $containerSpec.targetContainerName }}
                 {{- "targeting:" | bold | nindent 6 }} {{ . | cyan }}
             {{- end }}

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -1,0 +1,28 @@
+\A
+Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
+  Failed: Containers in CrashLoop state: crasher
+    Stalled: ContainerCrashLooping, Containers in CrashLoop state: crasher
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: \[crasher\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[crasher\] for 1m
+  Standalone POD\.
+  InitContainers:
+    init-setup \(busybox:latest\) Started 1m ago and Completed after 1m
+      Last 20 lines of logs:
+        init-setup-log-line
+    init-silent \(busybox:latest\) Started 1m ago and Completed after 1m, has no logs
+  Containers:
+    crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_default\([0-9a-f-]+\), restarted [0-9]+ times
+      previously: Started 1m ago and Error after 1m with exit code exit with 1
+      Last 20 lines of logs from previous instance \(restarted within last hour\):
+        crasher-log-line
+    healthy \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
+      usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
+    sidecar \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
+      usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Known/recorded manage events:
+    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
+\z

--- a/tests/e2e-artifacts/pod-container-logs.yaml
+++ b/tests/e2e-artifacts/pod-container-logs.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-container-logs
+  namespace: default
+spec:
+  restartPolicy: Always
+  initContainers:
+    - name: init-setup
+      image: busybox
+      command: ["sh", "-c", "echo init-setup-log-line"]
+    - name: init-silent
+      image: busybox
+      command: ["true"]
+  containers:
+    - name: sidecar
+      image: busybox
+      restartPolicy: Always
+      command: ["sh", "-c", "echo sidecar-log-line; sleep infinity"]
+    - name: healthy
+      image: busybox
+      command: ["sh", "-c", "echo healthy-log-line; sleep infinity"]
+    - name: crasher
+      image: busybox
+      command: ["sh", "-c", "echo crasher-log-line; sleep 1; exit 1"]

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -7,5 +7,7 @@ Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingres
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-ingress -n default, ClusterIP, 1 ready, 80/TCP
   Known/recorded manage events:
-    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)\n    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)\n    1m ago Updated by kube-controller-manager \(metadata, spec\))
+    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)
+    1m ago Updated by kube-controller-manager \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
@@ -9,5 +9,7 @@ PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, gen:1
     no disruptions allowed — all pods must stay healthy to meet the budget
   DisruptionAllowed InsufficientPods for 1m
   Known/recorded manage events:
-    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)\n    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)\n    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
+    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -7,5 +7,7 @@ Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodep
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
   Known/recorded manage events:
-    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)\n    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)\n    1m ago Updated by kube-controller-manager \(metadata, spec\))
+    (?:1m ago Updated by kube-controller-manager \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)
+    1m ago Updated by kube-controller-manager \(metadata, spec\))
 \z

--- a/tests/e2e-artifacts/sts-without-service.regex
+++ b/tests/e2e-artifacts/sts-without-service.regex
@@ -6,5 +6,7 @@ StatefulSet/sts-without-service -n default, created 1m ago, gen:1
     Pod/sts-without-service-0 -n default Running, 1/1 ready
   desired:1, existing:1, ready:1, current:1, updated:1, available:1
   Known/recorded manage events:
-    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)\n    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)\n    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
+    (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kube-controller-manager \(status\)|1m ago Updated by kube-controller-manager \(status\)
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\))
 \z


### PR DESCRIPTION
## Summary
- Containers in a terminal state now show their last 20 log lines; containers that restarted within the last hour show the last 20 lines of the *previous* instance's logs (like `kubectl logs --previous`). Both are gated behind `--shallow` being off and scoped to each container's own status, so a restart in one container never pulls logs for healthy siblings.
- When there are no log lines to show, an inline yellow `has no logs` / `has no previous logs` is appended to the container's status line instead of a separate empty block.
- Works around a kubelet quirk where a garbage-collected previous container's logs come back as an HTTP 200 with an "unable to retrieve container logs for ..." error string body instead of a proper HTTP error — now treated as no logs rather than printed as log content.
- New live e2e case (`tests/e2e-artifacts/pod-container-logs.{yaml,regex}`) covering an init container with output, an init container with no output, a healthy sidecar, a healthy regular container, and a crashlooping container — since `--shallow` (used by the offline golden tests) makes log fetching a no-op, this is the only place that exercises real log fetching.
- Reformatted existing `.regex` e2e fixtures to use real line breaks instead of literal `\n` escapes for readability (see updated e2e testing notes in CONTRIBUTING.md, not included in this commit per repo convention of not committing Markdown).

## Test plan
- [x] `make test` (go vet, staticcheck, go test ./...)
- [x] Golden artifacts regenerated via `make update-artifacts` — no diff (log sections are gated out under `--shallow`)
- [x] New e2e subtest run live against minikube twice via `RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/... -run 'TestE2EDynamicManifests/pod-container-logs'` — passes
- [x] Other regex-fixture e2e subtests re-run after reformatting (`sts-with-ingress`, `sts-with-nodeport`, `sts-without-service`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)