### PR TITLE
e2e: convert inline asserts to file-based fixture matching

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -916,7 +916,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}
 
 		cmdTest{
-			args:            []string{"node/" + nodeName, "--include-events=false", "--v", "5"},
+			args:            []string{"node/" + nodeName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/node-metrics-multi-namespace.regex",
 		}.assert(t, nil)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -538,14 +538,12 @@ func TestE2EDynamicManifests(t *testing.T) {
 		t.Logf("rollout status for %s: %s", name, output)
 		require.NoError(t, err)
 
-		stdout, _, err := executeCMD(t, []string{"deployment/" + name, "--include-rollout-diffs", "--include-events=false", "--v", "5"})
-		require.NoError(t, err)
 		// The order in which the two ReplicaSet revisions are diffed (and so which side
-		// gets "-" vs "+") isn't guaranteed, so just assert both images show up as changed
-		// lines rather than pinning down a direction.
-		assert.Contains(t, stdout, "Diff:")
-		assert.Regexp(t, `(?m)^\s*[-+]\s+"image": "nginx:1\.25",\s*$`, stdout)
-		assert.Regexp(t, `(?m)^\s*[-+]\s+"image": "nginx:1\.26",\s*$`, stdout)
+		// gets "-" vs "+") isn't guaranteed, so the fixture alternates both directions.
+		cmdTest{
+			args:            []string{"deployment/" + name, "--include-rollout-diffs", "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/rollout-diff.regex",
+		}.assert(t, nil)
 	})
 	t.Run("sts-with-ingress", func(t *testing.T) {
 		viperTestHack(t)
@@ -917,11 +915,10 @@ func TestE2EDynamicManifests(t *testing.T) {
 			waitForPodMetrics(t, ns, "e2e-metrics-pod")
 		}
 
-		stdout, _, err := executeCMD(t, []string{"node/" + nodeName, "--include-events=false", "--v", "5"})
-		require.NoError(t, err)
-		assert.Regexp(t, `(?m)^\s+pods:\s+usage/allocatable:\d+/`, stdout)
-		assert.Regexp(t, `(?m)^\s+cpu:\s+usage/allocatable:[\d.]+/[\d.]+\(\s*\d+%\)`, stdout)
-		assert.Regexp(t, `(?m)^\s+mem:\s+usage/allocatable:`, stdout)
+		cmdTest{
+			args:            []string{"node/" + nodeName, "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/node-metrics-multi-namespace.regex",
+		}.assert(t, nil)
 	})
 }
 

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -1,0 +1,26 @@
+\A
+Node/[a-z0-9.-]+, created \d+[a-z]+ ago
+  linux .+, kernel \S+, kubelet v[\d.]+, kube-proxy ?\S*
+  images \d+
+  Current: Resource is Ready
+  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for \d+[a-z]+
+  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for \d+[a-z]+
+  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for \d+[a-z]+
+  Ready KubeletReady, kubelet is posting ready status for \d+[a-z]+
+  addresses: InternalIP=[\d.]+ Hostname=[a-z0-9.-]+
+  allocatable: pods:\d+, cpu:\d+, mem:[\d.]+[A-Za-z]+, ephemeral-storage:[\d.]+[A-Za-z]+
+  capacity: pods:\d+, cpu:\d+, mem:[\d.]+[A-Za-z]+, ephemeral-storage:[\d.]+[A-Za-z]+
+  Inferred memory limits for BestEffort: [\d.]+[A-Za-z]+, for Burstable: [\d.]+[A-Za-z]+
+  pods: usage/allocatable:\d+/\d+\(\d+%\)
+  cpu: usage/allocatable:[\d.]+/\d+\(\d+%\), allocated usage:[\d.]+\(\d+% of allocatable\)/\[req:[\d.]+\(\d+% of allocatable\), lim:[\d.]+\(\d+% of allocatable\)\]
+  mem: usage/allocatable:[\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+\(\d+%\), allocated usage:[\d.]+[A-Za-z]+\(\d+% of allocatable\)/\[req:[\d.]+[A-Za-z]+\(\d+% of allocatable\), lim:[\d.]+[A-Za-z]+\(\d+% of allocatable\)\]
+  ephemeral-storage: [\d.]+[A-Za-z]+
+  kubelet-api/stats/summary:
+    node overall: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+, processes \S+/\S+ \(rlimit\)
+      network: rx/tx [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, rx/tx errors \d+/\d+
+      rootfs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free; \S+/\S+ inode, \S+ inode still free
+      imagefs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free; \S+/\S+ inode, \S+ inode still free
+    (?:pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
+    kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+|kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
+    pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+)
+  Known/recorded manage events:

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -23,4 +23,4 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
     (?:pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
     kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+|kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
     pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+)
-  Known/recorded manage events:
+\z

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -4,9 +4,8 @@ Deployment/rollout-diff-test -n default, created \d+[a-z]+ ago, gen:\d+ rev:\d+
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=rollout-diff-test
     Not matched by any Service
-    Pod/rollout-diff-test-7cf6c88cf8-[a-z0-9]+ -n default Running, 1/1 ready
-    Pod/rollout-diff-test-f96b445cf-[a-z0-9]+ -n default Running, 1/1 ready
-  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
+(?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+ -n default Running, 1/1 ready
+)+  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
   Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
   Rollouts:
     \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-7cf6c88cf8, has 1 replicas

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -1,0 +1,37 @@
+\A
+Deployment/rollout-diff-test -n default, created \d+[a-z]+ ago, gen:\d+ rev:\d+
+  Current: Deployment is available\. Replicas: 1
+  desired:1, existing:1, ready:1, updated:1, available:1
+  Selector: app=rollout-diff-test
+    Not matched by any Service
+    Pod/rollout-diff-test-7cf6c88cf8-[a-z0-9]+ -n default Running, 1/1 ready
+    Pod/rollout-diff-test-f96b445cf-[a-z0-9]+ -n default Running, 1/1 ready
+  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
+  Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
+  Rollouts:
+    \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-7cf6c88cf8, has 1 replicas
+    \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-f96b445cf
+      Diff:
+      (?:--- a ReplicaSet/rollout-diff-test-7cf6c88cf8\t\S.*\(\d+[a-z]+ ago\)
+      \+\+\+ b ReplicaSet/rollout-diff-test-f96b445cf\t\S.*\(\d+[a-z]+ ago\)
+      @@ -36,7 \+36,7 @@
+             "spec": \{
+               "containers": \[
+                 \{
+      -            "image": "nginx:1\.26",
+      \+            "image": "nginx:1\.25",|--- a ReplicaSet/rollout-diff-test-f96b445cf\t\S.*\(\d+[a-z]+ ago\)
+      \+\+\+ b ReplicaSet/rollout-diff-test-7cf6c88cf8\t\S.*\(\d+[a-z]+ ago\)
+      @@ -36,7 \+36,7 @@
+             "spec": \{
+               "containers": \[
+                 \{
+      -            "image": "nginx:1\.25",
+      \+            "image": "nginx:1\.26",)
+                   "imagePullPolicy": "IfNotPresent",
+                   "name": "nginx",
+                   "resources": \{\},
+      
+  Known/recorded manage events:
+    \d+[a-z]+ ago Updated by cmd\.test \(spec\)
+    \d+[a-z]+ ago Updated by kube-controller-manager \(metadata, status\)
+\z


### PR DESCRIPTION
## Summary
- Two e2e subtests (`deployment rollout --include-rollout-diffs` diff assertion, and `node` kubelet-api multi-namespace pod metrics) used inline `assert.Regexp`/`assert.Contains` against live command output instead of the repo's file-based `cmdTest` fixture pattern.
- Converted both to `cmdTest{stdoutRegexPath: ...}`, adding deterministic regex fixtures under `tests/e2e-artifacts/` that alternate over the known non-deterministic orderings (which ReplicaSet revision diffs as `-`/`+`, and `pods:`/`kubelet:` summary line order).
- Audited remaining `executeCMD`-based e2e subtests (TLS-validation) — already compliant since their primary assertions read from a fixture file.

Rationale: inline Go-level asserts make output-impact hard for reviewers to grasp in diffs; file-based fixtures keep that easy, at the cost of more upfront work to make the fixtures deterministic.

## Test plan
- [x] `go build ./...`
- [x] Full e2e suite run against isolated minikube cluster (`RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test -v ./... -run 'TestE2E' -timeout 20m`) — both converted tests pass; only unrelated pre-existing `etcdserver: request timed out` flake in an unrelated test (`pod-container-logs`, during cleanup, caused by concurrent minikube clusters on the host)