### PR TITLE
Surface NetworkPolicy selection when rendering a Pod

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -501,6 +502,49 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"rs/bad-rs", "--include-events=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-on-bad-node-for-rs.regex",
+		}.assert(t, nil)
+	})
+	t.Run("pod selected by a NetworkPolicy surfaces the compact isolation signal", func(t *testing.T) {
+		// A dedicated namespace keeps this test in control of exactly which NetworkPolicy
+		// objects exist -- an empty podSelector elsewhere in a shared namespace (e.g. "default")
+		// would also match this Pod and make the asserted policy name/count non-deterministic.
+		viperTestHack(t)
+		ns := "e2e-netpol-pod"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "netpol-selected-pod",
+				Namespace: ns,
+				Labels:    map[string]string{"app": "kubectl-status-test-netpol-target"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "busybox", Command: []string{"sleep", "infinity"}}},
+			},
+		}
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		netpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "deny-ingress-to-app", Namespace: ns},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "kubectl-status-test-netpol-target"}},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			},
+		}
+		_, err = clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), netpol, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), netpol.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args:            []string{"pod/netpol-selected-pod", "-n", ns, "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-selected-by-network-policy.regex",
 		}.assert(t, nil)
 	})
 	t.Run("deployment rollout with --include-rollout-diffs shows the diff between revisions", func(t *testing.T) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -547,6 +547,80 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/pod-selected-by-network-policy.regex",
 		}.assert(t, nil)
 	})
+	t.Run("pod selected by multiple NetworkPolicies lists all of them and unions both directions", func(t *testing.T) {
+		// Same isolation rationale as the single-policy case above, but with three policies that
+		// each cover only part of the picture -- a default-deny (both directions, no rules), an
+		// egress-only allow, and an ingress-only allow -- to exercise the union across matching
+		// policies (Kubernetes NetworkPolicy is additive/OR'd, never a single winning policy) and
+		// the multi-name/plural "NetworkPolicies" wording. Names are chosen to sort the same way
+		// alphabetically as they're created below: the underlying list (server-side, not an
+		// informer cache) comes back name-ordered, and creationTimestamp -- the only explicit
+		// sort key applied -- has second granularity, so objects created in the same second (as
+		// these three are) keep that name order rather than creation order.
+		viperTestHack(t)
+		ns := "e2e-netpol-multi-pod"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		podLabels := map[string]string{"app": "kubectl-status-test-netpol-multi-target"}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "netpol-multi-selected-pod",
+				Namespace: ns,
+				Labels:    podLabels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "busybox", Command: []string{"sleep", "infinity"}}},
+			},
+		}
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		defaultDeny := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "default-deny-both", Namespace: ns},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			},
+		}
+		_, err = clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), defaultDeny, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), defaultDeny.Name, metav1.DeleteOptions{})
+
+		egressOnly := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "egress-only", Namespace: ns},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+			},
+		}
+		_, err = clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), egressOnly, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), egressOnly.Name, metav1.DeleteOptions{})
+
+		ingressOnly := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "ingress-only", Namespace: ns},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: podLabels},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+			},
+		}
+		_, err = clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), ingressOnly, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), ingressOnly.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args:            []string{"pod/netpol-multi-selected-pod", "-n", ns, "--include-events=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-selected-by-multiple-network-policies.regex",
+		}.assert(t, nil)
+	})
 	t.Run("deployment rollout with --include-rollout-diffs shows the diff between revisions", func(t *testing.T) {
 		viperTestHack(t)
 		name := "rollout-diff-test"

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -542,6 +542,11 @@ func TestE2EDynamicManifests(t *testing.T) {
 		require.NoError(t, err)
 		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), netpol.Name, metav1.DeleteOptions{})
 
+		// The full-output regex fixture below pins the Pod to a Running/Ready state, so this
+		// must wait rather than race the kubelet -- otherwise the render can catch it Pending.
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+			"pod/netpol-selected-pod", "-n", ns, "--timeout=2m").Run())
+
 		cmdTest{
 			args:            []string{"pod/netpol-selected-pod", "-n", ns, "--include-events=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-selected-by-network-policy.regex",
@@ -615,6 +620,11 @@ func TestE2EDynamicManifests(t *testing.T) {
 		_, err = clientset.NetworkingV1().NetworkPolicies(ns).Create(context.TODO(), ingressOnly, metav1.CreateOptions{})
 		require.NoError(t, err)
 		defer clientset.NetworkingV1().NetworkPolicies(ns).Delete(context.TODO(), ingressOnly.Name, metav1.DeleteOptions{})
+
+		// The full-output regex fixture below pins the Pod to a Running/Ready state, so this
+		// must wait rather than race the kubelet -- otherwise the render can catch it Pending.
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+			"pod/netpol-multi-selected-pod", "-n", ns, "--timeout=2m").Run())
 
 		cmdTest{
 			args:            []string{"pod/netpol-multi-selected-pod", "-n", ns, "--include-events=false", "--v", "5"},

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -347,6 +347,39 @@ func (r RenderableObject) KubeGetEndpointSlicesForService(namespace, serviceName
 	return r.objectsToRenderableObjects(objects)
 }
 
+// KubeGetNetworkPoliciesMatchingPod returns all NetworkPolicies in namespace whose
+// spec.podSelector matches podLabels -- the mirror direction of KubeGetServicesMatchingPod: a
+// Service's selector is matched against a Pod's labels via endpoints, but a NetworkPolicy has no
+// reference back to the Pods it covers, so every policy in the Pod's namespace has to be listed
+// and its podSelector checked client-side. See networkPolicySelectsPod for the selector-matching
+// semantics.
+func (r RenderableObject) KubeGetNetworkPoliciesMatchingPod(namespace string, podLabels map[string]interface{}) (out []RenderableObject) {
+	out = make([]RenderableObject, 0)
+	if viper.GetBool("shallow") {
+		return
+	}
+	klog.V(5).InfoS("called KubeGetNetworkPoliciesMatchingPod", "r", r, "namespace", namespace, "podLabels", podLabels)
+	castedLabels := make(map[string]string, len(podLabels))
+	for k, v := range podLabels {
+		castedLabels[k] = fmt.Sprintf("%v", v)
+	}
+	policies, err := r.repo.Objects(namespace, []string{"networkpolicies"}, "")
+	if err != nil {
+		klog.V(3).ErrorS(err, "error listing networkpolicies", "r", r, "namespace", namespace)
+		return
+	}
+	for _, obj := range policies {
+		spec, found, err := unstructured.NestedMap(obj, "spec")
+		if err != nil || !found {
+			continue
+		}
+		if networkPolicySelectsPod(spec, castedLabels) {
+			out = append(out, r.newRenderableObject(obj))
+		}
+	}
+	return out
+}
+
 func doesServiceMatchLabels(svc corev1.Service, labels map[string]string) bool {
 	if svc.Spec.Type == "ExternalName" {
 		return false

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 	resource2 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 )
@@ -84,6 +85,7 @@ func funcMap() template.FuncMap {
 		"relativeTime":              relativeTime,
 		"labelSelector":             labelSelector,
 		"taintsNotToleratedByPod":   taintsNotToleratedByPod,
+		"networkPolicyPolicyTypes":  networkPolicyPolicyTypes,
 		"cronNextTime":              cronNextTime,
 		"withinLastHour":            withinLastHour,
 		"parseTLSSecretCertificate": parseTLSSecretCertificate,
@@ -539,6 +541,47 @@ func taintsNotToleratedByPod(nodeTaints, tolerations []interface{}) (result []in
 		}
 	}
 	return result
+}
+
+// networkPolicySelectsPod reports whether a NetworkPolicy's spec.podSelector matches podLabels.
+// podSelector is a full metav1.LabelSelector (matchLabels + matchExpressions), and an empty
+// selector ({} -- no matchLabels, no matchExpressions) matches every Pod in the policy's
+// namespace, per https://kubernetes.io/docs/concepts/services-networking/network-policies/ --
+// metav1.LabelSelectorAsSelector already returns labels.Everything() for that case, so this uses
+// real selector semantics rather than the isSubset helper (which is for a different direction of
+// matching, see KubeGetServicesMatchingPod).
+func networkPolicySelectsPod(policySpec map[string]interface{}, podLabels map[string]string) bool {
+	selMap, _ := policySpec["podSelector"].(map[string]interface{})
+	ls := &metav1.LabelSelector{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(selMap, ls); err != nil {
+		return false
+	}
+	sel, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		return false
+	}
+	return sel.Matches(labels.Set(podLabels))
+}
+
+// networkPolicyPolicyTypes normalizes NetworkPolicy spec.policyTypes, applying the documented
+// default used when the field is omitted: Ingress always applies, and Egress applies only when
+// the policy also defines an egress rule set. See
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#networkpolicyspec-v1-networking-k8s-io
+func networkPolicyPolicyTypes(spec map[string]interface{}) []string {
+	if rawTypes, ok := spec["policyTypes"].([]interface{}); ok && len(rawTypes) > 0 {
+		types := make([]string, 0, len(rawTypes))
+		for _, t := range rawTypes {
+			if s, ok := t.(string); ok {
+				types = append(types, s)
+			}
+		}
+		return types
+	}
+	types := []string{"Ingress"}
+	if _, hasEgress := spec["egress"]; hasEgress {
+		types = append(types, "Egress")
+	}
+	return types
 }
 
 // parseTLSSecretCertificate inspects a Secret expected to be type kubernetes.io/tls and

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -244,6 +244,97 @@ func TestTaintsNotToleratedByPod(t *testing.T) {
 	}
 }
 
+func TestNetworkPolicySelectsPod(t *testing.T) {
+	tests := []struct {
+		name      string
+		spec      map[string]interface{}
+		podLabels map[string]string
+		want      bool
+	}{
+		{
+			name:      "empty podSelector matches every pod",
+			spec:      map[string]interface{}{"podSelector": map[string]interface{}{}},
+			podLabels: map[string]string{"app": "foo"},
+			want:      true,
+		},
+		{
+			name: "matchLabels subset matches",
+			spec: map[string]interface{}{"podSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": "foo"},
+			}},
+			podLabels: map[string]string{"app": "foo", "tier": "backend"},
+			want:      true,
+		},
+		{
+			name: "matchLabels mismatch does not match",
+			spec: map[string]interface{}{"podSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"app": "bar"},
+			}},
+			podLabels: map[string]string{"app": "foo"},
+			want:      false,
+		},
+		{
+			name: "matchExpressions In matches",
+			spec: map[string]interface{}{"podSelector": map[string]interface{}{
+				"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "tier", "operator": "In", "values": []interface{}{"backend", "frontend"}},
+				},
+			}},
+			podLabels: map[string]string{"tier": "backend"},
+			want:      true,
+		},
+		{
+			name: "matchExpressions DoesNotExist fails when key present",
+			spec: map[string]interface{}{"podSelector": map[string]interface{}{
+				"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "tier", "operator": "DoesNotExist"},
+				},
+			}},
+			podLabels: map[string]string{"tier": "backend"},
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkPolicySelectsPod(tt.spec, tt.podLabels); got != tt.want {
+				t.Errorf("networkPolicySelectsPod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNetworkPolicyPolicyTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		spec map[string]interface{}
+		want []string
+	}{
+		{
+			name: "no policyTypes, no egress -- defaults to Ingress only",
+			spec: map[string]interface{}{},
+			want: []string{"Ingress"},
+		},
+		{
+			name: "no policyTypes, has egress -- defaults to Ingress and Egress",
+			spec: map[string]interface{}{"egress": []interface{}{map[string]interface{}{}}},
+			want: []string{"Ingress", "Egress"},
+		},
+		{
+			name: "explicit policyTypes is used as-is",
+			spec: map[string]interface{}{"policyTypes": []interface{}{"Egress"}},
+			want: []string{"Egress"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := networkPolicyPolicyTypes(tt.spec)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("networkPolicyPolicyTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAgoSuffix(t *testing.T) {
 	viper.Set("absolute-time", false)
 	if got := agoSuffix(); got != " ago" {

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -48,6 +48,7 @@
     {{- template "pod_volumes" . }}
     {{- template "matching_services" . }}
     {{- template "matching_pdbs" . }}
+    {{- template "matching_network_policies" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
@@ -348,6 +349,32 @@
                 {{- range $pdbs }}
                     {{- $.Include "pdb_health_summary" . | nindent 4 }}
                 {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_network_policies" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects the Pod RenderableObject. A NetworkPolicy doesn't reference the Pods it covers
+           -- its spec.podSelector is what does the matching -- so this lists every NetworkPolicy
+           in the Pod's namespace and checks which ones select this Pod's labels. Kubernetes
+           treats a Pod matched by any policy as "isolated" for that policy's direction
+           (Ingress/Egress) regardless of whether the policy's rules actually allow all traffic,
+           so this can only say the Pod is selected and which direction(s) are restricted, not
+           whether real traffic is blocked -- see network_policy_selection_summary in
+           common.tmpl. Full policy rules are only shown under --deep (falls back to
+           DefaultResource; there's no dedicated NetworkPolicy.tmpl). */ -}}
+    {{- if not ($.Config.GetBool "shallow") }}
+        {{- $policies := $.KubeGetNetworkPoliciesMatchingPod $.Namespace $.Labels }}
+        {{- if $policies }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- "NetworkPolicies:" | bold | nindent 2 }}
+                {{- range $policies }}
+                    {{- $.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "NetworkPolicy:" | bold | nindent 2 }} {{ $.Include "network_policy_selection_summary" $policies }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -227,6 +227,8 @@
     {{- if $total }}, {{ if lt $ready $total }}{{ printf "%d/%d" $ready $total | red | bold }}{{ else }}{{ printf "%d/%d" $ready $total | green }}{{ end }} ready{{ end }}
     {{- $nodeProblems := .Include "pod_node_problem_flags" . }}
     {{- with $nodeProblems }}, {{ . }}{{ end }}
+    {{- $netpolFlag := .Include "pod_network_policy_flags" . }}
+    {{- with $netpolFlag }}, {{ . }}{{ end }}
 {{- end }}
 
 {{- define "pod_node_problem_flags" }}
@@ -256,6 +258,50 @@
                 {{- $flags = append $flags ("untolerated node taint" | red | bold) }}
             {{- end }}
             {{- join ", " $flags }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "network_policy_selection_summary" }}
+    {{- /* Expects a non-empty slice of NetworkPolicy RenderableObjects that select a Pod. Returns
+           "selected by NetworkPolic{y,ies} X[, Y] (ingress/egress restricted)". A Pod matched by
+           any policy is "restricted" in that direction per the NetworkPolicy spec, regardless of
+           whether the policy's rules actually allow all traffic -- this can't say whether traffic
+           is really blocked, only that these policies are worth checking. */ -}}
+    {{- $names := list }}
+    {{- $ingress := false }}{{- $egress := false }}
+    {{- range . }}
+        {{- $names = append $names .Name }}
+        {{- $types := networkPolicyPolicyTypes .Spec }}
+        {{- if has "Ingress" $types }}{{ $ingress = true }}{{ end }}
+        {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
+    {{- end }}
+    {{- $directions := list }}
+    {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
+    {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
+    {{- $label := "NetworkPolicy" }}{{ if gt (len .) 1 }}{{ $label = "NetworkPolicies" }}{{ end }}
+    {{- printf "selected by %s %s (%s restricted)" $label (join ", " $names | cyan) (join ", " $directions) }}
+{{- end }}
+
+{{- define "pod_network_policy_flags" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects the Pod RenderableObject. Returns a compact inline fragment (no leading
+           separator) naming NetworkPolicy-restricted directions, or "" when no NetworkPolicy
+           selects this Pod. Used where a single-line-per-pod summary is needed; see
+           "matching_network_policies" in Pod.tmpl for the fuller per-policy render. */ -}}
+    {{- if not (.Config.GetBool "shallow") }}
+        {{- $policies := .KubeGetNetworkPoliciesMatchingPod .Namespace .Labels }}
+        {{- if $policies }}
+            {{- $ingress := false }}{{- $egress := false }}
+            {{- range $policies }}
+                {{- $types := networkPolicyPolicyTypes .Spec }}
+                {{- if has "Ingress" $types }}{{ $ingress = true }}{{ end }}
+                {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
+            {{- end }}
+            {{- $directions := list }}
+            {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
+            {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
+            {{- printf "netpol: %s restricted" (join "+" $directions) }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
+++ b/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
@@ -1,0 +1,1 @@
+NetworkPolicy: selected by NetworkPolicies default-deny-both, egress-only, ingress-only \(ingress, egress restricted\)

--- a/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
+++ b/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
@@ -1,1 +1,14 @@
-NetworkPolicy: selected by NetworkPolicies default-deny-both, egress-only, ingress-only \(ingress, egress restricted\)
+\A
+Pod/netpol-multi-selected-pod -n e2e-netpol-multi-pod, created 1m ago, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
+  Current: Pod is Ready
+  Managed by kubectl-status-test-netpol-multi-target application
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: app \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  NetworkPolicy: selected by NetworkPolicies default-deny-both, egress-only, ingress-only \(ingress, egress restricted\)
+  Known/recorded manage events:
+    1m ago Updated by cmd\.test \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z

--- a/tests/e2e-artifacts/pod-selected-by-network-policy.regex
+++ b/tests/e2e-artifacts/pod-selected-by-network-policy.regex
@@ -1,0 +1,1 @@
+NetworkPolicy: selected by NetworkPolicy deny-ingress-to-app \(ingress restricted\)

--- a/tests/e2e-artifacts/pod-selected-by-network-policy.regex
+++ b/tests/e2e-artifacts/pod-selected-by-network-policy.regex
@@ -1,1 +1,14 @@
-NetworkPolicy: selected by NetworkPolicy deny-ingress-to-app \(ingress restricted\)
+\A
+Pod/netpol-selected-pod -n e2e-netpol-pod, created 1m ago, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
+  Current: Pod is Ready
+  Managed by kubectl-status-test-netpol-target application
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: app \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
+  Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  NetworkPolicy: selected by NetworkPolicy deny-ingress-to-app \(ingress restricted\)
+  Known/recorded manage events:
+    1m ago Updated by cmd\.test \(metadata, spec\)
+    1m ago Updated by kubelet \(status\)
+\z


### PR DESCRIPTION
## Summary
- Surface a compact, opinionated signal on `Pod.tmpl` (and via `pod_health_summary`, so any workload's pod list carries it too) when a Pod is selected by one or more `NetworkPolicy` objects in its namespace: `selected by NetworkPolicy X (ingress restricted)` / `NetworkPolicies X, Y (ingress, egress restricted)`.
- Doesn't attempt full allow/deny rule evaluation — that needs CNI-dependent enforcement semantics not observable via the core API. The goal is pointing operators at the right objects to check, not a verdict.
- `--deep` inlines the full matched `NetworkPolicy` objects (via the existing `DefaultResource` fallback — no dedicated `NetworkPolicy.tmpl` needed).
- New pure Go helpers `networkPolicySelectsPod`/`networkPolicyPolicyTypes` use real `LabelSelectorAsSelector`/`.Matches` semantics (matchExpressions-aware) and the documented `policyTypes` default (Ingress implied; Egress only if the policy defines egress rules), unit-tested in `template_functions_static_test.go`.
- `KubeGetNetworkPoliciesMatchingPod` mirrors `KubeGetServicesMatchingPod` in the opposite direction, since a `NetworkPolicy` has no back-reference to the Pods it selects.

## Before/after
Before: nothing in `kubectl status pod/x` output hinted that a `NetworkPolicy` applied to the pod.

After:
```
Pod/demo-pod -n manual-netpol-test, created 12s ago, gen:1 Running BestEffort
  Current: Pod is Ready
  ...
  NetworkPolicy: selected by NetworkPolicy deny-ingress (ingress restricted)
```
And in a workload's pod list (e.g. `kubectl status deployment/demo-dep`):
```
    Pod/demo-dep-7789d5c48-f5k6m -n manual-netpol-test Running, 1/1 ready, netpol: ingress+egress restricted
```

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `gofmt -l` all clean
- [x] `go test ./...` (289 tests) passes, including new `TestNetworkPolicySelectsPod`/`TestNetworkPolicyPolicyTypes` unit tests
- [x] `make update-artifacts` produces no diffs (`--shallow`/`--local` make the new lookup a no-op, as expected)
- [x] New e2e subtest (`TestE2EDynamicManifests/pod_selected_by_a_NetworkPolicy_surfaces_the_compact_isolation_signal`) passes against a real minikube cluster
- [x] Full `TestE2EDynamicManifests` suite passes against the same cluster (no regressions)
- [x] Manually verified default, `--deep`, and workload-summary-flag rendering against a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)