### PR TITLE
Stabilize pod-image-pull-secrets e2e checks and convert to regex fixtures

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -762,30 +762,31 @@ Secret\/child -n default, created 1m ago by Secret/owner
 		// correlation branch of the ImagePullBackOff hint (Check B).
 		viperTestHack(t)
 		applyManifest(t, "e2e-artifacts/pod-image-pull-secrets.yaml")
-		waitForImagePullBackoff(t, "pod/e2e-pod-missing-pull-secret")
-		waitForImagePullBackoff(t, "pod/e2e-pod-wrong-type-pull-secret")
-		waitForImagePullBackoff(t, "pod/e2e-pod-healthy-pull-secret")
+		// waitForImagePullBackoff accepts either ErrImagePull or ImagePullBackOff, but the
+		// kubelet keeps cycling between them on its retry loop, so it doesn't give a stable
+		// render. Pin to ImagePullBackOff specifically -- it's the longer-lived of the two
+		// (exponential backoff), so it survives the gap until the subtests below observe it.
+		waitForContainerWaitingReason(t, "pod/e2e-pod-missing-pull-secret", "main", "ImagePullBackOff")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-wrong-type-pull-secret", "main", "ImagePullBackOff")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-healthy-pull-secret", "main", "ImagePullBackOff")
 
 		t.Run("pod referencing a non-existent Secret flags it and correlates with the pull failure", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-missing-pull-secret", "--include-events=false", "--v", "5"})
-			require.NoError(t, err)
-			assert.Regexp(t, `Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.`, stdout)
-			assert.Contains(t, stdout, "this Pod's imagePullSecrets have problems, see above")
-			assert.NotContains(t, stdout, "no imagePullSecrets on this Pod")
+			cmdTest{
+				args:            []string{"pod/e2e-pod-missing-pull-secret", "--include-events=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-missing.regex",
+			}.assert(t, nil)
 		})
 		t.Run("pod referencing a wrong-type Secret flags it and correlates with the pull failure", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-wrong-type-pull-secret", "--include-events=false", "--v", "5"})
-			require.NoError(t, err)
-			assert.Regexp(t, `Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.`, stdout)
-			assert.Contains(t, stdout, "this Pod's imagePullSecrets have problems, see above")
-			assert.NotContains(t, stdout, "no imagePullSecrets on this Pod")
+			cmdTest{
+				args:            []string{"pod/e2e-pod-wrong-type-pull-secret", "--include-events=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-wrong-type.regex",
+			}.assert(t, nil)
 		})
 		t.Run("pod referencing a healthy Secret shows no warnings", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"pod/e2e-pod-healthy-pull-secret", "--include-events=false", "--v", "5"})
-			require.NoError(t, err)
-			for _, problem := range []string{"doesn't exist", "wrong type:", "no imagePullSecrets on this Pod", "imagePullSecrets have problems"} {
-				assert.NotContains(t, stdout, problem)
-			}
+			cmdTest{
+				args:            []string{"pod/e2e-pod-healthy-pull-secret", "--include-events=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-healthy.regex",
+			}.assert(t, nil)
 		})
 	})
 	t.Run("pod-container-logs", func(t *testing.T) {
@@ -878,30 +879,6 @@ func waitFor(t *testing.T, resource, forParam string) {
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s: %s", resource, string(output))
 	require.NoError(t, err)
-}
-
-// waitForImagePullBackoff polls until the resource's first container reports an
-// ImagePullBackOff or ErrImagePull waiting reason. `kubectl wait` doesn't support
-// waiting for one-of-several jsonpath values, and the kubelet transiently reports
-// other reasons (e.g. ContainerCreating) before settling on the pull-failure state.
-// Transient kubectl errors (e.g. the pod not yet registered in the API server) are
-// tolerated and just retried until the deadline.
-func waitForImagePullBackoff(t *testing.T, resource string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Minute)
-	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", resource,
-			"-o", "jsonpath={.status.containerStatuses[0].state.waiting.reason}")
-		output, err := cmd.CombinedOutput()
-		if err == nil {
-			if reason := strings.TrimSpace(string(output)); reason == "ImagePullBackOff" || reason == "ErrImagePull" {
-				t.Logf("%s container waiting reason: %s", resource, reason)
-				return
-			}
-		}
-		time.Sleep(2 * time.Second)
-	}
-	t.Fatalf("timed out waiting for %s to report ImagePullBackOff/ErrImagePull", resource)
 }
 
 // waitForContainerRestart polls until the named container in the resource reports a

--- a/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
@@ -1,0 +1,13 @@
+\A
+Pod/e2e-pod-healthy-pull-secret -n default, created 1m ago, gen:1(, started after 1m)? Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD.
+  Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z

--- a/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
@@ -1,0 +1,15 @@
+\A
+Pod/e2e-pod-missing-pull-secret -n default, created 1m ago, gen:1(, started after 1m)? Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD.
+  Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.
+  Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
+  \(this Pod's imagePullSecrets have problems, see above .* that's likely why\)
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z

--- a/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
@@ -1,0 +1,15 @@
+\A
+Pod/e2e-pod-wrong-type-pull-secret -n default, created 1m ago, gen:1(, started after 1m)? Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD.
+  Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.
+  Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
+  \(this Pod's imagePullSecrets have problems, see above .* that's likely why\)
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z


### PR DESCRIPTION
## Summary
- `waitForImagePullBackoff` accepted either `ErrImagePull` or `ImagePullBackOff`, but the kubelet cycles between those states on its retry loop, so the rendered `Containers:` line (and whether it appeared at all) varied between runs of this subtest. Switched to the existing `waitForContainerWaitingReason` helper, pinned to the more durable `ImagePullBackOff` state (removed the now-unused `waitForImagePullBackoff`).
- Converted the `pod-image-pull-secrets` subtests from inline `assert.Regexp`/`assert.Contains` checks to whole-output `.regex` fixtures (`stdoutRegexPath`), per CONTRIBUTING.md's e2e fixture convention — this now also exercises the previously-unchecked parts of the render (e.g. the ordering and exact wording around the pull-failure correlation hint), not just the couple of lines the old inline checks spot-checked.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `RUN_E2E_TESTS=true go test -run 'TestE2EDynamicManifests/pod-image-pull-secrets' ./cmd/...` passed twice in a row against a cleanly-owned minikube cluster