### PR TITLE
Isolate local e2e minikube profiles per branch/session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cover.html
 
 bin/
 dist/
+.e2e/
 
 .DS_Store
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,16 +213,33 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 
 ### Running e2e Tests Locally
 
-`make test-e2e` runs the `TestE2E*` suite against a real cluster (see `cmd/main_test.go`). By
-default it starts its own minikube cluster; set `ASSUME_MINIKUBE_IS_CONFIGURED=true` if your
-current kubeconfig context already points at a suitable cluster (this is what CI does).
+`make test-e2e` runs the `TestE2E*` suite against a real cluster (see `cmd/main_test.go`). It
+manages its own minikube cluster, named and isolated by an `E2E_PROFILE` the Makefile computes
+from your current git branch (plus, when running under Claude Code, `CLAUDE_CODE_SESSION_ID`) —
+so parallel worktrees/branches, and even multiple sessions working the same branch, never share a
+profile or step on each other's cluster. Run `make print-e2e-profile` to see the profile name and
+kubeconfig path (`.e2e/<profile>.kubeconfig`, gitignored) it'll use. `install-e2e-deps` (cert-manager,
+Gateway API CRDs) runs against that same cluster right after it's created, so deps always land on
+the cluster the tests actually use. The cluster is left running after the tests finish, for fast
+reruns; delete it explicitly with `make e2e-minikube-down` when you're done with the branch, or
+run `make install-hooks` once (installs a `reference-transaction` git hook, shared across all
+worktrees of the clone) to have it deleted automatically whenever you delete the local branch.
+
+CI instead sets `ASSUME_MINIKUBE_IS_CONFIGURED=true`, which makes `make test-e2e` skip all of the
+above and use whatever cluster your current kubeconfig context already points at (that's what
+`medyagh/setup-minikube` in `ci-test.yml` provisions) — set the same var locally if you'd rather
+manage the cluster yourself.
 
 Some e2e scenarios exercise cert-manager-issued TLS `Secret`s and Gateway API objects.
 `make test-e2e` installs both automatically (via its `install-e2e-deps` prerequisite target
-in the `Makefile`) against whatever cluster is configured before running the test suite — no
-separate manual setup needed. Bump the pinned versions in that target periodically to track
-upstream stable releases; CI uses the same `make test-e2e` target, so it stays in sync
-automatically.
+in the `Makefile`) — no separate manual setup needed. Bump the pinned versions in that target
+periodically to track upstream stable releases; CI uses the same `make test-e2e` target, so it
+stays in sync automatically.
+
+Note: `TestE2E*` functions invoked directly via `go test -run TestE2E...` (bypassing the
+Makefile) fall back to using the bare test function name as the minikube profile if `E2E_PROFILE`
+isn't set in the environment, so ad hoc runs across worktrees can still collide — export
+`E2E_PROFILE` yourself (e.g. from `make print-e2e-profile`) to isolate those too.
 
 When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.Include`,
 or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`

--- a/Makefile
+++ b/Makefile
@@ -41,15 +41,70 @@ staticcheck:
 test: vet staticcheck
 	go test ./...
 
+#--------------------------
+# E2E cluster identity
+#--------------------------
+# Local test-e2e runs get their own minikube profile/kubeconfig, isolated by git
+# branch (worktrees can't share a branch, so this covers parallel worktrees) and,
+# when running under Claude Code, by session id too (so two sessions working the
+# same branch/worktree don't step on each other's cluster either). The branch name
+# is kept as a readable prefix; a hash carries the actual uniqueness so truncating
+# long/ULID-suffixed branch names (e.g. worktree-*-<ulid>) can't collide.
+E2E_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+ifeq ($(E2E_GIT_BRANCH),HEAD)
+E2E_GIT_BRANCH := $(shell git rev-parse --short HEAD 2>/dev/null)
+endif
+ifeq ($(E2E_GIT_BRANCH),)
+E2E_GIT_BRANCH := local
+endif
+E2E_BRANCH_SLUG := $(shell ./hack/e2e-branch-slug.sh '$(E2E_GIT_BRANCH)')
+E2E_IDENTITY_HASH := $(shell echo -n '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)' | sha1sum | cut -c1-8)
+E2E_PROFILE := kstat-e2e-$(E2E_BRANCH_SLUG)-$(E2E_IDENTITY_HASH)
+E2E_KUBECONFIG := $(CURDIR)/.e2e/$(E2E_PROFILE).kubeconfig
+
+# CI (and anyone else who already has a suitable cluster configured) sets
+# ASSUME_MINIKUBE_IS_CONFIGURED=true, in which case we deliberately fall back to the
+# ambient kubeconfig/context and default minikube profile instead of the isolated
+# ones above -- that's what medyagh/setup-minikube in ci-test.yml provisions.
+ifeq ($(ASSUME_MINIKUBE_IS_CONFIGURED),true)
+E2E_KUBECONFIG_ENV :=
+E2E_PROFILE_FLAG :=
+else
+E2E_KUBECONFIG_ENV := KUBECONFIG=$(E2E_KUBECONFIG)
+E2E_PROFILE_FLAG := -p $(E2E_PROFILE)
+endif
+
+.PHONY: print-e2e-profile
+print-e2e-profile:
+	@echo "profile:   $(E2E_PROFILE)"
+	@echo "kubeconfig: $(E2E_KUBECONFIG)"
+
+.PHONY: install-hooks
+install-hooks:
+	@hooks_dir="$$(git rev-parse --git-path hooks)"; \
+	install -m 755 hack/git-hooks/reference-transaction "$$hooks_dir/reference-transaction"; \
+	echo "Installed hack/git-hooks/reference-transaction -> $$hooks_dir/reference-transaction"; \
+	echo "(shared by all worktrees of this clone; deletes a branch's e2e minikube profile when the branch is deleted)"
+
+.PHONY: e2e-minikube-up
+e2e-minikube-up:
+	@mkdir -p $(dir $(E2E_KUBECONFIG))
+	$(E2E_KUBECONFIG_ENV) minikube start -p $(E2E_PROFILE) --addons=metrics-server
+
+.PHONY: e2e-minikube-down
+e2e-minikube-down:
+	$(E2E_KUBECONFIG_ENV) minikube delete -p $(E2E_PROFILE)
+	@rm -f $(E2E_KUBECONFIG)
+
 .PHONY: install-e2e-deps
 install-e2e-deps:
 	# metrics-server is needed by e2e scenarios exercising pod/node metrics rendering.
-	minikube addons enable metrics-server
-	kubectl -n kube-system rollout status deployment/metrics-server --timeout=120s
+	$(E2E_KUBECONFIG_ENV) minikube addons enable metrics-server $(E2E_PROFILE_FLAG)
+	$(E2E_KUBECONFIG_ENV) kubectl -n kube-system rollout status deployment/metrics-server --timeout=120s
 	# cert-manager and Gateway API CRDs are needed by e2e TLS-validation test scenarios.
 	# Pinned to latest stable at time of writing; bump these tags periodically.
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
-	kubectl wait --for=condition=Available --timeout=300s deployment --all -n cert-manager
+	$(E2E_KUBECONFIG_ENV) kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
+	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Available --timeout=300s deployment --all -n cert-manager
 	# CRDs only (no controller needed): e2e tests only exercise kubectl-status's own
 	# read-only rendering of these objects, they don't need a controller reconciling them.
 	# Experimental channel is a superset of standard and adds TCPRoute/UDPRoute/
@@ -57,12 +112,20 @@ install-e2e-deps:
 	# --server-side: the experimental bundle's CRDs (e.g. HTTPRoute) are large enough that
 	# client-side apply's kubectl.kubernetes.io/last-applied-configuration annotation trips
 	# the 262144-byte annotation limit; server-side apply doesn't need that annotation.
-	kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
+	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
 
 .PHONY: test-e2e
+ifeq ($(ASSUME_MINIKUBE_IS_CONFIGURED),true)
 test-e2e: vet staticcheck install-e2e-deps
 	# using count to prevent caching
-	RUN_E2E_TESTS=true go test -v ./... -count=1 -run 'TestE2E*'
+	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test -v ./... -count=1 -run 'TestE2E*'
+else
+test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
+	# The cluster is left running (profile: $(E2E_PROFILE)) for fast reruns; tear it
+	# down explicitly with `make e2e-minikube-down` once you're done with this branch.
+	# using count to prevent caching
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test -v ./... -count=1 -run 'TestE2E*'
+endif
 
 #--------------------------
 # Test Artifacts

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ifeq ($(E2E_GIT_BRANCH),)
 E2E_GIT_BRANCH := local
 endif
 E2E_BRANCH_SLUG := $(shell ./hack/e2e-branch-slug.sh '$(E2E_GIT_BRANCH)')
-E2E_IDENTITY_HASH := $(shell echo -n '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)' | sha1sum | cut -c1-8)
+E2E_IDENTITY_HASH := $(shell printf '%s' '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)' | (sha1sum 2>/dev/null || shasum) | cut -c1-8)
 E2E_PROFILE := kstat-e2e-$(E2E_BRANCH_SLUG)-$(E2E_IDENTITY_HASH)
 E2E_KUBECONFIG := $(CURDIR)/.e2e/$(E2E_PROFILE).kubeconfig
 
@@ -82,6 +82,7 @@ print-e2e-profile:
 .PHONY: install-hooks
 install-hooks:
 	@hooks_dir="$$(git rev-parse --git-path hooks)"; \
+	mkdir -p "$$hooks_dir"; \
 	install -m 755 hack/git-hooks/reference-transaction "$$hooks_dir/reference-transaction"; \
 	echo "Installed hack/git-hooks/reference-transaction -> $$hooks_dir/reference-transaction"; \
 	echo "(shared by all worktrees of this clone; deletes a branch's e2e minikube profile when the branch is deleted)"

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -325,7 +325,18 @@ func executeCMD(t *testing.T, args []string) (string, string, error) {
 
 func startMinikube(t *testing.T) {
 	t.Helper()
-	clusterName := t.Name()
+	// `make test-e2e` computes an isolated profile name (branch + Claude Code session
+	// hash, see Makefile) and passes ASSUME_MINIKUBE_IS_CONFIGURED=true, so it never
+	// reaches this function. This fallback only matters for ad hoc
+	// `go test -run TestE2E...` invocations that bypass the Makefile: set E2E_PROFILE
+	// yourself (`make print-e2e-profile` prints the same name the Makefile would use)
+	// to avoid colliding with other worktrees/sessions on a shared t.Name() profile.
+	// TODO: derive branch+session identity here directly instead of relying on the
+	// caller to export E2E_PROFILE, so ad hoc runs are isolated automatically too.
+	clusterName := os.Getenv("E2E_PROFILE")
+	if clusterName == "" {
+		clusterName = t.Name()
+	}
 	t.Logf("Creating temp folder for minikube.kubeconfig for minikube %s ...", clusterName)
 	dir, err := os.MkdirTemp("", clusterName)
 	require.NoError(t, err)

--- a/hack/e2e-branch-slug.sh
+++ b/hack/e2e-branch-slug.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Sanitizes a git branch name into the readable prefix used for e2e minikube
+# profile names (see the E2E_* variables in the Makefile and
+# hack/git-hooks/reference-transaction). Shared so both places stay in sync.
+set -euo pipefail
+
+echo "$1" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed 's/-\{1,\}/-/g;s/^-//;s/-$//' | cut -c1-20 | sed 's/-$//'

--- a/hack/e2e-branch-slug.sh
+++ b/hack/e2e-branch-slug.sh
@@ -4,4 +4,4 @@
 # hack/git-hooks/reference-transaction). Shared so both places stay in sync.
 set -euo pipefail
 
-echo "$1" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed 's/-\{1,\}/-/g;s/^-//;s/-$//' | cut -c1-20 | sed 's/-$//'
+printf '%s' "$1" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed 's/-\{1,\}/-/g;s/^-//;s/-$//' | cut -c1-20 | sed 's/-$//'

--- a/hack/git-hooks/reference-transaction
+++ b/hack/git-hooks/reference-transaction
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Installed via `make install-hooks`. `make test-e2e` names its minikube profile
+# after the current branch (see E2E_* in the Makefile); this hook deletes any such
+# profile once the branch that owned it is deleted locally, so leftover clusters
+# don't pile up as worktrees/branches churn.
+#
+# git invokes every "reference-transaction" hook with a stage argument
+# (prepared/committed/aborted) and feeds "<old-oid> <new-oid> <ref>" triples for
+# every ref touched by the transaction on stdin. This fires for far more than
+# branch deletion (checkouts, merges, fetches...), so we filter down to
+# refs/heads/* transitioning to the all-zero oid, which is how git represents a
+# deleted ref.
+set -euo pipefail
+
+stage="${1:-}"
+[ "$stage" = "committed" ] || exit 0
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+slug_script="$repo_root/hack/e2e-branch-slug.sh"
+[ -x "$slug_script" ] || exit 0
+command -v minikube >/dev/null 2>&1 || exit 0
+
+is_zero_oid() {
+	case "$1" in
+	0000000000000000000000000000000000000000|0000000000000000000000000000000000000000000000000000000000000000000000) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+while read -r old_oid new_oid ref_name; do
+	case "$ref_name" in
+	refs/heads/*) ;;
+	*) continue ;;
+	esac
+	is_zero_oid "$new_oid" || continue
+
+	branch="${ref_name#refs/heads/}"
+	slug="$("$slug_script" "$branch")"
+	[ -n "$slug" ] || continue
+
+	profiles="$(minikube profile list -o json 2>/dev/null \
+		| grep -o "\"Name\":\"kstat-e2e-${slug}-[a-f0-9]\{8\}\"" \
+		| cut -d'"' -f4 \
+		| sort -u)"
+	for profile in $profiles; do
+		echo "reference-transaction: branch '$branch' deleted, removing its e2e minikube profile '$profile'" >&2
+		minikube delete -p "$profile" >/dev/null 2>&1 || true
+	done
+done
+
+exit 0

--- a/hack/git-hooks/reference-transaction
+++ b/hack/git-hooks/reference-transaction
@@ -39,9 +39,9 @@ while read -r old_oid new_oid ref_name; do
 	[ -n "$slug" ] || continue
 
 	profiles="$(minikube profile list -o json 2>/dev/null \
-		| grep -o "\"Name\":\"kstat-e2e-${slug}-[a-f0-9]\{8\}\"" \
+		| grep -o "\"Name\"[[:space:]]*:[[:space:]]*\"kstat-e2e-${slug}-[a-f0-9]\{8\}\"" \
 		| cut -d'"' -f4 \
-		| sort -u)"
+		| sort -u || true)"
 	for profile in $profiles; do
 		echo "reference-transaction: branch '$branch' deleted, removing its e2e minikube profile '$profile'" >&2
 		minikube delete -p "$profile" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- `make test-e2e` previously used fixed minikube profile names (`t.Name()`), so parallel worktrees or multiple sessions on the same branch collided on the same profile/cluster.
- The Makefile now computes an `E2E_PROFILE` from the current git branch plus (under Claude Code) `CLAUDE_CODE_SESSION_ID`, and owns the full local cluster lifecycle: start → install e2e deps (cert-manager, Gateway API CRDs) → run tests, all against an isolated kubeconfig under `.e2e/` (never touching `~/.kube/config`). This also fixes a latent bug where `install-e2e-deps` ran before the ephemeral test cluster existed.
- CI's `ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e` path is unchanged (verified via `make -n`).
- Added `make install-hooks`, which installs a `reference-transaction` git hook (shared across all worktrees of the clone) that deletes a branch's e2e minikube profile when that branch is deleted locally.
- `TestE2E*` in `cmd/main_test.go` now honors an `E2E_PROFILE` env var for ad hoc `go test -run TestE2E...` runs that bypass the Makefile.
- CONTRIBUTING.md updated to document the new flow.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `make -n test-e2e` / `ASSUME_MINIKUBE_IS_CONFIGURED=true make -n test-e2e` dry-run diffs reviewed; CI path byte-for-byte unchanged
- [x] `hack/e2e-branch-slug.sh` sanitization checked against real branch names (incl. ULID-suffixed worktree branches)
- [x] `hack/git-hooks/reference-transaction` exercised end-to-end in a throwaway repo: fires at the `committed` stage exactly on branch deletion, profile-name extraction from `minikube profile list -o json` verified
- [ ] Full `make test-e2e` run against a live cluster (not run here — multi-minute, real infra side effects)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>