### PR TITLE
Show matching Services, PDBs, NetworkPolicies and HPAs on workload templates

### DIFF
--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -47,6 +47,11 @@
     {{- end }}
     {{- template "finalizer_details_on_termination" . }}
     {{- template "application_details" . }}
+    {{- $jobTemplate := .Spec.jobTemplate | default dict }}
+    {{- $jobTemplateSpec := $jobTemplate.spec | default dict }}
+    {{- $podTemplate := $jobTemplateSpec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" false) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -6,6 +6,9 @@
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
     {{- template "selector_with_health_summary" . }}
+    {{- $podTemplate := .Spec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" true) }}
     {{- template "daemonset_replicas_status" . }}
     {{- template "conditions_summary" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -17,6 +17,9 @@
         {{- "Strategy" | bold | nindent 2 }}: {{ .type | yellow }}
     {{- end }}{{ end }}
     {{- template "selector_with_health_summary" . }}
+    {{- $podTemplate := .Spec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
     {{- template "conditions_summary" . }}
     {{- template "suspended" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -66,6 +66,9 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "conditions_summary" . }}
     {{- template "application_details" . }}
+    {{- $podTemplate := .Spec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" false) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -46,11 +46,11 @@
     {{- template "pod_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_ephemeral_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_volumes" . }}
-    {{- template "matching_services" . }}
-    {{- template "matching_pdbs" . }}
-    {{- template "matching_network_policies" . }}
-    {{- template "matching_cilium_network_policies" . }}
-    {{- template "matching_calico_network_policies" . }}
+    {{- template "matching_services" (dict "ctx" . "namespace" .Namespace "svcs" (.KubeGetServicesMatchingPod .Namespace .Name)) }}
+    {{- template "matching_pdbs" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
+    {{- template "matching_network_policies" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
+    {{- template "matching_cilium_network_policies" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
+    {{- template "matching_calico_network_policies" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
@@ -306,157 +306,6 @@
                 {{- if and $deep $pvc.Metadata }}
                     {{- $.Include "PersistentVolumeClaim" $pvc | nindent 6 }}
                 {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "matching_services" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $svcs := $.KubeGetServicesMatchingPod $.Namespace $.Name }}
-        {{- if $svcs }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "Services:" | bold | nindent 2 }}
-                {{- range $svcs }}
-                    {{- $.Include "Service" . | nindent 4 }}
-                {{- end }}
-            {{- else if eq (len $svcs) 1 }}
-                {{- "Services:" | bold | nindent 2 }} {{ $.Include "service_health_summary" (index $svcs 0) }}
-            {{- else }}
-                {{- "Services:" | bold | nindent 2 }}
-                {{- range $svcs }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "matching_pdbs" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $pdbs := $.KubeGetPodDisruptionBudgetsMatchingLabels $.Namespace $.Labels }}
-        {{- if $pdbs }}
-            {{- with $.Include "pdb_conflict_warning" $pdbs }}{{ . | nindent 2 }}{{ end }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
-                {{- range $pdbs }}
-                    {{- $.Include "PodDisruptionBudget" . | nindent 4 }}
-                {{- end }}
-            {{- else if eq (len $pdbs) 1 }}
-                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $.Include "pdb_health_summary" (index $pdbs 0) }}
-            {{- else }}
-                {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
-                {{- range $pdbs }}
-                    {{- $.Include "pdb_health_summary" . | nindent 4 }}
-                {{- end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "matching_network_policies" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects the Pod RenderableObject. A NetworkPolicy doesn't reference the Pods it covers
-           -- its spec.podSelector is what does the matching -- so this lists every NetworkPolicy
-           in the Pod's namespace and checks which ones select this Pod's labels. Kubernetes
-           treats a Pod matched by any policy as "isolated" for that policy's direction
-           (Ingress/Egress) regardless of whether the policy's rules actually allow all traffic,
-           so this can only say the Pod is selected and which direction(s) are restricted, not
-           whether real traffic is blocked -- see network_policy_selection_summary in
-           common.tmpl. Full policy rules are only shown under --deep (falls back to
-           DefaultResource; there's no dedicated NetworkPolicy.tmpl). */ -}}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $policies := $.KubeGetNetworkPoliciesMatchingPod $.Namespace $.Labels }}
-        {{- if $policies }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "NetworkPolicies:" | bold | nindent 2 }}
-                {{- range $policies }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- "NetworkPolicy:" | bold | nindent 2 }} {{ $.Include "network_policy_selection_summary" $policies }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "matching_cilium_network_policies" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects the Pod RenderableObject. Same "no back-reference, list and match client-side"
-           approach as matching_network_policies, extended to Cilium's own CRDs: CiliumNetworkPolicy
-           (namespaced, matched against Pods in the Pod's namespace) and
-           CiliumClusterwideNetworkPolicy (cluster-scoped, so it can select Pods across
-           namespaces). Both CRDs are optional -- only present when Cilium is the CNI -- and the
-           KubeGet* helpers already degrade to an empty result rather than erroring when the CRD
-           isn't registered. Only the compact endpointSelector-match + restricted-direction signal
-           is shown here, not Cilium's L3-L7/DNS rule content -- see
-           cilium_policy_selection_summary in common.tmpl. Full policy content is only shown
-           under --deep (falls back to DefaultResource; there's no dedicated
-           CiliumNetworkPolicy.tmpl). */ -}}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $cnp := $.KubeGetCiliumNetworkPoliciesMatchingPod $.Namespace $.Labels }}
-        {{- if $cnp }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "CiliumNetworkPolicies:" | bold | nindent 2 }}
-                {{- range $cnp }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- "CiliumNetworkPolicy:" | bold | nindent 2 }} {{ $.Include "cilium_policy_selection_summary" (dict "policies" $cnp "labels" $.Labels "kindSingular" "CiliumNetworkPolicy" "kindPlural" "CiliumNetworkPolicies") }}
-            {{- end }}
-        {{- end }}
-        {{- $ccnp := $.KubeGetCiliumClusterwideNetworkPoliciesMatchingPod $.Labels }}
-        {{- if $ccnp }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "CiliumClusterwideNetworkPolicies:" | bold | nindent 2 }}
-                {{- range $ccnp }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- "CiliumClusterwideNetworkPolicy:" | bold | nindent 2 }} {{ $.Include "cilium_policy_selection_summary" (dict "policies" $ccnp "labels" $.Labels "kindSingular" "CiliumClusterwideNetworkPolicy" "kindPlural" "CiliumClusterwideNetworkPolicies") }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- define "matching_calico_network_policies" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects the Pod RenderableObject. Same approach again for Calico's own NetworkPolicy
-           (namespaced -- served under crd.projectcalico.org/v1, a different API group than both
-           upstream networking.k8s.io/v1 NetworkPolicy and the projectcalico.org/v3 API
-           calicoctl/the Calico API server present, despite the identical kind name) and
-           GlobalNetworkPolicy (cluster-scoped, additionally gated by spec.namespaceSelector
-           against the Pod's namespace). Both CRDs are optional -- only present when Calico is the
-           CNI -- and degrade to an empty result when not registered, same as the Cilium/upstream
-           helpers. Calico's selector is its own boolean expression language, evaluated via
-           pkg/plugin/calicoselector -- see calicoPolicySelectsPod for why. This intentionally
-           doesn't attempt Calico's order/tier/deny-vs-allow resolution -- see
-           calico_policy_selection_summary in common.tmpl. Full policy content is only shown
-           under --deep (falls back to DefaultResource; there's no dedicated
-           NetworkPolicy.tmpl for the Calico kind). */ -}}
-    {{- if not ($.Config.GetBool "shallow") }}
-        {{- $np := $.KubeGetCalicoNetworkPoliciesMatchingPod $.Namespace $.Labels }}
-        {{- if $np }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "Calico NetworkPolicies:" | bold | nindent 2 }}
-                {{- range $np }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- "Calico NetworkPolicy:" | bold | nindent 2 }} {{ $.Include "calico_policy_selection_summary" (dict "policies" $np "kindSingular" "Calico NetworkPolicy" "kindPlural" "Calico NetworkPolicies") }}
-            {{- end }}
-        {{- end }}
-        {{- $gnp := $.KubeGetCalicoGlobalNetworkPoliciesMatchingPod $.Namespace $.Labels }}
-        {{- if $gnp }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- "Calico GlobalNetworkPolicies:" | bold | nindent 2 }}
-                {{- range $gnp }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
-            {{- else }}
-                {{- "Calico GlobalNetworkPolicy:" | bold | nindent 2 }} {{ $.Include "calico_policy_selection_summary" (dict "policies" $gnp "kindSingular" "Calico GlobalNetworkPolicy" "kindPlural" "Calico GlobalNetworkPolicies") }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/ReplicaSet.tmpl
@@ -6,6 +6,9 @@
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
     {{- template "selector_with_health_summary" . }}
+    {{- $podTemplate := .Spec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
     {{- /* Where there is no readyReplicas, STS doesn't have that fields at all,
            and apparantly the numbers are parsed as float 64, so used 0.0 rather then 0 */ -}}
     {{- $injectedStatus := .Status }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -6,6 +6,9 @@
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
     {{- template "selector_with_health_summary" . }}
+    {{- $podTemplate := .Spec.template | default dict }}
+    {{- $podMeta := $podTemplate.metadata | default dict }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
     {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -287,7 +287,7 @@
            leading separator) naming NetworkPolicy/CiliumNetworkPolicy/Calico-restricted
            directions, or "" when none of these select this Pod. Used where a
            single-line-per-pod summary is needed; see "matching_network_policies",
-           "matching_cilium_network_policies" and "matching_calico_network_policies" in Pod.tmpl
+           "matching_cilium_network_policies" and "matching_calico_network_policies" (this file)
            for the fuller per-policy render. */ -}}
     {{- if not (.Config.GetBool "shallow") }}
         {{- $flags := list }}
@@ -484,40 +484,243 @@
 
 {{- define "selector_with_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Renders the "Selector: ..." line plus the workload's own member Pods. Matched Services,
+           PodDisruptionBudgets, NetworkPolicies and HorizontalPodAutoscalers are a separate
+           concern -- see matching_workload_resources, called independently by the workload
+           templates that use this -- kept apart so this template can stay focused on "which Pods
+           does this selector cover" for kinds (like PodDisruptionBudget) that don't want the
+           full matching_workload_resources treatment. */ -}}
     {{- with .Spec.selector }}
         {{- "Selector" | bold | nindent 2 }}: {{ . | labelSelector | cyan }}
         {{- $matchLabels := .matchLabels }}
         {{- /* $matchLabels is nil when the selector uses only matchExpressions; passing nil to
              KubeGetByLabelsMap builds an empty selector and matches every pod in the namespace. */ -}}
         {{- if and $matchLabels (not ($.Config.GetBool "shallow")) }}
-            {{- $svcs := $.KubeGetServicesMatchingLabels $.Namespace $matchLabels }}
-            {{- if and (not $svcs) (not ($.Config.GetBool "local")) }}
-                {{- "Not matched by any Service" | yellow | bold | nindent 4 }}
-            {{- end }}
-            {{- $pdbs := $.KubeGetPodDisruptionBudgetsMatchingLabels $.Namespace $matchLabels }}
-            {{- with $.Include "pdb_conflict_warning" $pdbs }}{{ . | nindent 4 }}{{ end }}
             {{- if $.Config.GetBool "deep" }}
                 {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
                     {{- $.IncludeRenderableObject . | nindent 4 }}
                 {{- end }}
-                {{- range $pdbs }}
-                    {{- $.IncludeRenderableObject . | nindent 4 }}
-                {{- end }}
             {{- else }}
-                {{- range $svcs }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
-                {{- end }}
                 {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
                     {{- $.Include "pod_health_summary" . | nindent 4 }}
                 {{- end }}
-                {{- $rolloutInProgress := false }}
-                {{- with $.RolloutStatus $ }}{{ if not .done }}{{ $rolloutInProgress = true }}{{ end }}{{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_services" }}
+    {{- /* Expects dict "ctx" (RenderableObject used for Include/Config) "svcs" ([]RenderableObject,
+           already resolved by the caller since Pods and workloads find their Services
+           differently: a Pod is matched by actual EndpointSlice membership
+           (KubeGetServicesMatchingPod), a workload's Pods aren't named yet so it's matched by
+           selector-subset against its Pod template labels (KubeGetServicesMatchingLabels)). */ -}}
+    {{- $ctx := .ctx }}
+    {{- with .svcs }}
+        {{- if $ctx.Config.GetBool "deep" }}
+            {{- "Services:" | bold | nindent 2 }}
+            {{- range . }}
+                {{- $ctx.Include "Service" . | nindent 4 }}
+            {{- end }}
+        {{- else if eq (len .) 1 }}
+            {{- "Services:" | bold | nindent 2 }} {{ $ctx.Include "service_health_summary" (index . 0) }}
+        {{- else }}
+            {{- "Services:" | bold | nindent 2 }}
+            {{- range . }}
+                {{- $ctx.Include "service_health_summary" . | nindent 4 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_pdbs" }}
+    {{- /* Expects dict "ctx" (RenderableObject) "namespace" "labels" (the labels of the Pods
+           this workload/Pod produces). */ -}}
+    {{- $ctx := .ctx }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $pdbs := $ctx.KubeGetPodDisruptionBudgetsMatchingLabels .namespace .labels }}
+        {{- if $pdbs }}
+            {{- with $ctx.Include "pdb_conflict_warning" $pdbs }}{{ . | nindent 2 }}{{ end }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
                 {{- range $pdbs }}
-                    {{- $.Include "pdb_health_summary" . | nindent 4 }}
-                    {{- if $rolloutInProgress }} {{ "(rollout in progress)" | yellow }}{{ end }}
+                    {{- $ctx.Include "PodDisruptionBudget" . | nindent 4 }}
+                {{- end }}
+            {{- else if eq (len $pdbs) 1 }}
+                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $ctx.Include "pdb_health_summary" (index $pdbs 0) }}
+            {{- else }}
+                {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
+                {{- range $pdbs }}
+                    {{- $ctx.Include "pdb_health_summary" . | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_network_policies" }}
+    {{- /* Expects dict "ctx" (RenderableObject used for Include/Config/fetches) "namespace"
+           "labels" (the labels of the Pods this workload/Pod produces). Generic sibling of the
+           Pod-only Kube* helpers this calls -- despite the "Pod" in their Go names they only take
+           a plain label map, nothing Pod-specific -- so this renders the same
+           "NetworkPolicies matched" block for any workload's Pod template labels, not just an
+           actual Pod. See network_policy_selection_summary for the compact form used here. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $policies := $ctx.KubeGetNetworkPoliciesMatchingPod .namespace .labels }}
+        {{- if $policies }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "NetworkPolicies:" | bold | nindent 2 }}
+                {{- range $policies }}
+                    {{- $ctx.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "NetworkPolicy:" | bold | nindent 2 }} {{ $ctx.Include "network_policy_selection_summary" $policies }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_cilium_network_policies" }}
+    {{- /* Expects dict "ctx" "namespace" "labels", see matching_network_policies. Covers Cilium's
+           namespaced CiliumNetworkPolicy and cluster-scoped CiliumClusterwideNetworkPolicy CRDs;
+           both degrade to an empty result when Cilium isn't the CNI. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $cnp := $ctx.KubeGetCiliumNetworkPoliciesMatchingPod .namespace .labels }}
+        {{- if $cnp }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "CiliumNetworkPolicies:" | bold | nindent 2 }}
+                {{- range $cnp }}
+                    {{- $ctx.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "CiliumNetworkPolicy:" | bold | nindent 2 }} {{ $ctx.Include "cilium_policy_selection_summary" (dict "policies" $cnp "labels" .labels "kindSingular" "CiliumNetworkPolicy" "kindPlural" "CiliumNetworkPolicies") }}
+            {{- end }}
+        {{- end }}
+        {{- $ccnp := $ctx.KubeGetCiliumClusterwideNetworkPoliciesMatchingPod .labels }}
+        {{- if $ccnp }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "CiliumClusterwideNetworkPolicies:" | bold | nindent 2 }}
+                {{- range $ccnp }}
+                    {{- $ctx.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "CiliumClusterwideNetworkPolicy:" | bold | nindent 2 }} {{ $ctx.Include "cilium_policy_selection_summary" (dict "policies" $ccnp "labels" .labels "kindSingular" "CiliumClusterwideNetworkPolicy" "kindPlural" "CiliumClusterwideNetworkPolicies") }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_calico_network_policies" }}
+    {{- /* Expects dict "ctx" "namespace" "labels", see matching_network_policies. Covers Calico's
+           namespaced NetworkPolicy (crd.projectcalico.org/v1) and cluster-scoped
+           GlobalNetworkPolicy CRDs; both degrade to an empty result when Calico isn't the CNI. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $np := $ctx.KubeGetCalicoNetworkPoliciesMatchingPod .namespace .labels }}
+        {{- if $np }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "Calico NetworkPolicies:" | bold | nindent 2 }}
+                {{- range $np }}
+                    {{- $ctx.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "Calico NetworkPolicy:" | bold | nindent 2 }} {{ $ctx.Include "calico_policy_selection_summary" (dict "policies" $np "kindSingular" "Calico NetworkPolicy" "kindPlural" "Calico NetworkPolicies") }}
+            {{- end }}
+        {{- end }}
+        {{- $gnp := $ctx.KubeGetCalicoGlobalNetworkPoliciesMatchingPod .namespace .labels }}
+        {{- if $gnp }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "Calico GlobalNetworkPolicies:" | bold | nindent 2 }}
+                {{- range $gnp }}
+                    {{- $ctx.IncludeRenderableObject . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- "Calico GlobalNetworkPolicy:" | bold | nindent 2 }} {{ $ctx.Include "calico_policy_selection_summary" (dict "policies" $gnp "kindSingular" "Calico GlobalNetworkPolicy" "kindPlural" "Calico GlobalNetworkPolicies") }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "hpa_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
+    {{- $minReplicas := 1 }}{{- if hasKey .Spec "minReplicas" }}{{- $minReplicas = .Spec.minReplicas | int }}{{- end }}
+    {{- $current := .Status.currentReplicas | default 0 | int }}
+    {{- $desired := .Status.desiredReplicas | default 0 | int }}
+    {{- printf ", %d" $current | redBoldIf (ne $current $desired) }}/{{ printf "%d-%d" $minReplicas (.Spec.maxReplicas | int) }}
+    {{- if ne $current $desired }}, {{ "desired" | yellow | bold }}: {{ printf "%d" $desired | yellow }}{{ end }}
+{{- end -}}
+
+{{- define "matching_hpas" }}
+    {{- /* Expects dict "ctx" (RenderableObject) "namespace" "kind" "name" (this workload's own
+           identity). HorizontalPodAutoscaler doesn't get discovered via labels -- it names its
+           target directly in spec.scaleTargetRef -- so unlike the other matching_* templates
+           this lists every HPA in the namespace and keeps the ones whose scaleTargetRef points
+           back at this workload, mirroring how recent_deployment_rollouts finds a Deployment's
+           ReplicaSets. Only Deployment/StatefulSet/ReplicaSet (and CRDs with a /scale
+           subresource) can be scaleTargetRef targets; callers should only invoke this for kinds
+           that can actually be autoscaled. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $namespace := .namespace }}
+    {{- $kind := .kind }}
+    {{- $name := .name }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $hpas := list }}
+        {{- range $ctx.KubeGet $namespace "HorizontalPodAutoscalers" }}
+            {{- $ref := .Spec.scaleTargetRef | default dict }}
+            {{- if and (eq (index $ref "kind" | default "") $kind) (eq (index $ref "name" | default "") $name) }}
+                {{- $hpas = append $hpas . }}
+            {{- end }}
+        {{- end }}
+        {{- if $hpas }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "HorizontalPodAutoscalers:" | bold | nindent 2 }}
+                {{- range $hpas }}
+                    {{- $ctx.Include "HorizontalPodAutoscaler" . | nindent 4 }}
+                {{- end }}
+            {{- else if eq (len $hpas) 1 }}
+                {{- "HorizontalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "hpa_health_summary" (index $hpas 0) }}
+            {{- else }}
+                {{- "HorizontalPodAutoscalers:" | bold | nindent 2 }}
+                {{- range $hpas }}
+                    {{- $ctx.Include "hpa_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "matching_workload_resources" }}
+    {{- /* Expects dict "ctx" (the workload's own RenderableObject: Deployment/StatefulSet/
+           DaemonSet/ReplicaSet/Job/CronJob) "namespace" "labels" (this workload's Pod template
+           labels, already resolved by the caller since the field path to reach them differs per
+           kind -- e.g. CronJob nests an extra .spec.template under .spec.jobTemplate) "scalable"
+           (bool, whether HorizontalPodAutoscaler can target this kind -- only Deployment/
+           StatefulSet/ReplicaSet expose a /scale subresource) "serviceExpected" (bool, whether to
+           warn when no Service matches -- Job/CronJob Pods aren't normally service-fronted, so
+           that warning would just be noise for those kinds). Renders the same set of matched
+           resources Pod.tmpl shows for a single Pod -- Services, PodDisruptionBudgets,
+           NetworkPolicy family -- using $labels (selector-subset matched, mirroring how a
+           Service would select this workload's Pods), plus any HorizontalPodAutoscaler that
+           targets $namespace/$.ctx.Name when $scalable. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $namespace := .namespace }}
+    {{- $serviceExpected := .serviceExpected }}
+    {{- with .labels }}
+        {{- $svcs := $ctx.KubeGetServicesMatchingLabels $namespace . }}
+        {{- if and $serviceExpected (not $svcs) (not ($ctx.Config.GetBool "local")) (not ($ctx.Config.GetBool "shallow")) }}
+            {{- "Not matched by any Service" | yellow | bold | nindent 2 }}
+        {{- end }}
+        {{- template "matching_services" (dict "ctx" $ctx "namespace" $namespace "svcs" $svcs) }}
+        {{- template "matching_pdbs" (dict "ctx" $ctx "namespace" $namespace "labels" .) }}
+        {{- template "matching_network_policies" (dict "ctx" $ctx "namespace" $namespace "labels" .) }}
+        {{- template "matching_cilium_network_policies" (dict "ctx" $ctx "namespace" $namespace "labels" .) }}
+        {{- template "matching_calico_network_policies" (dict "ctx" $ctx "namespace" $namespace "labels" .) }}
+    {{- end }}
+    {{- if .scalable }}
+        {{- template "matching_hpas" (dict "ctx" $ctx "namespace" $namespace "kind" $ctx.Kind "name" $ctx.Name) }}
     {{- end }}
 {{- end }}
 

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -5,6 +5,7 @@ Deployment/rollout-diff-test -n default, created \d+[a-z]+ ago, gen:\d+ rev:\d+
   Selector: app=rollout-diff-test
 (?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+ -n default, created \d+[a-z]+ ago Running, 1/1 ready
 )+  Not matched by any Service
+  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
   Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
   Rollouts:
     \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-f96b445cf

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -3,9 +3,8 @@ Deployment/rollout-diff-test -n default, created \d+[a-z]+ ago, gen:\d+ rev:\d+
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=rollout-diff-test
-    Not matched by any Service
 (?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+ -n default, created \d+[a-z]+ ago Running, 1/1 ready
-)+  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
+)+  Not matched by any Service
   Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
   Rollouts:
     \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-f96b445cf

--- a/tests/e2e-artifacts/rollouts-single-blocked-daemonset.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-daemonset.regex
@@ -3,8 +3,8 @@ DaemonSet/e2e-rollouts-blocked-daemonset -n default, created 1m ago, gen:1
   InProgress: Available: 0/1
     Reconciling: LessAvailable, Available: 0/1
   Selector: app=e2e-rollouts-blocked-daemonset
-    Not matched by any Service
     Pod/e2e-rollouts-blocked-daemonset-[a-z0-9]+ -n default, created 1m ago Pending, 0/1 ready
+  Not matched by any Service
   desired:1, current:1, ready:0, updated:1
   Ongoing Rollout: Waiting for daemon set "e2e-rollouts-blocked-daemonset" rollout to finish: 0 of 1 updated pods are available\.\.\.
   Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!

--- a/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
@@ -4,8 +4,8 @@ Deployment/e2e-rollouts-blocked-deployment -n default, created 1m ago, gen:1 rev
     Reconciling: LessAvailable, Available: 0/1
   desired:1, existing:1, ready:0, updated:1, available:0, unavailable:1
   Selector: app=e2e-rollouts-blocked-deployment
-    Not matched by any Service
     Pod/e2e-rollouts-blocked-deployment-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Pending, 0/1 ready
+  Not matched by any Service
   Available MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
   Progressing ReplicaSetUpdated, ReplicaSet "e2e-rollouts-blocked-deployment-[a-z0-9]+" is progressing\. for 1m
   Ongoing Rollout: Waiting for deployment "e2e-rollouts-blocked-deployment" rollout to finish: 0 of 1 updated replicas are available\.\.\.

--- a/tests/e2e-artifacts/rollouts-single-blocked-statefulset.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-statefulset.regex
@@ -3,8 +3,8 @@ StatefulSet/e2e-rollouts-blocked-statefulset -n default, created 1m ago, gen:1
   InProgress: Ready: 0/1
     Reconciling: LessReady, Ready: 0/1
   Selector: app=e2e-rollouts-blocked-statefulset
-    Not matched by any Service
     Pod/e2e-rollouts-blocked-statefulset-0 -n default, created 1m ago Pending, 0/1 ready
+  Not matched by any Service
   desired:1, existing:1, ready:0, current:1, updated:1, available:0
   Outage: StatefulSet has no Ready replicas\.
   Stuck Initial Rollout\? First rollout not yet progressed\.

--- a/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
@@ -3,8 +3,8 @@ Deployment/e2e-rollouts-healthy-deployment -n default, created 1m ago, gen:1 rev
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=e2e-rollouts-healthy-deployment
-    Not matched by any Service
     Pod/e2e-rollouts-healthy-deployment-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready
+  Not matched by any Service
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
   Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-healthy-deployment-[a-z0-9]+" has successfully progressed\. for 1m
 \z

--- a/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
+++ b/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
@@ -3,8 +3,8 @@ Deployment/e2e-rollouts-three-revisions -n default, created 1m ago, gen:3 rev:3
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=e2e-rollouts-three-revisions
-    Not matched by any Service
     Pod/e2e-rollouts-three-revisions-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready
+  Not matched by any Service
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
   Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-three-revisions-[a-z0-9]+" has successfully progressed\. for 1m
   Rollouts:

--- a/tests/e2e-artifacts/sts-with-nodeport.sts.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.sts.regex
@@ -1,4 +1,4 @@
   Selector: app=sts-with-nodeport
-    Service/sts-with-nodeport -n default, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
     Pod/sts-with-nodeport-0 -n default, created 1m ago Running, 1/1 ready
-    PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, min available=1, evictions/drains currently blocked
+  Services: Service/sts-with-nodeport -n default, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
+  PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, min available=1, evictions/drains currently blocked

--- a/tests/e2e-artifacts/sts-without-service.regex
+++ b/tests/e2e-artifacts/sts-without-service.regex
@@ -2,7 +2,7 @@
 StatefulSet/sts-without-service -n default, created 1m ago, gen:1
   Current: Partition rollout complete\. updated: 1
   Selector: app=sts-without-service
-    Not matched by any Service
     Pod/sts-without-service-0 -n default, created 1m ago Running, 1/1 ready
+  Not matched by any Service
   desired:1, existing:1, ready:1, current:1, updated:1, available:1
 \z


### PR DESCRIPTION
## Summary
- Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob now surface the same matched-resource set Pod.tmpl already showed for a single Pod: Services, PodDisruptionBudgets, the NetworkPolicy/CiliumNetworkPolicy/CiliumClusterwideNetworkPolicy/Calico(Global)NetworkPolicy family, and (new) HorizontalPodAutoscaler via reverse `scaleTargetRef` matching.
- These are now shared, reusable `common.tmpl` templates (`matching_services`, `matching_pdbs`, `matching_network_policies` + Cilium/Calico variants, `matching_hpas`, bundled by `matching_workload_resources`) instead of Pod-only logic duplicated per workload kind. Pod.tmpl itself now calls the same shared templates.
- `selector_with_health_summary` was narrowed to just the `Selector:` line + member-pod listing; matched Services/PDBs moved into the shared `matching_workload_resources` block for a consistent rendering style across all workload kinds.
- Job/CronJob source their Pod labels from the Pod template (`.Spec.template`/`.Spec.jobTemplate.spec.template`), not `.Spec.selector`, since Job's selector is an auto-generated `controller-uid` and CronJob has no selector at all. They're also excluded from the "Not matched by any Service" warning and HPA matching, since those kinds aren't service-fronted or scale-subresource targets.
- Known minor tradeoff: the `(rollout in progress)` annotation previously shown next to a PDB line during an ongoing Deployment/StatefulSet rollout is dropped, since it was specific to the old inline rendering and doesn't carry over cleanly into the shared `matching_pdbs` template.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` all pass
- [x] Manually verified live output against a local minikube cluster for Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob with real Services, PDBs, NetworkPolicies and HPAs attached, in both default and `--deep` mode
- [x] Full `TestE2EDynamicManifests` e2e suite run against live minikube; updated regex fixtures (`rollout-diff`, `rollouts-single-blocked-*`, `rollouts-single-healthy-deployment`, `rollouts-three-revisions-with-diffs`, `sts-with-nodeport.sts`, `sts-without-service`) to match the new output layout — all pass. Remaining failures in that run are pre-existing environmental gaps in this dev cluster (missing metrics-server, Gateway API CRDs, cert-manager CRDs), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)