### PR TITLE
Notify when metrics-server is missing or unhealthy

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -906,6 +906,40 @@ func TestE2EDynamicManifests(t *testing.T) {
 		assert.Regexp(t, `(?m)^\s+cpu:\s+usage/allocatable:[\d.]+/[\d.]+\(\s*\d+%\)`, stdout)
 		assert.Regexp(t, `(?m)^\s+mem:\s+usage/allocatable:`, stdout)
 	})
+	t.Run("pod containers section warns when metrics-server's APIService is missing", func(t *testing.T) {
+		// Issue #165 case 1: metrics-server was never installed. We simulate that by removing
+		// just the APIService object that fronts it (not the Deployment/Service), which is
+		// exactly what KubeMetricsUnavailableReason checks -- so the round trip is near-instant
+		// and doesn't disturb metrics-server's actual health for other subtests.
+		viperTestHack(t)
+		apiServiceYAML, err := exec.Command("kubectl", "get", "apiservice", "v1beta1.metrics.k8s.io", "-o", "yaml").Output()
+		require.NoError(t, err)
+		require.NoError(t, exec.Command("kubectl", "delete", "apiservice", "v1beta1.metrics.k8s.io").Run())
+		t.Cleanup(func() {
+			applyCmd := exec.Command("kubectl", "apply", "-f", "-")
+			applyCmd.Stdin = bytes.NewReader(apiServiceYAML)
+			require.NoError(t, applyCmd.Run())
+			waitForMetricsAPIServiceAvailable(t)
+		})
+
+		_, err = clientset.CoreV1().Pods("default").Create(context.TODO(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "e2e-pod-metrics-server-missing"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"}}},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Pods("default").Delete(context.TODO(), "e2e-pod-metrics-server-missing", metav1.DeleteOptions{})
+		})
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+			"pod/e2e-pod-metrics-server-missing", "--timeout=2m").Run())
+
+		cmdTest{
+			args:            []string{"pod/e2e-pod-metrics-server-missing", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-metrics-server-missing.regex",
+		}.assert(t, nil)
+	})
 }
 
 func applyManifest(t *testing.T, filepath string) {
@@ -969,4 +1003,23 @@ func waitForPodMetrics(t *testing.T, namespace, name string) {
 		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("timed out waiting for metrics.k8s.io data for pod %s/%s", namespace, name)
+}
+
+// waitForMetricsAPIServiceAvailable polls until the metrics-server APIService reports
+// Available=True. Used after recreating it post-deletion: the backing Deployment/Service were
+// never touched, so this is a quick re-sync, not the ~1 minute metrics-server itself needs to
+// scrape fresh data.
+func waitForMetricsAPIServiceAvailable(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		output, err := exec.Command("kubectl", "get", "apiservice", "v1beta1.metrics.k8s.io",
+			"-o", `jsonpath={.status.conditions[?(@.type=="Available")].status}`).Output()
+		if err == nil && strings.TrimSpace(string(output)) == "True" {
+			t.Log("metrics-server APIService is Available again")
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for metrics-server APIService to become Available again")
 }

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -77,14 +77,15 @@ func NewResourceRepo(factory util.Factory) (*ResourceRepo, error) {
 }
 
 type ResourceRepo struct {
-	f                            util.Factory
-	dynamicClient                dynamic.Interface
-	kubernetesClientSet          *kubernetes.Clientset
-	nodeStatsSummaryCache        map[string]nodeStatsSummaryCacheEntry
-	objectsCache                 map[string]objectsCacheEntry
-	endpointSlicesCache          map[string]endpointSlicesCacheEntry
-	allNamespacesPodMetricsCache *objectsCacheEntry
-	ownerCache                   map[string]ownerCacheEntry
+	f                             util.Factory
+	dynamicClient                 dynamic.Interface
+	kubernetesClientSet           *kubernetes.Clientset
+	nodeStatsSummaryCache         map[string]nodeStatsSummaryCacheEntry
+	objectsCache                  map[string]objectsCacheEntry
+	endpointSlicesCache           map[string]endpointSlicesCacheEntry
+	allNamespacesPodMetricsCache  *objectsCacheEntry
+	ownerCache                    map[string]ownerCacheEntry
+	metricsUnavailableReasonCache *string
 }
 
 type nodeStatsSummaryCacheEntry struct {
@@ -201,6 +202,58 @@ func (r *ResourceRepo) AllNamespacesPodMetrics() (Objects, error) {
 	}
 	r.allNamespacesPodMetricsCache = &objectsCacheEntry{objects: objects, err: err}
 	return objects, err
+}
+
+// metricsAPIServiceGVR is the apiregistration.k8s.io APIService that fronts metrics-server,
+// equivalent to `kubectl get apiservice v1beta1.metrics.k8s.io`.
+var metricsAPIServiceGVR = schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}
+
+// MetricsUnavailableReason reports why the metrics.k8s.io API (served by metrics-server) can't be
+// used, or "" if it's healthy. It checks the APIService's Available condition directly -- the same
+// signal `kubectl top` relies on to report "Metrics API not available" -- rather than a
+// RESTMapper/discovery-based check, since discovery listings may still show a stale/cached group
+// version while the backing service is down. This distinguishes two different problems a caller
+// should word differently:
+//   - the APIService object doesn't exist at all: metrics-server was never installed.
+//   - the APIService exists but its Available condition is False: metrics-server is installed but
+//     currently unhealthy (e.g. crashed, unreachable); the condition's own message/reason is
+//     surfaced since it usually names the concrete problem (e.g. "no endpoints available").
+//
+// The result is cached since Pod/Node rendering checks this repeatedly.
+func (r *ResourceRepo) MetricsUnavailableReason() string {
+	if r.metricsUnavailableReasonCache != nil {
+		return *r.metricsUnavailableReasonCache
+	}
+	reason := ""
+	obj, err := r.DynamicObject(metricsAPIServiceGVR, "", "v1beta1.metrics.k8s.io")
+	switch {
+	case apierrors.IsNotFound(err):
+		reason = "metrics-server is not installed (no v1beta1.metrics.k8s.io APIService found)"
+	case err != nil:
+		klog.V(3).ErrorS(err, "failed to check metrics-server APIService availability")
+	default:
+		reason = unavailableReasonFromAPIServiceConditions(obj)
+	}
+	r.metricsUnavailableReasonCache = &reason
+	return reason
+}
+
+func unavailableReasonFromAPIServiceConditions(apiService Object) string {
+	conditions, _, _ := unstructured.NestedSlice(apiService, "status", "conditions")
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		if !ok || condition["type"] != "Available" {
+			continue
+		}
+		if condition["status"] == "True" {
+			return ""
+		}
+		if detail, _ := condition["message"].(string); detail != "" {
+			return fmt.Sprintf("metrics-server is not available: %s", detail)
+		}
+		return "metrics-server is not available"
+	}
+	return "metrics-server is not available"
 }
 
 // Owners resolves the ownerReferences of obj to the objects they point at. References whose

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -228,9 +228,10 @@ func (r *ResourceRepo) MetricsUnavailableReason() string {
 	obj, err := r.DynamicObject(metricsAPIServiceGVR, "", "v1beta1.metrics.k8s.io")
 	switch {
 	case apierrors.IsNotFound(err):
-		reason = "metrics-server is not installed (no v1beta1.metrics.k8s.io APIService found)"
+		reason = "metrics-server is not installed"
 	case err != nil:
 		klog.V(3).ErrorS(err, "failed to check metrics-server APIService availability")
+		reason = fmt.Sprintf("failed to check metrics-server availability: %v", err)
 	default:
 		reason = unavailableReasonFromAPIServiceConditions(obj)
 	}

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -2,11 +2,15 @@ package input
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
@@ -143,6 +147,108 @@ func TestOwnersClusterScopedOwner(t *testing.T) {
 	if len(owners) != 1 {
 		t.Fatalf("expected the cluster-scoped owner to resolve, got %d owners", len(owners))
 	}
+}
+
+// newAPIServiceFactory builds a test factory whose dynamic client can Get/Create
+// apiregistration.k8s.io APIService objects -- a group client-go's own scheme doesn't know about,
+// so the fake dynamic client needs an explicit List-kind mapping for it.
+func newAPIServiceFactory(t *testing.T, apiService *unstructured.Unstructured) *cmdtesting.TestFactory {
+	t.Helper()
+	f := newTestFactory()
+	objs := []runtime.Object{}
+	if apiService != nil {
+		objs = append(objs, apiService)
+	}
+	f.FakeDynamicClient = fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		scheme.Scheme,
+		map[schema.GroupVersionResource]string{metricsAPIServiceGVR: "APIServiceList"},
+		objs...,
+	)
+	return f
+}
+
+func apiServiceObj(available bool, message string) *unstructured.Unstructured {
+	status := "False"
+	if available {
+		status = "True"
+	}
+	condition := map[string]interface{}{"type": "Available", "status": status}
+	if message != "" {
+		condition["message"] = message
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       "APIService",
+		"metadata": map[string]interface{}{
+			"name": "v1beta1.metrics.k8s.io",
+		},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{condition},
+		},
+	}}
+}
+
+// TestMetricsUnavailableReason verifies that ResourceRepo.MetricsUnavailableReason distinguishes
+// three cluster states -- metrics-server's APIService missing entirely (not installed), present
+// but unhealthy (Available=False, surfacing the condition's own diagnostic message), and healthy
+// (Available=True) -- and that the result is cached rather than re-checked on every call.
+func TestMetricsUnavailableReason(t *testing.T) {
+	t.Run("not installed when the APIService doesn't exist", func(t *testing.T) {
+		f := newAPIServiceFactory(t, nil)
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reason := repo.MetricsUnavailableReason()
+		if !strings.Contains(reason, "not installed") {
+			t.Errorf("expected reason to mention metrics-server isn't installed, got %q", reason)
+		}
+	})
+
+	t.Run("unavailable, surfacing the condition's message, when the APIService exists but isn't Available", func(t *testing.T) {
+		f := newAPIServiceFactory(t, apiServiceObj(false, "no endpoints available for service \"metrics-server\""))
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reason := repo.MetricsUnavailableReason()
+		if !strings.Contains(reason, "no endpoints available for service \"metrics-server\"") {
+			t.Errorf("expected reason to surface the Available condition's message, got %q", reason)
+		}
+	})
+
+	t.Run("empty when the APIService is Available", func(t *testing.T) {
+		f := newAPIServiceFactory(t, apiServiceObj(true, ""))
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reason := repo.MetricsUnavailableReason(); reason != "" {
+			t.Errorf("expected empty reason when the APIService's Available condition is True, got %q", reason)
+		}
+	})
+
+	t.Run("result is cached", func(t *testing.T) {
+		f := newAPIServiceFactory(t, apiServiceObj(true, ""))
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reason := repo.MetricsUnavailableReason(); reason != "" {
+			t.Fatalf("expected empty reason, got %q", reason)
+		}
+		// Deleting the APIService out from under the repo must not change the cached result.
+		if err := f.FakeDynamicClient.Resource(metricsAPIServiceGVR).Delete(context.TODO(), "v1beta1.metrics.k8s.io", metav1.DeleteOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if reason := repo.MetricsUnavailableReason(); reason != "" {
+			t.Errorf("expected cached empty reason to stick even after the underlying APIService changed, got %q", reason)
+		}
+	})
 }
 
 // TestOwnersResolutionIsCached verifies that resolving the same ownerReference for two different

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -374,6 +374,18 @@ func (r RenderableObject) KubeGetNodeMetrics(name string) RenderableObject {
 	return r.newRenderableObject(nil)
 }
 
+// KubeMetricsUnavailableReason reports why the metrics.k8s.io API (metrics-server) can't be used
+// right now, or "" if it's healthy, so templates can tell users specifically whether it was never
+// installed or is installed but unhealthy, instead of silently omitting the usage section either
+// way. In shallow mode no cluster call is made (per this file's convention) and "" (available) is
+// assumed, so callers don't spuriously warn about something that was never checked.
+func (r RenderableObject) KubeMetricsUnavailableReason() string {
+	if viper.GetBool("shallow") {
+		return ""
+	}
+	return r.repo.MetricsUnavailableReason()
+}
+
 // KubeGetContainerLogs returns up to tailLines lines of log output for the named container in the
 // named pod. When previous is true it fetches logs from the container's previous (terminated)
 // instance, equivalent to `kubectl logs --previous`. Returns an empty string if there are no logs

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -142,12 +142,9 @@
             {{- end }}
             {{- with index .Status.allocatable "ephemeral-storage" }}{{ "ephemeral-storage" | bold | nindent 2 }}: {{ . | quantityToFloat64 | humanizeSI "B" }}{{ end }}
         {{- else if not (.Config.GetBool "shallow") }}
-            {{- $metricsUnavailableReason := $.KubeMetricsUnavailableReason }}
-            {{- if $metricsUnavailableReason }}
-                {{- $metricsUnavailableReason | yellow | nindent 2 }}: cpu/memory usage for this Node and its Pods can't be shown.
-            {{- else }}
-                {{- "no metrics yet" | yellow | nindent 2 }}: metrics-server hasn't reported cpu/memory usage for this Node yet.
-            {{- end }}
+            {{- $metricsUnavailableReason := $.KubeMetricsUnavailableReason | default "no metrics yet" }}
+            {{- "cpu" | bold | nindent 2 }}: [req:{{ $podsTotalCpuRequests | printf "%.3g" }}, lim:{{ $podsTotalCpuLimits | printf "%.3g" }}]
+            {{- ", " }}{{ "mem" | bold }}: [req:{{ $podsTotalMemRequests | humanizeSI "B" }}, lim:{{ $podsTotalMemLimits | humanizeSI "B" }}], ({{ $metricsUnavailableReason | yellow }})
         {{- end }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -141,6 +141,13 @@
                 {{- "Memory overcommitted" | red | bold | nindent 4 }}: Application may be OOMKilled. Expect BestEffort and then Burstable pods to have OOMKill due to overcommitted memory on the node.
             {{- end }}
             {{- with index .Status.allocatable "ephemeral-storage" }}{{ "ephemeral-storage" | bold | nindent 2 }}: {{ . | quantityToFloat64 | humanizeSI "B" }}{{ end }}
+        {{- else if not (.Config.GetBool "shallow") }}
+            {{- $metricsUnavailableReason := $.KubeMetricsUnavailableReason }}
+            {{- if $metricsUnavailableReason }}
+                {{- $metricsUnavailableReason | yellow | nindent 2 }}: cpu/memory usage for this Node and its Pods can't be shown.
+            {{- else }}
+                {{- "no metrics yet" | yellow | nindent 2 }}: metrics-server hasn't reported cpu/memory usage for this Node yet.
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -488,7 +488,7 @@
     {{- end }}
     {{- if .containerMetrics }}
         {{- if .containerMetrics.usage.cpu }}{{ "usage" | nindent 2 }} {{ template "container_usage" . }}{{ end }}
-    {{- else if .metricsUnavailableReason }}
+    {{- else if and .metricsUnavailableReason .containerStatus.state.running }}
         {{- "" | nindent 2 }}{{ template "container_requests_limits" . }}, ({{ .metricsUnavailableReason | yellow }})
     {{- end }}
     {{- with .containerStatus.lastState }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -130,6 +130,10 @@
         {{- $single := eq (len .) 1 }}
         {{- "Containers:" | nindent 2 }}
         {{- $podMetrics := $pod.KubeGetPodMetrics $pod.Namespace $pod.Name }}
+        {{- $metricsUnavailableReason := "" }}
+        {{- if and (not ($pod.Config.GetBool "shallow")) (eq $pod.Status.phase "Running") (not ($podMetrics.Object | default dict).containers) }}
+            {{- $metricsUnavailableReason = $pod.KubeMetricsUnavailableReason | default "no metrics yet" }}
+        {{- end }}
         {{- $containerStatusSummaryDict := dict }}
         {{- range $containerStatus := . }}
             {{- $containerSpec := $pod.Spec.containers | getMatchingItemInMapList (dict "name" $containerStatus.name) }}
@@ -157,20 +161,13 @@
                                                        "includeAllVolumes" ($pod.Config.GetBool "include-all-volumes")
                                                        "podImagePullSecrets" $pod.Spec.imagePullSecrets
                                                        "podPullSecretsBroken" $.podPullSecretsBroken
+                                                       "metricsUnavailableReason" $metricsUnavailableReason
                 }}
             {{- end }}
             {{- if $single }}
                 {{- " " }}{{- $pod.Include "container_status_summary" $containerStatusSummaryDict }}
             {{- else }}
                 {{- $pod.Include "container_status_summary" $containerStatusSummaryDict | nindent 4 }}
-            {{- end }}
-        {{- end }}
-        {{- if and (not ($pod.Config.GetBool "shallow")) (eq $pod.Status.phase "Running") (not ($podMetrics.Object | default dict).containers) }}
-            {{- $metricsUnavailableReason := $pod.KubeMetricsUnavailableReason }}
-            {{- if $metricsUnavailableReason }}
-                {{- $metricsUnavailableReason | yellow | nindent 4 }}: cpu/memory usage for containers can't be shown.
-            {{- else }}
-                {{- "no metrics yet" | yellow | nindent 4 }}: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet.
             {{- end }}
         {{- end }}
     {{- end }}
@@ -451,6 +448,16 @@
     ]
 {{- end -}}
 
+{{- define "container_requests_limits" -}}
+    {{- /* Expects to get a map with the key "containerSpec" (required): Pod.spec.containers[name=container].
+           Used in place of container_usage when there's no metrics data to show usage against. */ -}}
+    cpu: [{{ if .containerSpec.resources.requests.cpu }}req:{{ .containerSpec.resources.requests.cpu | quantityToFloat64 | printf "%.1g" }}{{ else }}{{ "no-req" | yellow }}{{ end -}}
+    , {{ if .containerSpec.resources.limits.cpu }}lim:{{ .containerSpec.resources.limits.cpu | quantityToFloat64 | printf "%.1g" }}{{ else }}{{ "no-lim" | yellow }}{{ end -}}
+    ], mem: [{{ if .containerSpec.resources.requests.memory }}req:{{ .containerSpec.resources.requests.memory | quantityToFloat64 | humanizeSI "B" }}{{ else }}{{ "no-req" | yellow }}{{ end -}}
+    , {{ if .containerSpec.resources.limits.memory }}lim:{{ .containerSpec.resources.limits.memory | quantityToFloat64 | humanizeSI "B" }}{{ else }}{{ "no-lim" | yellow }}{{ end -}}
+    ]
+{{- end -}}
+
 {{- define "container_status_summary" }}
     {{- /* Expects to get a map with these keys (and also their initContainer counterparts):
            * pod (required): Pod RenderableObject, used to fetch logs
@@ -461,6 +468,7 @@
            * defaultLogsContainer (optional): Boolean
            * podImagePullSecrets (optional): Pod.spec.imagePullSecrets
            * podPullSecretsBroken (optional): Boolean, true if any podImagePullSecrets entry doesn't resolve to a usable Secret
+           * metricsUnavailableReason (optional): non-empty string explaining why there's no containerMetrics
         */ -}}
     {{- .containerStatus.name | bold }}{{ if .sidecar }}{{ " [sidecar]" | cyan }}{{ end }} ({{ .containerStatus.image | markYellow "latest" }}) {{ template "container_state_summary" .containerStatus.state }}
     {{- if .containerStatus.state.running }}{{ if .containerStatus.ready }} and {{ "Ready" | green }}{{ else }} but {{ "Not Ready" | red | bold }}{{ end }}{{ end }}
@@ -478,7 +486,11 @@
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- if .containerMetrics }}{{ if .containerMetrics.usage.cpu }}{{ "usage" | nindent 2 }} {{ template "container_usage" . }}{{ end }}{{ end }}
+    {{- if .containerMetrics }}
+        {{- if .containerMetrics.usage.cpu }}{{ "usage" | nindent 2 }} {{ template "container_usage" . }}{{ end }}
+    {{- else if .metricsUnavailableReason }}
+        {{- "" | nindent 2 }}{{ template "container_requests_limits" . }}, ({{ .metricsUnavailableReason | yellow }})
+    {{- end }}
     {{- with .containerStatus.lastState }}
         {{- "previously:" | yellow | nindent 2 }} {{ template "container_state_summary" . }}
     {{- end }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -164,6 +164,14 @@
                 {{- $pod.Include "container_status_summary" $containerStatusSummaryDict | nindent 4 }}
             {{- end }}
         {{- end }}
+        {{- if and (not ($pod.Config.GetBool "shallow")) (eq $pod.Status.phase "Running") (not ($podMetrics.Object | default dict).containers) }}
+            {{- $metricsUnavailableReason := $pod.KubeMetricsUnavailableReason }}
+            {{- if $metricsUnavailableReason }}
+                {{- $metricsUnavailableReason | yellow | nindent 4 }}: cpu/memory usage for containers can't be shown.
+            {{- else }}
+                {{- "no metrics yet" | yellow | nindent 4 }}: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet.
+            {{- end }}
+        {{- end }}
     {{- end }}
 {{- end }}
 

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -4,7 +4,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
@@ -381,4 +386,159 @@ func TestPodImagePullSecretMissingTemplate(t *testing.T) {
 		"status": map[string]interface{}{},
 	}
 	checkTemplate(t, "Pod", obj, "Secret/does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets.", true)
+}
+
+func runningPodWithNoMetricsObj() map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "some-pod",
+			"namespace": "test",
+		},
+		"spec": map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{"name": "main", "image": "some-image"},
+			},
+		},
+		"status": map[string]interface{}{
+			"phase": "Running",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{
+					"name":  "main",
+					"image": "some-image",
+					"state": map[string]interface{}{"running": map[string]interface{}{"startedAt": "2024-01-01T00:00:00Z"}},
+				},
+			},
+		},
+	}
+}
+
+// metricsAPIServiceGVR mirrors the unexported schema.GroupVersionResource of the same name in
+// pkg/input -- the apiregistration.k8s.io APIService that fronts metrics-server.
+var metricsAPIServiceGVR = schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}
+
+// factoryWithHealthyMetricsServer builds a test factory whose dynamic client reports
+// metrics-server's APIService as installed and Available, so KubeMetricsUnavailableReason
+// returns "" -- letting tests exercise the "healthy but no data recorded for this object yet"
+// case (#165 case 3) distinctly from "metrics-server itself is missing/unhealthy" (cases 1-2).
+func factoryWithHealthyMetricsServer(t *testing.T) *cmdtesting.TestFactory {
+	t.Helper()
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	apiService := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       "APIService",
+		"metadata":   map[string]interface{}{"name": "v1beta1.metrics.k8s.io"},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Available", "status": "True"},
+			},
+		},
+	}}
+	f.FakeDynamicClient = fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		scheme.Scheme,
+		map[schema.GroupVersionResource]string{metricsAPIServiceGVR: "APIServiceList"},
+		apiService,
+	)
+	return f
+}
+
+func renderPodTemplate(t *testing.T, f *cmdtesting.TestFactory, obj map[string]interface{}) string {
+	t.Helper()
+	tmpl, _ := getTemplate()
+	t.Cleanup(func() { f.Cleanup() })
+	repo, err := input.NewResourceRepo(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard())
+	e.Template = *tmpl
+	r := newRenderableObject(obj, e, repo)
+	got, err := r.renderTemplate("Pod", r)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	return got
+}
+
+// TestPodContainersMetricsNotInstalledWarningTemplate covers issue #165 case 1: when
+// metrics-server was never installed (the default fake test client has no APIService for it), a
+// Running pod's Containers section should say so instead of silently omitting cpu/memory usage.
+func TestPodContainersMetricsNotInstalledWarningTemplate(t *testing.T) {
+	checkTemplate(t, "Pod", runningPodWithNoMetricsObj(), "not installed", true)
+}
+
+// TestPodContainersMetricsUnhealthyWarningTemplate covers issue #165 case 2: metrics-server is
+// installed but its APIService reports Available=False, surfacing the condition's own message.
+func TestPodContainersMetricsUnhealthyWarningTemplate(t *testing.T) {
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	apiService := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "apiregistration.k8s.io/v1",
+		"kind":       "APIService",
+		"metadata":   map[string]interface{}{"name": "v1beta1.metrics.k8s.io"},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Available", "status": "False", "message": "endpoints for service/metrics-server in \"kube-system\" have no addresses"},
+			},
+		},
+	}}
+	f.FakeDynamicClient = fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		scheme.Scheme,
+		map[schema.GroupVersionResource]string{metricsAPIServiceGVR: "APIServiceList"},
+		apiService,
+	)
+	got := renderPodTemplate(t, f, runningPodWithNoMetricsObj())
+	if !strings.Contains(got, "endpoints for service/metrics-server") {
+		t.Errorf("expected the APIService condition's message to be surfaced, got = %q", got)
+	}
+}
+
+// TestPodContainersMetricsNoDataYetTemplate covers issue #165 case 3: metrics-server is healthy,
+// but this specific Pod has no recorded usage yet (e.g. it was just created and hasn't been
+// scraped). This should say so explicitly rather than staying silent or claiming metrics-server
+// itself is unavailable.
+func TestPodContainersMetricsNoDataYetTemplate(t *testing.T) {
+	got := renderPodTemplate(t, factoryWithHealthyMetricsServer(t), runningPodWithNoMetricsObj())
+	if !strings.Contains(got, "no metrics yet") {
+		t.Errorf("expected a \"no metrics yet\" note, got = %q", got)
+	}
+	if strings.Contains(got, "not installed") || strings.Contains(got, "not available") {
+		t.Errorf("expected no metrics-server-unavailable wording when metrics-server is healthy, got = %q", got)
+	}
+}
+
+// TestPodContainersMetricsWarningSuppressedInShallowMode verifies that --shallow, which never
+// queries the cluster for enrichment, doesn't misreport an unchecked metrics-server as missing.
+func TestPodContainersMetricsWarningSuppressedInShallowMode(t *testing.T) {
+	viper.Set("shallow", true)
+	t.Cleanup(func() { viper.Set("shallow", false) })
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	got := renderPodTemplate(t, f, runningPodWithNoMetricsObj())
+	if strings.Contains(got, "not installed") || strings.Contains(got, "not available") || strings.Contains(got, "no metrics yet") {
+		t.Errorf("expected no metrics-related note in shallow mode, got = %q", got)
+	}
+}
+
+// TestNodePodDetailsMetricsNotInstalledWarningTemplate covers issue #165 case 1 for Node's
+// detailed usage section: with metrics-server not installed (the default fake test client has no
+// APIService for it), enabling the opt-in "include-node-detailed-usage" section should surface a
+// warning instead of silently skipping cpu/mem/pods usage.
+func TestNodePodDetailsMetricsNotInstalledWarningTemplate(t *testing.T) {
+	viper.Set("include-node-detailed-usage", true)
+	t.Cleanup(func() { viper.Set("include-node-detailed-usage", false) })
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "some-node"},
+		"status": map[string]interface{}{
+			"allocatable": map[string]interface{}{
+				"cpu":    "4",
+				"memory": "16Gi",
+				"pods":   "110",
+			},
+		},
+	}
+	checkTemplate(t, "node_pod_details", obj, "not installed", true)
 }

--- a/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
+++ b/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
@@ -4,6 +4,7 @@ Pod/pdb-conflict-test-0 -n default, created 1m ago by StatefulSet/pdb-conflict-t
   Managed by pdb-conflict-test application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: pdb-conflict-test \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   2 PodDisruptionBudgets match — evictions of these pods will fail \(Kubernetes doesn't support a pod covered by multiple PDBs\)
   PodDisruptionBudgets:

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -16,12 +16,11 @@ Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1(, started after [0-
       previously: Started 1m ago and Error after 1m with exit code exit with 1
       Last 20 lines of logs from previous instance \(restarted within last hour\):
         crasher-log-line
-    healthy \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
-      usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
-    sidecar \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
-      usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
-(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
-)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+    healthy \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+      (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+    sidecar \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+      (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Known/recorded manage events:
     (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
     1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -20,7 +20,8 @@ Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1(, started after [0-
       usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
     sidecar \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
       usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
-  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
+)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Known/recorded manage events:
     (?:1m ago Updated by kubectl-client-side-apply \(metadata, spec\)
     1m ago Updated by kubelet \(status\)|1m ago Updated by kubelet \(status\)

--- a/tests/e2e-artifacts/pod-metrics-server-missing.regex
+++ b/tests/e2e-artifacts/pod-metrics-server-missing.regex
@@ -4,7 +4,7 @@ Pod/e2e-pod-metrics-server-missing -n default, created 1m ago, gen:1(, started a
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.
   Containers: main \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-    metrics-server is not installed \(no v1beta1\.metrics\.k8s\.io APIService found\): cpu/memory usage for containers can't be shown\.
+  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(metrics-server is not installed\)
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Known/recorded manage events:
     1m ago Updated by cmd\.test \(spec\)

--- a/tests/e2e-artifacts/pod-metrics-server-missing.regex
+++ b/tests/e2e-artifacts/pod-metrics-server-missing.regex
@@ -1,0 +1,12 @@
+\A
+Pod/e2e-pod-metrics-server-missing -n default, created 1m ago, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
+  Current: Pod is Ready
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: main \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+    metrics-server is not installed \(no v1beta1\.metrics\.k8s\.io APIService found\): cpu/memory usage for containers can't be shown\.
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Known/recorded manage events:
+    1m ago Updated by cmd\.test \(spec\)
+    1m ago Updated by kubelet \(status\)
+\z

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -3,10 +3,9 @@ Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingres
   Current: Pod is Ready
   Managed by sts-with-ingress application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
-  Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
-  usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
-(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
-)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-ingress -n default, ClusterIP, 1 ready, 80/TCP
   Known/recorded manage events:
     (?:1m ago Updated by kube-controller-manager \(metadata, spec\)

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -3,8 +3,10 @@ Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingres
   Current: Pod is Ready
   Managed by sts-with-ingress application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
-  Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
+  usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
+(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
+)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-ingress -n default, ClusterIP, 1 ready, 80/TCP
   Known/recorded manage events:
     (?:1m ago Updated by kube-controller-manager \(metadata, spec\)

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -3,10 +3,9 @@ Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodep
   Current: Pod is Ready
   Managed by sts-with-nodeport application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
-  Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
-  usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
-(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
-)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
   PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n default, min available=1, evictions/drains currently blocked
   Known/recorded manage events:

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -3,8 +3,10 @@ Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodep
   Current: Pod is Ready
   Managed by sts-with-nodeport application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
-  Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)(
+  usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\])?
+(    no metrics yet: metrics-server hasn't reported cpu/memory usage for this Pod's containers yet\.
+)?  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   Services: Service/sts-with-nodeport -n default, NodePort, 1 ready, http\(80/TCP\)→30081
   Known/recorded manage events:
     (?:1m ago Updated by kube-controller-manager \(metadata, spec\)


### PR DESCRIPTION
## Summary
- Closes #165. Node/Pod usage sections used to silently omit cpu/memory usage whenever `metrics.k8s.io` returned nothing, with no hint whether metrics-server isn't installed, is installed but unhealthy, or just hasn't scraped this object yet.
- Adds `ResourceRepo.MetricsUnavailableReason()`, which checks the `v1beta1.metrics.k8s.io` APIService's `Available` condition directly (the same signal `kubectl top` relies on for its own "Metrics API not available" error), and surfaces one of four distinct, explicit messages in Node/Pod rendering:
  1. metrics-server not installed (APIService object doesn't exist)
  2. metrics-server installed but unhealthy (`Available=False`, including the condition's own diagnostic message, e.g. "no endpoints available")
  3. metrics-server healthy but no data recorded yet for this specific object (a normal transient state right after creation)
  4. metrics-server healthy with data — unchanged real usage numbers, no message
- `--shallow` mode makes no cluster call and assumes availability, so it never spuriously warns about something it didn't check.

## Test plan
- [x] `go test ./...` — unit + template-level tests covering all 4 cases plus the shallow-mode suppression case
- [x] Full real e2e suite (`RUN_E2E_TESTS=true go test ./cmd/... -run TestE2E`) run against an isolated minikube cluster with metrics-server, cert-manager, and Gateway API CRDs installed — 0 failures
- [x] New e2e case (`pod-metrics-server-missing.regex`) verified against the real cluster by temporarily deleting/recreating the metrics-server APIService object
- [x] Updated 3 existing e2e fixtures (`sts-with-ingress.pod`, `sts-with-nodeport.pod`, `pod-container-logs`) whose Running-phase pods render before metrics-server has scraped them, to account for the new "no metrics yet" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)