### PR TITLE
Add StorageClass template

### DIFF
--- a/pkg/plugin/templates/StorageClass.tmpl
+++ b/pkg/plugin/templates/StorageClass.tmpl
@@ -4,7 +4,7 @@
     {{- template "status_summary_line" . }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
-    {{- if eq (index .Annotations "storageclass.kubernetes.io/is-default-class") "true" }}
+    {{- if or (eq (index .Annotations "storageclass.kubernetes.io/is-default-class") "true") (eq (index .Annotations "storageclass.beta.kubernetes.io/is-default-class") "true") }}
         {{- "Default StorageClass" | bold | green | nindent 2 }}
     {{- end }}
     {{- "Provisioner" | bold | nindent 2 }}: {{ .Object.provisioner | cyan }}

--- a/pkg/plugin/templates/StorageClass.tmpl
+++ b/pkg/plugin/templates/StorageClass.tmpl
@@ -1,0 +1,33 @@
+{{- define "StorageClass" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: storage.k8s.io/v1, Kind=StorageClass */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- if eq (index .Annotations "storageclass.kubernetes.io/is-default-class") "true" }}
+        {{- "Default StorageClass" | bold | green | nindent 2 }}
+    {{- end }}
+    {{- "Provisioner" | bold | nindent 2 }}: {{ .Object.provisioner | cyan }}
+    {{- $reclaimPolicy := .Object.reclaimPolicy | default "Delete" }}
+    {{- if ne $reclaimPolicy "Delete" }}, reclaimPolicy: {{ $reclaimPolicy | colorKeyword }}{{ end }}
+    {{- $bindingMode := .Object.volumeBindingMode | default "Immediate" }}
+    {{- if ne $bindingMode "Immediate" }}, volumeBindingMode: {{ $bindingMode | colorKeyword }}{{ end }}
+    {{- with .Object.allowVolumeExpansion }}, allows volume expansion{{ end }}
+    {{- with $params := .Object.parameters }}
+        {{- "Parameters" | bold | nindent 2 }}: {{ range $i, $k := (keys $params | sortAlpha) }}{{ if $i }}, {{ end }}{{ $k }}={{ index $params $k | cyan }}{{ end }}
+    {{- end }}
+    {{- with .Object.mountOptions }}
+        {{- "Mount options" | bold | nindent 2 }}: {{ . | join ", " | cyan }}
+    {{- end }}
+    {{- with .Object.allowedTopologies }}
+        {{- "Allowed topologies" | bold | nindent 2 }}
+        {{- range . }}
+            {{- range .matchLabelExpressions }}
+                {{- "" | nindent 4 }}{{ .key }} in [{{ .values | join ", " }}]
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}

--- a/tests/artifacts/storageclass-default-minimal.out
+++ b/tests/artifacts/storageclass-default-minimal.out
@@ -1,0 +1,5 @@
+
+StorageClass/standard, created 1m ago
+  Current: Resource is current
+  Default StorageClass
+  Provisioner: k8s.io/minikube-hostpath

--- a/tests/artifacts/storageclass-default-minimal.yaml
+++ b/tests/artifacts/storageclass-default-minimal.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: standard
+  resourceVersion: "317050"
+  uid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/tests/artifacts/storageclass-full-featured.out
+++ b/tests/artifacts/storageclass-full-featured.out
@@ -1,0 +1,8 @@
+
+StorageClass/fast-ebs, created 1m ago
+  Current: Resource is current
+  Provisioner: ebs.csi.aws.com, reclaimPolicy: Retain, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+  Parameters: fsType=ext4, type=gp3
+  Mount options: debug, discard
+  Allowed topologies
+    topology.kubernetes.io/zone in [us-east-1a, us-east-1b]

--- a/tests/artifacts/storageclass-full-featured.yaml
+++ b/tests/artifacts/storageclass-full-featured.yaml
@@ -1,0 +1,23 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: fast-ebs
+  resourceVersion: "317051"
+  uid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+mountOptions:
+- debug
+- discard
+parameters:
+  fsType: ext4
+  type: gp3
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.kubernetes.io/zone
+    values:
+    - us-east-1a
+    - us-east-1b

--- a/tests/artifacts/storageclass-legacy-default-annotation.out
+++ b/tests/artifacts/storageclass-legacy-default-annotation.out
@@ -1,0 +1,5 @@
+
+StorageClass/gp2, created 1m ago
+  Current: Resource is current
+  Default StorageClass
+  Provisioner: kubernetes.io/aws-ebs

--- a/tests/artifacts/storageclass-legacy-default-annotation.yaml
+++ b/tests/artifacts/storageclass-legacy-default-annotation.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: gp2
+  resourceVersion: "317052"
+  uid: c3d4e5f6-a7b8-9012-cdef-123456789012
+provisioner: kubernetes.io/aws-ebs
+reclaimPolicy: Delete
+volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary
- Adds a built-in `kubectl-status` template for `StorageClass`, rendering provisioner, default-class marker, non-default reclaimPolicy/volumeBindingMode, allowVolumeExpansion, parameters, mountOptions, and allowedTopologies.
- Follows CONVENTIONS.md: omits Kubernetes-default values (reclaimPolicy=Delete, volumeBindingMode=Immediate), collapses parameters/mountOptions to single lines.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Added `tests/artifacts/storageclass-default-minimal.{yaml,out}` (bare default StorageClass) and `tests/artifacts/storageclass-full-featured.{yaml,out}` (all optional fields) under `TestAllArtifactsLocal`
- [x] Manually verified against a live minikube `standard` StorageClass and a hand-applied fully-populated StorageClass