### PR TITLE
Add Lease, ReferenceGrant, and Gateway API TCPRoute/UDPRoute/ListenerSet/BackendTLSPolicy support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ install-e2e-deps:
 	# read-only rendering of these objects, they don't need a controller reconciling them.
 	# Experimental channel is a superset of standard and adds TCPRoute/UDPRoute/
 	# BackendTLSPolicy/ListenerSet, which some e2e scenarios also render.
-	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
+	# --server-side: the experimental bundle's CRDs (e.g. HTTPRoute) are large enough that
+	# client-side apply's kubectl.kubernetes.io/last-applied-configuration annotation trips
+	# the 262144-byte annotation limit; server-side apply doesn't need that annotation.
+	kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
 
 .PHONY: test-e2e
 test-e2e: vet staticcheck install-e2e-deps

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,12 @@ install-e2e-deps:
 	# cert-manager and Gateway API CRDs are needed by e2e TLS-validation test scenarios.
 	# Pinned to latest stable at time of writing; bump these tags periodically.
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
-	kubectl wait --for=condition=Available --timeout=180s deployment --all -n cert-manager
-	# CRDs only (standard channel, no controller needed): e2e tests only exercise
-	# kubectl-status's own read-only rendering of Gateway/HTTPRoute objects, they don't
-	# need a controller reconciling them.
-	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
+	kubectl wait --for=condition=Available --timeout=300s deployment --all -n cert-manager
+	# CRDs only (no controller needed): e2e tests only exercise kubectl-status's own
+	# read-only rendering of these objects, they don't need a controller reconciling them.
+	# Experimental channel is a superset of standard and adds TCPRoute/UDPRoute/
+	# BackendTLSPolicy/ListenerSet, which some e2e scenarios also render.
+	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
 
 .PHONY: test-e2e
 test-e2e: vet staticcheck install-e2e-deps

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -595,6 +595,54 @@ Secret\/child -n default, created 1m ago by Secret/owner
 			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.pdb.regex",
 		}.assert(t, nodeNameModifier)
 	})
+	t.Run("tcproute-with-gateway", func(t *testing.T) {
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/tcproute-with-gateway.yaml")
+		cmdTest{
+			args:            []string{"tcproute/e2e-tcproute", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/tcproute-with-gateway.regex",
+		}.assert(t, nil)
+		cmdTest{
+			args:            []string{"tcproute/e2e-tcproute", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/tcproute-with-gateway.deep.regex",
+		}.assert(t, nil)
+	})
+	t.Run("udproute-with-gateway", func(t *testing.T) {
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/udproute-with-gateway.yaml")
+		cmdTest{
+			args:            []string{"udproute/e2e-udproute", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/udproute-with-gateway.regex",
+		}.assert(t, nil)
+		cmdTest{
+			args:            []string{"udproute/e2e-udproute", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/udproute-with-gateway.deep.regex",
+		}.assert(t, nil)
+	})
+	t.Run("listenerset-with-gateway", func(t *testing.T) {
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/listenerset-with-gateway.yaml")
+		cmdTest{
+			args:            []string{"listenerset/e2e-listenerset", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/listenerset-with-gateway.regex",
+		}.assert(t, nil)
+		cmdTest{
+			args:            []string{"listenerset/e2e-listenerset", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/listenerset-with-gateway.deep.regex",
+		}.assert(t, nil)
+	})
+	t.Run("backendtlspolicy-with-target", func(t *testing.T) {
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/backendtlspolicy-with-target.yaml")
+		cmdTest{
+			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/backendtlspolicy-with-target.regex",
+		}.assert(t, nil)
+		cmdTest{
+			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "--include-events=false", "--deep", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/backendtlspolicy-with-target.deep.regex",
+		}.assert(t, nil)
+	})
 	t.Run("sts-without-service", func(t *testing.T) {
 		viperTestHack(t)
 		applyManifest(t, "e2e-artifacts/sts-without-service.yaml")

--- a/tests/artifacts/backendtlspolicy-accepted.out
+++ b/tests/artifacts/backendtlspolicy-accepted.out
@@ -1,0 +1,11 @@
+
+BackendTLSPolicy/tls-backend-policy -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Targets:
+    Service/tls-backend
+  TLS: SNI tls-backend.default.svc.cluster.local
+    CA certs:
+      ConfigMap/backend-ca-cert
+  Status:
+    Gateway/multi-proto-gw (gateway.envoyproxy.io/gatewayclass-controller)
+      Accepted Accepted, Policy has been accepted. for 1m

--- a/tests/artifacts/backendtlspolicy-accepted.yaml
+++ b/tests/artifacts/backendtlspolicy-accepted.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"gateway.networking.k8s.io/v1alpha3","kind":"BackendTLSPolicy","metadata":{"annotations":{},"name":"tls-backend-policy","namespace":"default"},"spec":{"targetRefs":[{"group":"","kind":"Service","name":"tls-backend"}],"validation":{"caCertificateRefs":[{"group":"","kind":"ConfigMap","name":"backend-ca-cert"}],"hostname":"tls-backend.default.svc.cluster.local"}}}
+  creationTimestamp: "2026-07-07T22:02:36Z"
+  generation: 1
+  name: tls-backend-policy
+  namespace: default
+  resourceVersion: "1194"
+  uid: 4b997f4a-a2a4-4297-a9f4-1f069c4e6c8f
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: tls-backend
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: backend-ca-cert
+    hostname: tls-backend.default.svc.cluster.local
+status:
+  ancestors:
+  - ancestorRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: multi-proto-gw
+      sectionName: http
+    conditions:
+    - lastTransitionTime: "2026-07-07T22:02:36Z"
+      message: Policy has been accepted.
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/tests/artifacts/lease-node.out
+++ b/tests/artifacts/lease-node.out
@@ -1,0 +1,3 @@
+
+Lease/minikube -n kube-node-lease, created 1m ago by Node/minikube
+  Lease renewed 1m ago being hold for 40s by minikube

--- a/tests/artifacts/lease-node.yaml
+++ b/tests/artifacts/lease-node.yaml
@@ -1,0 +1,17 @@
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  creationTimestamp: "2026-07-07T21:55:45Z"
+  name: minikube
+  namespace: kube-node-lease
+  ownerReferences:
+  - apiVersion: v1
+    kind: Node
+    name: minikube
+    uid: 2b461e6e-bca3-4a1b-adfd-a323488283c6
+  resourceVersion: "1320"
+  uid: c82ff13b-bf30-4d3f-be20-29ac25cf60ad
+spec:
+  holderIdentity: minikube
+  leaseDurationSeconds: 40
+  renewTime: "2026-07-07T22:04:12.740781Z"

--- a/tests/artifacts/listenerset-pending.out
+++ b/tests/artifacts/listenerset-pending.out
@@ -1,0 +1,9 @@
+
+ListenerSet/extra-listeners -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Gateway:
+    Gateway/multi-proto-gw
+  Listeners:
+    extra-http: port=8081/HTTP, namespaces=Same
+  Accepted Pending, Waiting for controller for 1m
+  Programmed Pending, Waiting for controller for 1m

--- a/tests/artifacts/listenerset-pending.yaml
+++ b/tests/artifacts/listenerset-pending.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"gateway.networking.k8s.io/v1","kind":"ListenerSet","metadata":{"annotations":{},"name":"extra-listeners","namespace":"default"},"spec":{"listeners":[{"allowedRoutes":{"namespaces":{"from":"Same"}},"name":"extra-http","port":8081,"protocol":"HTTP"}],"parentRef":{"name":"multi-proto-gw"}}}
+  creationTimestamp: "2026-07-07T22:03:13Z"
+  generation: 1
+  name: extra-listeners
+  namespace: default
+  resourceVersion: "1242"
+  uid: 0aa5b6f7-53d1-433d-bc4a-49ffdccd5a78
+spec:
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: extra-http
+    port: 8081
+    protocol: HTTP
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: multi-proto-gw
+status:
+  conditions:
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: Waiting for controller
+    reason: Pending
+    status: Unknown
+    type: Accepted
+  - lastTransitionTime: "1970-01-01T00:00:00Z"
+    message: Waiting for controller
+    reason: Pending
+    status: Unknown
+    type: Programmed

--- a/tests/artifacts/referencegrant-cross-namespace.out
+++ b/tests/artifacts/referencegrant-cross-namespace.out
@@ -1,0 +1,7 @@
+
+ReferenceGrant/allow-route-ns-to-default -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Allows:
+    HTTPRoute/route-ns (gateway.networking.k8s.io)
+  To access:
+    Service/tls-backend

--- a/tests/artifacts/referencegrant-cross-namespace.yaml
+++ b/tests/artifacts/referencegrant-cross-namespace.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"gateway.networking.k8s.io/v1beta1","kind":"ReferenceGrant","metadata":{"annotations":{},"name":"allow-route-ns-to-default","namespace":"default"},"spec":{"from":[{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","namespace":"route-ns"}],"to":[{"group":"","kind":"Service","name":"tls-backend"}]}}
+  creationTimestamp: "2026-07-07T22:03:37Z"
+  generation: 1
+  name: allow-route-ns-to-default
+  namespace: default
+  resourceVersion: "1275"
+  uid: ce01cc79-6f14-40fb-a590-d0ea0c81f459
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: route-ns
+  to:
+  - group: ""
+    kind: Service
+    name: tls-backend

--- a/tests/artifacts/tcproute-accepted.out
+++ b/tests/artifacts/tcproute-accepted.out
@@ -1,0 +1,11 @@
+
+TCPRoute/tcp-backend-route -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/multi-proto-gw [tcp]
+  Rules:
+    → Service/tcp-backend:8080
+  Status:
+    Gateway/multi-proto-gw [tcp] (gateway.envoyproxy.io/gatewayclass-controller)
+      Accepted Accepted, Route is accepted for 1m
+      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m

--- a/tests/artifacts/tcproute-accepted.yaml
+++ b/tests/artifacts/tcproute-accepted.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"gateway.networking.k8s.io/v1alpha2","kind":"TCPRoute","metadata":{"annotations":{},"name":"tcp-backend-route","namespace":"default"},"spec":{"parentRefs":[{"name":"multi-proto-gw","sectionName":"tcp"}],"rules":[{"backendRefs":[{"name":"tcp-backend","port":8080}]}]}}
+  creationTimestamp: "2026-07-07T22:00:04Z"
+  generation: 1
+  name: tcp-backend-route
+  namespace: default
+  resourceVersion: "980"
+  uid: 146d433e-8b4f-450b-a954-4e042ec0af10
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: multi-proto-gw
+    sectionName: tcp
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: tcp-backend
+      port: 8080
+      weight: 1
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-07-07T22:00:04Z"
+      message: Route is accepted
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-07-07T22:00:04Z"
+      message: Resolved all the Object references for the Route
+      observedGeneration: 1
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: multi-proto-gw
+      sectionName: tcp

--- a/tests/artifacts/udproute-accepted.out
+++ b/tests/artifacts/udproute-accepted.out
@@ -1,0 +1,11 @@
+
+UDPRoute/udp-backend-route -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/multi-proto-gw [udp]
+  Rules:
+    → Service/udp-backend:9090
+  Status:
+    Gateway/multi-proto-gw [udp] (gateway.envoyproxy.io/gatewayclass-controller)
+      Accepted Accepted, Route is accepted for 1m
+      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m

--- a/tests/artifacts/udproute-accepted.yaml
+++ b/tests/artifacts/udproute-accepted.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"gateway.networking.k8s.io/v1alpha2","kind":"UDPRoute","metadata":{"annotations":{},"name":"udp-backend-route","namespace":"default"},"spec":{"parentRefs":[{"name":"multi-proto-gw","sectionName":"udp"}],"rules":[{"backendRefs":[{"name":"udp-backend","port":9090}]}]}}
+  creationTimestamp: "2026-07-07T22:00:04Z"
+  generation: 1
+  name: udp-backend-route
+  namespace: default
+  resourceVersion: "983"
+  uid: acd69dc9-bce2-40b7-b7b7-91634b8f8597
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: multi-proto-gw
+    sectionName: udp
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: udp-backend
+      port: 9090
+      weight: 1
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-07-07T22:00:04Z"
+      message: Route is accepted
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-07-07T22:00:04Z"
+      message: Resolved all the Object references for the Route
+      observedGeneration: 1
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: multi-proto-gw
+      sectionName: udp

--- a/tests/e2e-artifacts/backendtlspolicy-with-target.deep.regex
+++ b/tests/e2e-artifacts/backendtlspolicy-with-target.deep.regex
@@ -1,0 +1,15 @@
+\A
+BackendTLSPolicy/e2e-backendtlspolicy -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Targets:
+    Service/e2e-tls-backend-svc -n default, created 1m ago
+      Current: Service is ready
+      Missing Endpoint: Service has no matching endpoint\.
+      Known/recorded manage events:
+        1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  TLS: SNI e2e-tls-backend\.example\.com
+    CA certs:
+      ConfigMap/e2e-backend-ca
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/backendtlspolicy-with-target.regex
+++ b/tests/e2e-artifacts/backendtlspolicy-with-target.regex
@@ -1,0 +1,11 @@
+\A
+BackendTLSPolicy/e2e-backendtlspolicy -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Targets:
+    Service/e2e-tls-backend-svc
+  TLS: SNI e2e-tls-backend\.example\.com
+    CA certs:
+      ConfigMap/e2e-backend-ca
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/backendtlspolicy-with-target.yaml
+++ b/tests/e2e-artifacts/backendtlspolicy-with-target.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-backend-ca
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDEzCCAfugAwIBAgIUJK9TbxnGrUNyo2HJEDUfJLr2ww8wDQYJKoZIhvcNAQEL
+    BQAwGTEXMBUGA1UEAwwOdGxzLWJhY2tlbmQtY2EwHhcNMjYwNzA3MjIwMDMwWhcN
+    MjcwNzA3MjIwMDMwWjAZMRcwFQYDVQQDDA50bHMtYmFja2VuZC1jYTCCASIwDQYJ
+    KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKYp21ZpHHai1JiISmhwBHe5sICA8mTa
+    UWaOs2cAxGRiX0C0Ln8uBeyB6kkHkdXkhCq9sKKkGy0sICQ5PSGAzuhkpd/5OezJ
+    zo2yfBY0FKgoKI3sVlN7Mf1YFZLQxJgHS2RPfNuB1E0GvIPok84up7JA6R87EdRU
+    KUCia9i+yA+APojPQeczkzz1EbkTtT+Y6h7Av/n4xoaF/3mxM5amZvcXjDHsup/M
+    oW5l1jPfQNTyV83RCPb48DRGyUY4r/0zbPdRfnWz7Z64XDt3L0BDJ40J27li5S6V
+    FG8V67G54nMnlJziUuCH4663N5T+HVsZBb70ptiupfB9QJt0eyOVrl8CAwEAAaNT
+    MFEwHQYDVR0OBBYEFJTGCAEk5dXbUpw4W5sGwqzbc68BMB8GA1UdIwQYMBaAFJTG
+    CAEk5dXbUpw4W5sGwqzbc68BMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+    BQADggEBAI8podF6dSVr6MsPmrDDnhj9JL6tYq9QJGe23TkOv1/m5QTwUXE7h5Er
+    ZIdulW5Tdy77dYOdOFtuNtS+0P7HwpCvF4uN6vAiFJPqYqs7AcN8k2/LuOWuDc4F
+    opO3zZlPZnmpZCg5+R9yzaens9SMZjvMYB5d5qzTY+8acG9unZ8Db/r70gh4tC3G
+    rzEdwusa8Zb2c+4/vtyAVLreZt3IKgmJbpu3prxqPEbup6ta7Cx4dYeDXzTioh6a
+    d3iitoQRL/3p0CFRdYwNnrJMfkTFyke1md+05hAKF2njFT1tpeNTg4toMKKtAwHq
+    GfXN+ntx4pYiTHq4kJP6obHk5ctsc6w=
+    -----END CERTIFICATE-----
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-tls-backend-svc
+spec:
+  ports:
+  - port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: e2e-backendtlspolicy
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: e2e-tls-backend-svc
+  validation:
+    hostname: e2e-tls-backend.example.com
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: e2e-backend-ca

--- a/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
@@ -1,0 +1,19 @@
+\A
+ListenerSet/e2e-listenerset -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Gateway:
+    Gateway/e2e-lset-gw -n default, created 1m ago, gen:1
+      Current: Resource is current
+      Accepted Pending, Waiting for controller for 1m
+      Programmed Pending, Waiting for controller for 1m
+      Listeners:
+        http: port=80/HTTP, namespaces=Same
+      Known/recorded manage events:
+        1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  Listeners:
+    extra-http: port=8081/HTTP, namespaces=Same
+  Accepted Pending, Waiting for controller for 1m
+  Programmed Pending, Waiting for controller for 1m
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/listenerset-with-gateway.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.regex
@@ -1,0 +1,12 @@
+\A
+ListenerSet/e2e-listenerset -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Gateway:
+    Gateway/e2e-lset-gw
+  Listeners:
+    extra-http: port=8081/HTTP, namespaces=Same
+  Accepted Pending, Waiting for controller for 1m
+  Programmed Pending, Waiting for controller for 1m
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/listenerset-with-gateway.yaml
+++ b/tests/e2e-artifacts/listenerset-with-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-lset-gw
+spec:
+  gatewayClassName: e2e-unused-gwc
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: e2e-listenerset
+spec:
+  parentRef:
+    name: e2e-lset-gw
+  listeners:
+  - name: extra-http
+    port: 8081
+    protocol: HTTP

--- a/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
@@ -1,0 +1,17 @@
+\A
+TCPRoute/e2e-tcproute -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/e2e-tcp-gw -n default, created 1m ago, gen:1
+      Current: Resource is current
+      Accepted Pending, Waiting for controller for 1m
+      Programmed Pending, Waiting for controller for 1m
+      Listeners:
+        tcp: port=8080/TCP, namespaces=Same
+      Known/recorded manage events:
+        1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  Rules:
+    → Service/e2e-tcp-svc:8080
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/tcproute-with-gateway.regex
+++ b/tests/e2e-artifacts/tcproute-with-gateway.regex
@@ -1,0 +1,10 @@
+\A
+TCPRoute/e2e-tcproute -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/e2e-tcp-gw \[tcp\]
+  Rules:
+    → Service/e2e-tcp-svc:8080
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/tcproute-with-gateway.yaml
+++ b/tests/e2e-artifacts/tcproute-with-gateway.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-tcp-gw
+spec:
+  gatewayClassName: e2e-unused-gwc
+  listeners:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-tcp-svc
+spec:
+  ports:
+  - port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: e2e-tcproute
+spec:
+  parentRefs:
+  - name: e2e-tcp-gw
+    sectionName: tcp
+  rules:
+  - backendRefs:
+    - name: e2e-tcp-svc
+      port: 8080

--- a/tests/e2e-artifacts/udproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/udproute-with-gateway.deep.regex
@@ -1,0 +1,17 @@
+\A
+UDPRoute/e2e-udproute -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/e2e-udp-gw -n default, created 1m ago, gen:1
+      Current: Resource is current
+      Accepted Pending, Waiting for controller for 1m
+      Programmed Pending, Waiting for controller for 1m
+      Listeners:
+        udp: port=9090/UDP, namespaces=Same
+      Known/recorded manage events:
+        1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+  Rules:
+    → Service/e2e-udp-svc:9090
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/udproute-with-gateway.regex
+++ b/tests/e2e-artifacts/udproute-with-gateway.regex
@@ -1,0 +1,10 @@
+\A
+UDPRoute/e2e-udproute -n default, created 1m ago, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/e2e-udp-gw \[udp\]
+  Rules:
+    → Service/e2e-udp-svc:9090
+  Known/recorded manage events:
+    1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
+\z

--- a/tests/e2e-artifacts/udproute-with-gateway.yaml
+++ b/tests/e2e-artifacts/udproute-with-gateway.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-udp-gw
+spec:
+  gatewayClassName: e2e-unused-gwc
+  listeners:
+  - name: udp
+    port: 9090
+    protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-udp-svc
+spec:
+  ports:
+  - port: 9090
+    protocol: UDP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: e2e-udproute
+spec:
+  parentRefs:
+  - name: e2e-udp-gw
+    sectionName: udp
+  rules:
+  - backendRefs:
+    - name: e2e-udp-svc
+      port: 9090


### PR DESCRIPTION
## Summary
- Adds offline golden-file coverage for `Lease` and `ReferenceGrant`.
- Adds live e2e coverage (manifests + `.regex` fixtures, including `--deep`) for `TCPRoute`, `UDPRoute`, `ListenerSet`, and `BackendTLSPolicy` rendering.
- Fixes `install-e2e-deps` to install the Gateway API **experimental** channel instead of standard: `TCPRoute`/`UDPRoute`/`BackendTLSPolicy`/`ListenerSet` are experimental-only resources, so the standard bundle's CRDs don't cover them.
- Fixes the new e2e fixture manifests to use `apiVersion: gateway.networking.k8s.io/v1` for `TCPRoute`/`UDPRoute`/`BackendTLSPolicy` — in Gateway API v1.6.0 these are served at `v1`; the `v1alpha2`/`v1alpha3` versions exist in the CRD only for conversion and aren't served, so applying at those versions fails with `no matches for kind ... ensure CRDs are installed first` even though the CRD itself is installed.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./...` (offline suite, 264 tests) passes, including the new `lease-node`/`referencegrant-cross-namespace` golden files
- [x] `RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test -run 'TestE2EDynamicManifests/(tcproute-with-gateway|udproute-with-gateway|listenerset-with-gateway|backendtlspolicy-with-target)' ./cmd/...` passed twice in a row against a live cluster with the experimental Gateway API channel installed