### PR TITLE
Fix flaky pod-container-logs.regex: crasher's (logs: ...) suffix isn't guaranteed

### DIFF
--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -12,7 +12,7 @@ Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1, started after 1m R
         init-setup-log-line
     init-silent \(busybox:latest\) Started 1m ago and Completed after 1m, has no logs
   Containers:
-    crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_default\([0-9a-f-]+\), restarted [0-9]+ times \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+    crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_default\([0-9a-f-]+\), restarted [0-9]+ times(?: \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
       previously: Started 1m ago and Error after 1m with exit code exit with 1
       Last 20 lines of logs from previous instance \(restarted within last hour\):
         crasher-log-line


### PR DESCRIPTION
## Summary
- Both recent `ci-test` runs on master (`29093897332`, `29089815605`) fail in `TestE2EDynamicManifests/pod-container-logs`.
- `4c773f5` made the crasher container's `(logs: ...)` suffix mandatory in the regex fixture, assuming kubectl-status always renders log-fs stats regardless of container state. In practice kubelet's `/stats/summary` is scraped periodically, so a container that just flipped to `Waiting/CrashLoopBackOff` may not have log-fs-usage data cached yet when the test snapshots output — the test only waits for the `CrashLoopBackOff` reason, not for stats to catch up.
- This makes the suffix optional in the regex instead of mandatory, matching actual (non-deterministic) behavior.

## Test plan
- [x] `go test ./cmd/... -run TestE2ERegexFixturesAreAnchored -v` passes
- [ ] CI `ci-test` (full e2e) passes on this branch