### PR TITLE
Convert sts-with-ingress service e2e checks to file-based regex fixtures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,21 @@ since there's no live cluster to query either way), which makes `KubeGetFirst` a
 can't exercise the "found the related object" or `--deep` include branches, so the live e2e suite
 is the only place that covers them.
 
+Prefer a whole-output `.regex` fixture (`stdoutRegexPath`) over ad hoc `assert.Contains`/
+`assert.Regexp` calls scattered through the subtest, unless you're only asserting on a couple of
+one-off lines. A single regex covering the full rendered output, matched with `\A`...`\z` anchors
+(see the existing `tests/e2e-artifacts/*.regex` files for the pattern), lets a reviewer diff the
+expected output like a golden `.out` file and catches regressions anywhere in the render, not just
+in the specific substrings an inline assertion happens to check. Use `[0-9.]+[A-Za-z]+` and similar
+tolerant patterns for the non-deterministic parts (log/volume usage bytes, backoff windows, restart
+counts, container/pod UIDs); `viperTestHack(t)`/`testHack(t)` freeze relative durations to `1m` so
+those can stay literal. Prefer real line breaks over literal `\n` escapes when a pattern needs to
+match across multiple output lines (e.g. inside a `(?:...|...)` alternation) — a raw newline in the
+fixture file matches a newline in the output just as well and keeps the file readable as plain
+text. One gotcha: the regex file must not have a trailing newline after the final `\z` — `\z`
+asserts absolute end-of-text, so a trailing newline in the fixture file makes the pattern
+impossible to satisfy.
+
 ### Improving The Documentation
 
 We don't yet have a comprehensive documentation, we maintain just a few Markdown files in the repo. We aim to keep the

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -559,12 +559,12 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.pod.regex",
 		}.assert(t, nodeNameModifier)
 		cmdTest{
-			args:        []string{"service/sts-with-ingress", "--include-events=false", "--v", "5"},
-			stdoutRegex: `(?m)Ingresses matching this Service:\n    Ingress/sts-with-ingress -n default, sts-with-ingress\.com, [^\n]*Current`,
+			args:            []string{"service/sts-with-ingress", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.service.regex",
 		}.assert(t, nil)
 		cmdTest{
-			args:        []string{"service/sts-with-ingress", "--include-events=false", "--deep", "--v", "5"},
-			stdoutRegex: `(?m)Ingresses matching this Service:\n    Ingress/sts-with-ingress -n default, created 1m ago, gen:1\n      Current: Resource is current`,
+			args:            []string{"service/sts-with-ingress", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.service-deep.regex",
 		}.assert(t, nil)
 	})
 	t.Run("svc-with-httproute", func(t *testing.T) {

--- a/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
@@ -1,0 +1,3 @@
+Ingresses matching this Service:
+    Ingress/sts-with-ingress -n default, created 1m ago, gen:1
+      Current: Resource is current

--- a/tests/e2e-artifacts/sts-with-ingress.service.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service.regex
@@ -1,0 +1,2 @@
+Ingresses matching this Service:
+    Ingress/sts-with-ingress -n default, sts-with-ingress\.com, [^\n]*Current


### PR DESCRIPTION
## Summary
- Follow-up to #635: finishes converting the `sts-with-ingress` e2e subtest's two remaining inline `stdoutRegex` assertions (for the Service render, plain and `--deep`) to file-based `stdoutRegexPath` fixtures, matching the convention used everywhere else in the e2e suite.
- These fixtures (`tests/e2e-artifacts/sts-with-ingress.service.regex` / `.service-deep.regex`) were drafted alongside #635 but never got wired into `main_test.go` or committed.
- Documents the `.regex` e2e fixture convention in `CONTRIBUTING.md`: prefer whole-output regex fixtures over inline assertions, use tolerant patterns for non-deterministic output, prefer real line breaks over literal `\n` escapes, and the `\z`-must-not-be-followed-by-a-trailing-newline gotcha.

## Test plan
- [x] `make test`
- [x] `RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/... -run 'TestE2EDynamicManifests/sts-with-ingress'` against live minikube — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)