### PR TITLE
Add LimitRange template and Pod LimitRange-defaults note

### DIFF
--- a/pkg/plugin/templates/LimitRange.tmpl
+++ b/pkg/plugin/templates/LimitRange.tmpl
@@ -1,0 +1,47 @@
+{{- define "LimitRange" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: v1, Kind=LimitRange */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- with .Spec.limits }}
+        {{- "Limits" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- template "limit_range_item" . }}
+        {{- end }}
+    {{- end }}
+    {{- template "application_details" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}
+
+{{- define "limit_range_item" }}
+    {{- /* Expects a single spec.limits[] entry (type + default/defaultRequest/max/min/
+           maxLimitRequestRatio maps keyed by resource name, e.g. cpu/memory/storage). Rather than
+           rendering each map as its own block (forcing the reader to cross-reference by resource
+           name across five separate lists), this collects the resource names once and renders one
+           line per resource name with whichever facts apply to it. */ -}}
+    {{- $default := .default | default dict }}
+    {{- $defaultRequest := .defaultRequest | default dict }}
+    {{- $max := .max | default dict }}
+    {{- $min := .min | default dict }}
+    {{- $ratio := .maxLimitRequestRatio | default dict }}
+    {{- $resourceNames := list }}
+    {{- range $m := list $default $defaultRequest $max $min $ratio }}
+        {{- range $name, $_ := $m }}
+            {{- if not (has $name $resourceNames) }}{{ $resourceNames = append $resourceNames $name }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- .type | bold | nindent 4 }}:
+    {{- range $resourceNames | sortAlpha }}
+        {{- $name := . }}
+        {{- $facts := list }}
+        {{- with index $min $name }}{{ $facts = append $facts (printf "min %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $defaultRequest $name }}{{ $facts = append $facts (printf "default request %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $default $name }}{{ $facts = append $facts (printf "default limit %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $max $name }}{{ $facts = append $facts (printf "max %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $ratio $name }}{{ $facts = append $facts (printf "max limit/request ratio %s" (. | toString | cyan)) }}{{ end }}
+        {{- printf "%s: %s" $name (join ", " $facts) | nindent 6 }}
+    {{- end }}
+{{- end -}}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -407,13 +407,50 @@
 {{- end -}}
 
 {{- define "container_requests_limits" -}}
-    {{- /* Expects to get a map with the key "containerSpec" (required): Pod.spec.containers[name=container].
+    {{- /* Expects to get a map with the keys "containerSpec" (required): Pod.spec.containers[name=container]
+           and "pod" (required): Pod RenderableObject, used to look up namespace LimitRanges.
            Used in place of container_usage when there's no metrics data to show usage against. */ -}}
     cpu: [{{ if .containerSpec.resources.requests.cpu }}req:{{ .containerSpec.resources.requests.cpu | quantityToFloat64 | printf "%.1g" }}{{ else }}{{ "no-req" | yellow }}{{ end -}}
     , {{ if .containerSpec.resources.limits.cpu }}lim:{{ .containerSpec.resources.limits.cpu | quantityToFloat64 | printf "%.1g" }}{{ else }}{{ "no-lim" | yellow }}{{ end -}}
     ], mem: [{{ if .containerSpec.resources.requests.memory }}req:{{ .containerSpec.resources.requests.memory | quantityToFloat64 | humanizeSI "B" }}{{ else }}{{ "no-req" | yellow }}{{ end -}}
     , {{ if .containerSpec.resources.limits.memory }}lim:{{ .containerSpec.resources.limits.memory | quantityToFloat64 | humanizeSI "B" }}{{ else }}{{ "no-lim" | yellow }}{{ end -}}
     ]
+    {{- template "container_limitrange_defaults_note" . }}
+{{- end -}}
+
+{{- define "container_limitrange_defaults_note" }}
+    {{- /* Expects the same map as container_requests_limits. Appends "(matches LimitRange
+           defaults)" when every requests/limits value this container has is exactly explained by
+           a single namespace LimitRange's Container-type default/defaultRequest. The stored Pod
+           spec keeps no record of which fields the API server actually defaulted, so this can
+           only report a coincidence, never real admission-time provenance -- do not strengthen
+           the wording to "defaulted by LimitRange" without direct evidence (see CONVENTIONS.md).
+        */ -}}
+    {{- if not (.pod.Config.GetBool "shallow") }}
+        {{- $requests := ((.containerSpec.resources | default dict).requests) | default dict }}
+        {{- $limits := ((.containerSpec.resources | default dict).limits) | default dict }}
+        {{- if or $requests $limits }}
+            {{- $matched := false }}
+            {{- range .pod.KubeGet .pod.Namespace "limitrange" }}
+                {{- range (.Spec.limits | default list) }}
+                    {{- if eq .type "Container" }}
+                        {{- $defaultRequest := .defaultRequest | default dict }}
+                        {{- $default := .default | default dict }}
+                        {{- $requestsExplained := eq (len $requests) (len $defaultRequest) }}
+                        {{- range $k, $v := $requests }}
+                            {{- if ne (index $defaultRequest $k) $v }}{{ $requestsExplained = false }}{{ end }}
+                        {{- end }}
+                        {{- $limitsExplained := eq (len $limits) (len $default) }}
+                        {{- range $k, $v := $limits }}
+                            {{- if ne (index $default $k) $v }}{{ $limitsExplained = false }}{{ end }}
+                        {{- end }}
+                        {{- if and $requestsExplained $limitsExplained }}{{ $matched = true }}{{ end }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+            {{- if $matched }} (matches LimitRange defaults){{ end }}
+        {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "container_status_summary" }}
@@ -445,7 +482,10 @@
         {{- end }}
     {{- end }}
     {{- if .containerMetrics }}
-        {{- if .containerMetrics.usage.cpu }}{{ "usage" | nindent 2 }} {{ template "container_usage" . }}{{ end }}
+        {{- if .containerMetrics.usage.cpu }}
+            {{- "usage" | nindent 2 }} {{ template "container_usage" . }}
+            {{- template "container_limitrange_defaults_note" . }}
+        {{- end }}
     {{- else if and .metricsUnavailableReason .containerStatus.state.running }}
         {{- "" | nindent 2 }}{{ template "container_requests_limits" . }}, ({{ .metricsUnavailableReason | yellow }})
     {{- end }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -436,13 +436,25 @@
                     {{- if eq .type "Container" }}
                         {{- $defaultRequest := .defaultRequest | default dict }}
                         {{- $default := .default | default dict }}
+                        {{- /* Compared as quantities, not raw strings -- "1000m" and "1" are the
+                               same request but wouldn't string-match. */ -}}
                         {{- $requestsExplained := eq (len $requests) (len $defaultRequest) }}
                         {{- range $k, $v := $requests }}
-                            {{- if ne (index $defaultRequest $k) $v }}{{ $requestsExplained = false }}{{ end }}
+                            {{- $defaultVal := index $defaultRequest $k }}
+                            {{- if $defaultVal }}
+                                {{- if ne ($defaultVal | toString | quantityToFloat64) ($v | toString | quantityToFloat64) }}{{ $requestsExplained = false }}{{ end }}
+                            {{- else }}
+                                {{- $requestsExplained = false }}
+                            {{- end }}
                         {{- end }}
                         {{- $limitsExplained := eq (len $limits) (len $default) }}
                         {{- range $k, $v := $limits }}
-                            {{- if ne (index $default $k) $v }}{{ $limitsExplained = false }}{{ end }}
+                            {{- $defaultVal := index $default $k }}
+                            {{- if $defaultVal }}
+                                {{- if ne ($defaultVal | toString | quantityToFloat64) ($v | toString | quantityToFloat64) }}{{ $limitsExplained = false }}{{ end }}
+                            {{- else }}
+                                {{- $limitsExplained = false }}
+                            {{- end }}
                         {{- end }}
                         {{- if and $requestsExplained $limitsExplained }}{{ $matched = true }}{{ end }}
                     {{- end }}

--- a/tests/artifacts/limitrange-container.out
+++ b/tests/artifacts/limitrange-container.out
@@ -1,0 +1,7 @@
+
+LimitRange/container-limits -n lr-test, created 1m ago
+  Current: Resource is current
+  Limits:
+    Container:
+      cpu: min 50m, default request 100m, default limit 500m, max 2, max limit/request ratio 4
+      memory: min 64Mi, default request 256Mi, default limit 512Mi, max 2Gi

--- a/tests/artifacts/limitrange-container.yaml
+++ b/tests/artifacts/limitrange-container.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"LimitRange","metadata":{"annotations":{},"name":"container-limits","namespace":"lr-test"},"spec":{"limits":[{"default":{"cpu":"500m","memory":"512Mi"},"defaultRequest":{"cpu":"100m","memory":"256Mi"},"max":{"cpu":"2","memory":"2Gi"},"maxLimitRequestRatio":{"cpu":"4"},"min":{"cpu":"50m","memory":"64Mi"},"type":"Container"}]}}
+  creationTimestamp: "2026-07-11T07:04:04Z"
+  name: container-limits
+  namespace: lr-test
+  resourceVersion: "61643"
+  uid: ab185040-1ac5-4258-b312-31c61afa5b89
+spec:
+  limits:
+  - default:
+      cpu: 500m
+      memory: 512Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 256Mi
+    max:
+      cpu: "2"
+      memory: 2Gi
+    maxLimitRequestRatio:
+      cpu: "4"
+    min:
+      cpu: 50m
+      memory: 64Mi
+    type: Container

--- a/tests/artifacts/limitrange-pod.out
+++ b/tests/artifacts/limitrange-pod.out
@@ -1,0 +1,7 @@
+
+LimitRange/pod-limits -n lr-test, created 1m ago
+  Current: Resource is current
+  Limits:
+    Pod:
+      cpu: max 4
+      memory: max 4Gi

--- a/tests/artifacts/limitrange-pod.yaml
+++ b/tests/artifacts/limitrange-pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"LimitRange","metadata":{"annotations":{},"name":"pod-limits","namespace":"lr-test"},"spec":{"limits":[{"max":{"cpu":"4","memory":"4Gi"},"type":"Pod"}]}}
+  creationTimestamp: "2026-07-11T07:04:05Z"
+  name: pod-limits
+  namespace: lr-test
+  resourceVersion: "61645"
+  uid: fb515686-36df-40ec-90cb-228658eb913b
+spec:
+  limits:
+  - max:
+      cpu: "4"
+      memory: 4Gi
+    type: Pod

--- a/tests/artifacts/limitrange-pvc.out
+++ b/tests/artifacts/limitrange-pvc.out
@@ -1,0 +1,6 @@
+
+LimitRange/pvc-limits -n lr-test, created 1m ago
+  Current: Resource is current
+  Limits:
+    PersistentVolumeClaim:
+      storage: min 1Gi, max 1Ti

--- a/tests/artifacts/limitrange-pvc.yaml
+++ b/tests/artifacts/limitrange-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"LimitRange","metadata":{"annotations":{},"name":"pvc-limits","namespace":"lr-test"},"spec":{"limits":[{"max":{"storage":"1Ti"},"min":{"storage":"1Gi"},"type":"PersistentVolumeClaim"}]}}
+  creationTimestamp: "2026-07-11T07:04:05Z"
+  name: pvc-limits
+  namespace: lr-test
+  resourceVersion: "61644"
+  uid: 8aeb589e-0b0d-4c3c-b168-2db5b9f46513
+spec:
+  limits:
+  - max:
+      storage: 1Ti
+    min:
+      storage: 1Gi
+    type: PersistentVolumeClaim


### PR DESCRIPTION
## Summary
- Add `LimitRange.tmpl` (previously unimplemented embedded template). LimitRange has no status, so this renders `spec.limits[]` grouped by resource name (cpu/memory/storage/...) across default/defaultRequest/max/min/maxLimitRequestRatio, rather than five separate lists.
- Add a `(matches LimitRange defaults)` note next to a Pod container's existing resource line, shown only when every requests/limits value is exactly explained by a single namespace LimitRange's Container-type defaults. Worded as a coincidence, not provenance — the stored Pod spec doesn't retain which fields the API server actually defaulted.
- Investigated the rest of a proposed ResourceQuota/LimitRange coverage matrix (reverse-match from Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob/PVC) and found it's already covered by existing behavior:
  - Deployment/ReplicaSet already surface `FailedCreate: exceeded quota ...` via the `ReplicaFailure` condition.
  - StatefulSet/Job already surface the same via the default-on `events` section (verified live against a minikube cluster).
  - PVC creation rejected by quota produces no object at all (API server denies synchronously) — nothing to render.
- Filed #658 to track the one signal deliberately left out (quota-headroom / imminent-rollout-block check), which needs more careful wording around shared namespace state and currently has no path to automated test coverage.

Closes/relates to #658 (tracking issue for future quota-headroom work, not closed by this PR).

## Test plan
- [x] `go test ./...` passes
- [x] New local fixtures `tests/artifacts/limitrange-{container,pod,pvc}.yaml/.out` cover LimitRange rendering for Container/Pod/PersistentVolumeClaim limit types
- [x] Verified live against a minikube cluster: LimitRange render, Pod note firing when resources match namespace defaults, Pod note *not* firing when resources are explicitly set to different values, and Deployment/ReplicaSet/StatefulSet/Job quota-rejection visibility via existing conditions/events