### PR TITLE
Add VerticalPodAutoscaler support with HPA-style workload reverse-matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,15 @@ install-e2e-deps:
 	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
 	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
 	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/crds.yaml
+	# VerticalPodAutoscaler: unlike the CRD-only entries above, e2e scenarios exercise it
+	# actually acting (the updater evicting/recreating a Pod to apply a recommendation), so its
+	# controllers (recommender/updater/admission-controller) need to run for real, not just the
+	# CRDs. The upstream project has no plain `kubectl apply` release bundle (its install script
+	# generates webhook certs locally), so this uses the cowboysysop community Helm chart instead.
+	helm repo add cowboysysop https://cowboysysop.github.io/charts/
+	helm repo update cowboysysop
+	$(E2E_KUBECONFIG_ENV) helm upgrade --install vpa cowboysysop/vertical-pod-autoscaler --version 11.1.1 -n kube-system --wait --timeout 5m
+	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Available --timeout=120s deployment -l app.kubernetes.io/instance=vpa -n kube-system
 
 .PHONY: test-e2e
 ifeq ($(ASSUME_MINIKUBE_IS_CONFIGURED),true)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -20,6 +20,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1428,6 +1429,91 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/pod-metrics-server-missing.regex",
 		}.assert(t, nil)
 	})
+	t.Run("VerticalPodAutoscaler reverse-matches its target workload and shows an applied recommendation", func(t *testing.T) {
+		// Unlike the CRD-only e2e scenarios above, this needs the real VPA controllers
+		// (recommender/updater, installed by `make install-e2e-deps` via Helm) to actually
+		// compute and apply a recommendation -- the point is to exercise VPA "acting" (evicting
+		// and recreating the Pod), not just render a static object. The container burns real CPU
+		// against a deliberately low initial request so the recommender has a reason to raise it.
+		viperTestHack(t)
+		ns := "e2e-vpa"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		name := "vpa-burner"
+		one := int32(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &one,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name:    "burner",
+						Image:   "busybox",
+						Command: []string{"sh", "-c", "yes > /dev/null"},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10m"),
+								corev1.ResourceMemory: resource.MustParse("16Mi"),
+							},
+						},
+					}}},
+				},
+			},
+		}
+		_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Available",
+			"deployment/"+name, "-n", ns, "--timeout=2m").Run())
+		originalPod := waitForPodByLabel(t, ns, "app="+name)
+
+		vpaGVR := schema.GroupVersionResource{Group: "autoscaling.k8s.io", Version: "v1", Resource: "verticalpodautoscalers"}
+		vpa := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "autoscaling.k8s.io/v1",
+			"kind":       "VerticalPodAutoscaler",
+			"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+			"spec": map[string]interface{}{
+				"targetRef": map[string]interface{}{"apiVersion": "apps/v1", "kind": "Deployment", "name": name},
+				"updatePolicy": map[string]interface{}{
+					"updateMode":  "Recreate",
+					"minReplicas": int64(1),
+				},
+				"resourcePolicy": map[string]interface{}{
+					"containerPolicies": []interface{}{
+						map[string]interface{}{
+							"containerName": "burner",
+							"minAllowed":    map[string]interface{}{"cpu": "10m", "memory": "16Mi"},
+							"maxAllowed":    map[string]interface{}{"cpu": "500m", "memory": "128Mi"},
+						},
+					},
+				},
+			},
+		}}
+		_, err = dynamicClient.Resource(vpaGVR).Namespace(ns).Create(context.TODO(), vpa, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer dynamicClient.Resource(vpaGVR).Namespace(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+
+		waitForVPARecommendation(t, ns, name)
+		waitForPodRecreated(t, ns, "app="+name, originalPod)
+		// The evicted Pod can briefly still be listed (Terminating) alongside the replacement --
+		// wait for exactly one to remain so the fixture below can pin a single Pod line.
+		waitForSinglePod(t, ns, "app="+name)
+
+		cmdTest{
+			args:            []string{"deployment/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/vpa-workload-reverse-match.regex",
+		}.assert(t, nil)
+		cmdTest{
+			args:            []string{"vpa/" + name, "-n", ns, "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/vpa-standalone.regex",
+		}.assert(t, nil)
+	})
 }
 
 func applyManifest(t *testing.T, filepath string) {
@@ -1558,4 +1644,45 @@ func waitForMetricsAPIServiceAvailable(t *testing.T) {
 		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("timed out waiting for metrics-server APIService to become Available again")
+}
+
+// waitForVPARecommendation polls until a VerticalPodAutoscaler's status.recommendation is
+// populated. The recommender needs a window of real usage samples before it computes a first
+// recommendation, so this can take roughly a minute after the VPA and its target Pod both exist.
+func waitForVPARecommendation(t *testing.T, namespace, name string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		output, err := exec.Command("kubectl", "get", "vpa", name, "-n", namespace,
+			"-o", "jsonpath={.status.recommendation.containerRecommendations[0].target.cpu}").CombinedOutput()
+		if err == nil && strings.TrimSpace(string(output)) != "" {
+			t.Logf("VPA %s/%s has a recommendation: %s", namespace, name, strings.TrimSpace(string(output)))
+			return
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("timed out waiting for VPA %s/%s to compute a recommendation", namespace, name)
+}
+
+// waitForPodRecreated polls until the Pod matching labelSelector is no longer originalPodName --
+// evidence the VPA updater actually evicted/recreated it to apply the recommendation, not just
+// computed one that nobody applied.
+func waitForPodRecreated(t *testing.T, namespace, labelSelector, originalPodName string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		output, err := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+			"-o", "jsonpath={.items[*].metadata.name}").CombinedOutput()
+		if err == nil {
+			for _, name := range strings.Fields(string(output)) {
+				if name != originalPodName {
+					t.Logf("VPA updater recreated the pod: %s -> %s", originalPodName, name)
+					return
+				}
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("timed out waiting for pod matching %s in namespace %s to be recreated (still %s)",
+		labelSelector, namespace, originalPodName)
 }

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -79,6 +80,8 @@ func funcMap() template.FuncMap {
 		"humanizeSI":                humanizeSI,
 		"getMatchingItemInMapList":  getMatchingItemInMapList,
 		"sortMapListByKeysValue":    sortMapListByKeysValue,
+		"sortByRevisionAnnotation":  sortByRevisionAnnotation,
+		"sortByRevisionField":       sortByRevisionField,
 		"addFloat64":                addFloat64,
 		"subFloat64":                subFloat64,
 		"divFloat64":                divFloat64,
@@ -246,6 +249,49 @@ func sortMapListByKeysValue(key string, mapList []interface{}) (result []interfa
 		return typedMapListItemI < typedMapListItemJ
 	})
 	return
+}
+
+// sortByRevisionAnnotation returns a sorted copy of objs (RenderableObject ReplicaSets, passed as
+// []interface{} since that's what the "list"/"append" template builtins produce) ordered by their
+// "deployment.kubernetes.io/revision" annotation, ascending. Unlike creationTimestamp (which only
+// has second resolution, so ReplicaSets created within the same rollout can tie), the revision
+// annotation is a reliable total order for a Deployment's ReplicaSets.
+func sortByRevisionAnnotation(objs []interface{}) []interface{} {
+	result := append([]interface{}{}, objs...)
+	sort.SliceStable(result, func(i, j int) bool {
+		return revisionAnnotationInt(result[i]) < revisionAnnotationInt(result[j])
+	})
+	return result
+}
+
+func revisionAnnotationInt(obj interface{}) int {
+	r, ok := obj.(RenderableObject)
+	if !ok {
+		return 0
+	}
+	v, _ := r.Annotations()["deployment.kubernetes.io/revision"].(string)
+	n, _ := strconv.Atoi(v)
+	return n
+}
+
+// sortByRevisionField returns a sorted copy of objs (ControllerRevisions) ordered by their
+// numeric top-level "revision" field, ascending, for the same tie-breaking reason as
+// sortByRevisionAnnotation.
+func sortByRevisionField(objs []interface{}) []interface{} {
+	result := append([]interface{}{}, objs...)
+	sort.SliceStable(result, func(i, j int) bool {
+		return revisionFieldInt(result[i]) < revisionFieldInt(result[j])
+	})
+	return result
+}
+
+func revisionFieldInt(obj interface{}) int {
+	r, ok := obj.(RenderableObject)
+	if !ok {
+		return 0
+	}
+	n, _ := cast.ToIntE(r.Object["revision"])
+	return n
 }
 
 func isStatusConditionHealthy(condition map[string]interface{}) bool {

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -51,7 +51,7 @@
     {{- $jobTemplateSpec := $jobTemplate.spec | default dict }}
     {{- $podTemplate := $jobTemplateSpec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" false) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" false "serviceExpected" false) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -46,6 +46,9 @@
             {{- $revisions = append $revisions . }}
         {{- end }}
     {{- end }}
+    {{- /* creationTimestamp only has second resolution, so ControllerRevisions created within the
+          same rollout can tie; sort by the numeric revision field for a reliable order. */ -}}
+    {{- $revisions = sortByRevisionField $revisions }}
     {{- $rolloutStatus := .RolloutStatus . }}
     {{- $rolloutProblem := or (not $rolloutStatus.done) (ne (.Status.desiredNumberScheduled | default 0 | int) (.Status.numberReady | default 0 | int)) (ne (.Status.desiredNumberScheduled | default 0 | int) (.Status.updatedNumberScheduled | default 0 | int)) (ne (.Status.numberMisscheduled | default 0 | int) 0) }}
     {{- if or (gt (len $revisions) 1) (and (eq (len $revisions) 1) $rolloutProblem) }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -8,7 +8,7 @@
     {{- template "selector_with_health_summary" . }}
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" true) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" true "serviceExpected" true) }}
     {{- template "daemonset_replicas_status" . }}
     {{- template "conditions_summary" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -19,7 +19,7 @@
     {{- template "selector_with_health_summary" . }}
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "vpaTargetable" true "serviceExpected" true) }}
     {{- template "conditions_summary" . }}
     {{- template "suspended" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -58,6 +58,9 @@
             {{- $replicaSets = append $replicaSets . }}
         {{- end }}
     {{- end }}
+    {{- /* creationTimestamp only has second resolution, so ReplicaSets created within the same
+          rollout can tie; sort by revision annotation for a reliable chronological order. */ -}}
+    {{- $replicaSets = sortByRevisionAnnotation $replicaSets }}
     {{- $rolloutStatus := .RolloutStatus . }}
     {{- $rolloutProblem := or (not $rolloutStatus.done) (ne (.Status.replicas | default 0 | int) (.Status.readyReplicas | default 0 | int)) }}
     {{- if or (gt (len $replicaSets) 1) (and (eq (len $replicaSets) 1) $rolloutProblem) }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -68,7 +68,7 @@
     {{- template "application_details" . }}
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "serviceExpected" false) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" false "serviceExpected" false) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/ReplicaSet.tmpl
@@ -8,7 +8,7 @@
     {{- template "selector_with_health_summary" . }}
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "vpaTargetable" true "serviceExpected" true) }}
     {{- /* Where there is no readyReplicas, STS doesn't have that fields at all,
            and apparantly the numbers are parsed as float 64, so used 0.0 rather then 0 */ -}}
     {{- $injectedStatus := .Status }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -140,6 +140,9 @@
             {{- $revisions = append $revisions . }}
         {{- end }}
     {{- end }}
+    {{- /* creationTimestamp only has second resolution, so ControllerRevisions created within the
+          same rollout can tie; sort by the numeric revision field for a reliable order. */ -}}
+    {{- $revisions = sortByRevisionField $revisions }}
     {{- $rolloutStatus := .RolloutStatus . }}
     {{- $rolloutProblem := or (not $rolloutStatus.done) (ne (.Status.currentReplicas | default 0 | int) (.Status.readyReplicas | default 0 | int)) }}
     {{- if or (gt (len $revisions) 1) (and (eq (len $revisions) 1) $rolloutProblem) }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -8,7 +8,7 @@
     {{- template "selector_with_health_summary" . }}
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
-    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "serviceExpected" true) }}
+    {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "vpaTargetable" true "serviceExpected" true) }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
     {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}

--- a/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
@@ -1,0 +1,54 @@
+{{- define "VerticalPodAutoscaler" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: autoscaling.k8s.io/v1, Kind=VerticalPodAutoscaler */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- with .Spec.targetRef }}
+        {{- if $.Config.GetBool "deep" }}
+            {{- $obj := $.KubeGetFirst $.Namespace (.kind | default "Deployment") .name }}
+            {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
+        {{- else }}
+            {{- "Scales" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "namespace" $.Namespace) }}
+        {{- end }}
+    {{- end }}
+    {{- $updateMode := (.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
+    {{- if ne $updateMode "Auto" }}
+        {{- "Update mode" | bold | nindent 2 }}: {{ $updateMode | cyan }}
+    {{- end }}
+    {{- with (.Spec.updatePolicy | default dict).minReplicas }}
+        {{- "Min replicas to evict" | bold | nindent 2 }}: {{ . | toString | cyan }}
+    {{- end }}
+    {{- range (.Spec.resourcePolicy | default dict).containerPolicies }}
+        {{- $mode := .mode | default "Auto" }}
+        {{- if or (eq $mode "Off") .minAllowed .maxAllowed }}
+            {{- printf "Policy[%s]" (.containerName | default "*") | bold | nindent 2 }}:
+            {{- if eq $mode "Off" }} {{ "Off" | yellow | bold }}
+            {{- else }}
+                {{- $parts := list }}
+                {{- with (.minAllowed | default dict).cpu }}{{ $parts = append $parts (printf "min cpu=%s" .) }}{{ end }}
+                {{- with (.minAllowed | default dict).memory }}{{ $parts = append $parts (printf "min mem=%s" .) }}{{ end }}
+                {{- with (.maxAllowed | default dict).cpu }}{{ $parts = append $parts (printf "max cpu=%s" .) }}{{ end }}
+                {{- with (.maxAllowed | default dict).memory }}{{ $parts = append $parts (printf "max mem=%s" .) }}{{ end }}
+                {{- " " }}{{ $parts | join ", " | cyan }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with (.Status.recommendation | default dict).containerRecommendations }}
+        {{- "Recommendation:" | bold | nindent 2 }}
+        {{- range . }}
+            {{- $lb := .lowerBound | default dict }}
+            {{- $ub := .upperBound | default dict }}
+            {{- $t := .target | default dict }}
+            {{- .containerName | nindent 4 }}:
+            {{- with $t.cpu }} cpu={{ . | cyan }}{{ with $lb.cpu }} (min {{ . | cyan }}{{ with $ub.cpu }}, max {{ . | cyan }}{{ end }}){{ end }}{{ end }}
+            {{- with $t.memory }}, mem={{ . | cyan }}{{ with $lb.memory }} (min {{ . | cyan }}{{ with $ub.memory }}, max {{ . | cyan }}{{ end }}){{ end }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
+    {{- template "application_details" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}

--- a/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
@@ -10,7 +10,7 @@
             {{- $obj := $.KubeGetFirst $.Namespace (.kind | default "Deployment") .name }}
             {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
         {{- else }}
-            {{- "Scales" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "namespace" $.Namespace) }}
+            {{- "Targets" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "namespace" $.Namespace) }}
         {{- end }}
     {{- end }}
     {{- $updateMode := (.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
@@ -18,7 +18,7 @@
         {{- "Update mode" | bold | nindent 2 }}: {{ $updateMode | cyan }}
     {{- end }}
     {{- with (.Spec.updatePolicy | default dict).minReplicas }}
-        {{- "Min replicas to evict" | bold | nindent 2 }}: {{ . | toString | cyan }}
+        {{- "Min replicas for eviction" | bold | nindent 2 }}: {{ . | toString | cyan }}
     {{- end }}
     {{- range (.Spec.resourcePolicy | default dict).containerPolicies }}
         {{- $mode := .mode | default "Auto" }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -692,19 +692,72 @@
     {{- end }}
 {{- end }}
 
+{{- define "vpa_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}
+    {{- $updateMode := (.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
+    {{- if ne $updateMode "Auto" }}, {{ $updateMode | cyan }}{{ end }}
+    {{- range (.Status.recommendation | default dict).containerRecommendations }}
+        {{- $t := .target | default dict }}
+        {{- printf ", %s:" .containerName }}
+        {{- with $t.cpu }} cpu={{ . | cyan }}{{ end }}
+        {{- with $t.memory }} mem={{ . | cyan }}{{ end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "matching_vpas" }}
+    {{- /* Expects dict "ctx" (RenderableObject) "namespace" "kind" "name" (this workload's own
+           identity). Mirrors matching_hpas: VerticalPodAutoscaler names its target directly in
+           spec.targetRef rather than via labels, so this lists every VPA in the namespace and
+           keeps the ones whose targetRef points back at this workload. Unlike HorizontalPodAutoscaler
+           (scale-subresource kinds only), VerticalPodAutoscaler also targets DaemonSet directly from
+           its spec, so callers gate this separately from matching_hpas' "scalable" flag. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $namespace := .namespace }}
+    {{- $kind := .kind }}
+    {{- $name := .name }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $vpas := list }}
+        {{- range $ctx.KubeGet $namespace "VerticalPodAutoscalers" }}
+            {{- $ref := .Spec.targetRef | default dict }}
+            {{- if and (eq (index $ref "kind" | default "") $kind) (eq (index $ref "name" | default "") $name) }}
+                {{- $vpas = append $vpas . }}
+            {{- end }}
+        {{- end }}
+        {{- if $vpas }}
+            {{- if $ctx.Config.GetBool "deep" }}
+                {{- "VerticalPodAutoscalers:" | bold | nindent 2 }}
+                {{- range $vpas }}
+                    {{- $ctx.Include "VerticalPodAutoscaler" . | nindent 4 }}
+                {{- end }}
+            {{- else if eq (len $vpas) 1 }}
+                {{- "VerticalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "vpa_health_summary" (index $vpas 0) }}
+            {{- else }}
+                {{- "VerticalPodAutoscalers:" | bold | nindent 2 }}
+                {{- range $vpas }}
+                    {{- $ctx.Include "vpa_health_summary" . | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- define "matching_workload_resources" }}
     {{- /* Expects dict "ctx" (the workload's own RenderableObject: Deployment/StatefulSet/
            DaemonSet/ReplicaSet/Job/CronJob) "namespace" "labels" (this workload's Pod template
            labels, already resolved by the caller since the field path to reach them differs per
            kind -- e.g. CronJob nests an extra .spec.template under .spec.jobTemplate) "scalable"
            (bool, whether HorizontalPodAutoscaler can target this kind -- only Deployment/
-           StatefulSet/ReplicaSet expose a /scale subresource) "serviceExpected" (bool, whether to
-           warn when no Service matches -- Job/CronJob Pods aren't normally service-fronted, so
-           that warning would just be noise for those kinds). Renders the same set of matched
-           resources Pod.tmpl shows for a single Pod -- Services, PodDisruptionBudgets,
-           NetworkPolicy family -- using $labels (selector-subset matched, mirroring how a
-           Service would select this workload's Pods), plus any HorizontalPodAutoscaler that
-           targets $namespace/$.ctx.Name when $scalable. */ -}}
+           StatefulSet/ReplicaSet expose a /scale subresource) "vpaTargetable" (bool, whether
+           VerticalPodAutoscaler can target this kind -- Deployment/StatefulSet/ReplicaSet via the
+           /scale subresource plus DaemonSet directly from its spec) "serviceExpected" (bool,
+           whether to warn when no Service matches -- Job/CronJob Pods aren't normally
+           service-fronted, so that warning would just be noise for those kinds). Renders the same
+           set of matched resources Pod.tmpl shows for a single Pod -- Services,
+           PodDisruptionBudgets, NetworkPolicy family -- using $labels (selector-subset matched,
+           mirroring how a Service would select this workload's Pods), plus any
+           HorizontalPodAutoscaler/VerticalPodAutoscaler that targets $namespace/$.ctx.Name when
+           $scalable/$vpaTargetable. */ -}}
     {{- $ctx := .ctx }}
     {{- $namespace := .namespace }}
     {{- $serviceExpected := .serviceExpected }}
@@ -721,6 +774,9 @@
     {{- end }}
     {{- if .scalable }}
         {{- template "matching_hpas" (dict "ctx" $ctx "namespace" $namespace "kind" $ctx.Kind "name" $ctx.Name) }}
+    {{- end }}
+    {{- if .vpaTargetable }}
+        {{- template "matching_vpas" (dict "ctx" $ctx "namespace" $namespace "kind" $ctx.Kind "name" $ctx.Name) }}
     {{- end }}
 {{- end }}
 

--- a/tests/e2e-artifacts/vpa-standalone.regex
+++ b/tests/e2e-artifacts/vpa-standalone.regex
@@ -1,0 +1,13 @@
+\A
+VerticalPodAutoscaler/vpa-burner -n e2e-vpa, created 1m ago, gen:1
+  Current: Resource is current
+  Scales: Deployment/vpa-burner -n e2e-vpa
+  Update mode: Recreate
+  Min replicas to evict: 1
+  Policy\[burner\]: min cpu=10m, min mem=16Mi, max cpu=500m, max mem=128Mi
+  Recommendation:
+    burner: cpu=\d+m \(min \d+m, max \d+m\), mem=\d+Mi \(min \d+Mi, max \d+Mi\)
+  RecommendationProvided for 1m
+  Events:
+    vpa-updater EvictedPod involving VerticalPodAutoscaler/vpa-burner \(in e2e-vpa\) 1m ago VPA Updater evicted Pod vpa-burner-[a-z0-9]+-[a-z0-9]+ to apply resource recommendation\.
+\z

--- a/tests/e2e-artifacts/vpa-standalone.regex
+++ b/tests/e2e-artifacts/vpa-standalone.regex
@@ -1,9 +1,9 @@
 \A
 VerticalPodAutoscaler/vpa-burner -n e2e-vpa, created 1m ago, gen:1
   Current: Resource is current
-  Scales: Deployment/vpa-burner -n e2e-vpa
+  Targets: Deployment/vpa-burner -n e2e-vpa
   Update mode: Recreate
-  Min replicas to evict: 1
+  Min replicas for eviction: 1
   Policy\[burner\]: min cpu=10m, min mem=16Mi, max cpu=500m, max mem=128Mi
   Recommendation:
     burner: cpu=\d+m \(min \d+m, max \d+m\), mem=\d+Mi \(min \d+Mi, max \d+Mi\)

--- a/tests/e2e-artifacts/vpa-workload-reverse-match.regex
+++ b/tests/e2e-artifacts/vpa-workload-reverse-match.regex
@@ -1,0 +1,10 @@
+\A
+Deployment/vpa-burner -n e2e-vpa, created 1m ago, gen:1 rev:1
+  Current: Deployment is available\. Replicas: 1
+  desired:1, existing:1, ready:1, updated:1, available:1
+  Selector: app=vpa-burner
+    Pod/vpa-burner-[a-z0-9]+-[a-z0-9]+ -n e2e-vpa, created 1m ago Running, 1/1 ready
+  Not matched by any Service
+  VerticalPodAutoscaler: VerticalPodAutoscaler/vpa-burner -n e2e-vpa, Recreate, burner: cpu=\d+m mem=\d+Mi
+  (?:Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n  Progressing NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m|Progressing NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m\n  Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
+\z


### PR DESCRIPTION
## Summary
- Adds a standalone `VerticalPodAutoscaler.tmpl` (target ref, update mode, per-container min/max policy, applied recommendation) built from the live `autoscaling.k8s.io/v1` CRD schema.
- Reverse-matches VPAs onto their target workload the same way `HorizontalPodAutoscaler` already does (`matching_hpas`), via a new `matching_vpas` template in `common.tmpl`, gated by a `vpaTargetable` flag separate from HPA's `scalable` gate since VPA can also target DaemonSet directly (unlike HPA).
- `install-e2e-deps` now installs the real VPA controllers (recommender/updater/admission-controller) via the `cowboysysop` Helm chart, since the new e2e scenario exercises the updater actually evicting/recreating a Pod to apply a recommendation, not just rendering a static object.
- New e2e test creates a CPU-burning Deployment with deliberately low resource requests, attaches a VPA, waits for a real recommendation and for the updater to evict/recreate the Pod, then asserts both the Deployment's reverse-match line and the VPA's own rendered output against fully anchored (`\A`...`\z`) fixtures.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`
- [x] `go test ./...` (unit suite)
- [x] `TestE2ERegexFixturesAreAnchored` passes for both new fixtures
- [x] `TestE2EDynamicManifests/VerticalPodAutoscaler...` passes against real minikube (verified on two independent fresh runs)
- [x] Manually verified `--deep` terminates cleanly (mutual-recursion guard, same as HPA) and DaemonSet reverse-matching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)