### PR TITLE
Allow user-provided abnormal-true condition types

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ The [Kubernetes API conventions](https://github.com/kubernetes/community/blob/ma
 recommend condition `type`s use the "abnormal-true" polarity (e.g. `status: "True"` means something's wrong), but
 most built-in resources don't follow it — for those `kubectl status` treats `status: "True"` as healthy by default.
 A known set of exceptions that do follow abnormal-true (like `DiskPressure` or `Failed`) is hardcoded. If your
-cluster has CRDs with their own abnormal-true condition types, list them (one per line, matched exactly against
-the condition `type`) in `~/.kubectl-status/abnormal-true-condition-types` and they'll be treated the same way.
+cluster has CRDs with their own abnormal-true condition types, list them (one per line) in
+`~/.kubectl-status/abnormal-true-condition-types` and they'll be treated the same way. Each line can be an exact
+condition `type`, a suffix pattern like `*Problematic`, or a prefix pattern like `Unhealthy*`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ For your own CRDs, drop a template into `~/.kubectl-status/templates/<Kind>.tmpl
 [Claude Code](https://claude.ai/code) skill (`/generate-template`) generate one from your CRD schema in seconds — see
 [Claude Code Integration](./CONTRIBUTING.md#claude-code-integration) in CONTRIBUTING.md.
 
+The [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties)
+recommend condition `type`s use the "abnormal-true" polarity (e.g. `status: "True"` means something's wrong), but
+most built-in resources don't follow it — for those `kubectl status` treats `status: "True"` as healthy by default.
+A known set of exceptions that do follow abnormal-true (like `DiskPressure` or `Failed`) is hardcoded. If your
+cluster has CRDs with their own abnormal-true condition types, list them (one per line, matched exactly against
+the condition `type`) in `~/.kubectl-status/abnormal-true-condition-types` and they'll be treated the same way.
+
 ## Development
 
 - [CONVENTIONS.md](./CONVENTIONS.md) — output philosophy, color rules, and template patterns

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -354,7 +354,7 @@ func isStatusConditionHealthy(condition map[string]interface{}) bool {
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Missing"),
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Flapping"),
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Unhealthy"),
-		condition["type"] == "Failed", // Failed Jobs has this condition
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Failed"), // Failed Jobs has this condition
 
 		// Conditions from "Node Problem Detector"
 		condition["type"] == "CorruptDockerImage",

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -347,50 +347,39 @@ func isStatusConditionHealthy(condition map[string]interface{}) bool {
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Unavailable"), // Node NetworkUnavailable condition
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Failure"),     // ReplicaSet ReplicaFailure: condition
 		strings.HasPrefix(fmt.Sprint(condition["type"]), "Non"),         // CRD NonStructuralSchema condition
-		condition["type"] == "Failed",                                   // Failed Jobs has this condition
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Problem"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Error"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Errors"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Hung"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Missing"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Flapping"),
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Unhealthy"),
+		condition["type"] == "Failed", // Failed Jobs has this condition
 
 		// Conditions from "Node Problem Detector"
 		condition["type"] == "CorruptDockerImage",
 		condition["type"] == "CorruptDockerOverlay2",
 		condition["type"] == "DockerContainerStartupFailure",
-		condition["type"] == "DockerHung",
-		condition["type"] == "Ext4Error",
 		condition["type"] == "Ext4Warning",
 		condition["type"] == "FilesystemIsReadOnly",
-		condition["type"] == "IOError",
-		condition["type"] == "NvmeTcpProblem",
-		condition["type"] == "EdgeDecryptionProblem",
-		condition["type"] == "IOErrorProblem",
-		condition["type"] == "NetworkProblem",
 		condition["type"] == "KernelDeadlock",
 		condition["type"] == "KernelOops",
-		condition["type"] == "MemoryReadError",
 		condition["type"] == "OOMKilling",
 		condition["type"] == "ReadonlyFilesystem",
-		condition["type"] == "TaskHung",
 		condition["type"] == "UnregisterNetDevice",
 		condition["type"] == "FrequentDockerRestart",
-		condition["type"] == "FilesystemCorruptionProblem",
 		condition["type"] == "FrequentContainerdRestart",
 		condition["type"] == "FrequentKubeletRestart",
 		condition["type"] == "RebootScheduled",
-		condition["type"] == "KubeletProblem",
 		condition["type"] == "TerminateScheduled",
-		condition["type"] == "ContainerRuntimeProblem",
 		condition["type"] == "RedeployScheduled",
 		condition["type"] == "PreemptScheduled",
 		condition["type"] == "FreezeScheduled",
 		condition["type"] == "FrequentUnregisterNetDevice",
 		condition["type"] == "VMEventScheduled",
-		condition["type"] == "GPUMissing",
 		condition["type"] == "NVLinkStatusInactive",
-		condition["type"] == "XIDErrors",
-		condition["type"] == "GPUXIDErrors",
-		condition["type"] == "IBLinkFlapping",
 		condition["type"] == "KernelDeadLock", // legacy mis-capitalized variant seen in some NPD configs
-		condition["type"] == "KubeletUnhealthy",
-		condition["type"] == "ContainerRuntimeUnhealthy",
-		condition["type"] == "OutOfDisk", // deprecated legacy Node condition, same polarity as DiskPressure
+		condition["type"] == "OutOfDisk",      // deprecated legacy Node condition, same polarity as DiskPressure
 
 		// User provided additions, see ~/.kubectl-status/abnormal-true-condition-types
 		userAbnormalTrueConditionTypeSet()[fmt.Sprint(condition["type"])]:

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -6,11 +6,14 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -294,6 +297,40 @@ func revisionFieldInt(obj interface{}) int {
 	return n
 }
 
+var (
+	userAbnormalTrueConditionTypesOnce sync.Once
+	userAbnormalTrueConditionTypes     map[string]bool
+)
+
+// userAbnormalTrueConditionTypeSet loads condition types from
+// ~/.kubectl-status/abnormal-true-condition-types, one per line, so users can extend the
+// hardcoded list of condition types below without recompiling. Blank lines and lines starting
+// with "#" are ignored. Read once and cached for the lifetime of the process.
+func userAbnormalTrueConditionTypeSet() map[string]bool {
+	userAbnormalTrueConditionTypesOnce.Do(func() {
+		userAbnormalTrueConditionTypes = map[string]bool{}
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			klog.V(3).ErrorS(err, "error getting user home dir, ignoring")
+			return
+		}
+		path := filepath.Join(homeDir, ".kubectl-status", "abnormal-true-condition-types")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			klog.V(5).ErrorS(err, "error reading user provided abnormal-true condition types file, ignoring", "path", path)
+			return
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			userAbnormalTrueConditionTypes[line] = true
+		}
+	})
+	return userAbnormalTrueConditionTypes
+}
+
 func isStatusConditionHealthy(condition map[string]interface{}) bool {
 	switch {
 	/*
@@ -343,7 +380,20 @@ func isStatusConditionHealthy(condition map[string]interface{}) bool {
 		condition["type"] == "RedeployScheduled",
 		condition["type"] == "PreemptScheduled",
 		condition["type"] == "FreezeScheduled",
-		condition["type"] == "FrequentUnregisterNetDevice":
+		condition["type"] == "FrequentUnregisterNetDevice",
+		condition["type"] == "VMEventScheduled",
+		condition["type"] == "GPUMissing",
+		condition["type"] == "NVLinkStatusInactive",
+		condition["type"] == "XIDErrors",
+		condition["type"] == "GPUXIDErrors",
+		condition["type"] == "IBLinkFlapping",
+		condition["type"] == "KernelDeadLock", // legacy mis-capitalized variant seen in some NPD configs
+		condition["type"] == "KubeletUnhealthy",
+		condition["type"] == "ContainerRuntimeUnhealthy",
+		condition["type"] == "OutOfDisk", // deprecated legacy Node condition, same polarity as DiskPressure
+
+		// User provided additions, see ~/.kubectl-status/abnormal-true-condition-types
+		userAbnormalTrueConditionTypeSet()[fmt.Sprint(condition["type"])]:
 		switch condition["status"] {
 		case "False":
 			return true

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -299,16 +299,43 @@ func revisionFieldInt(obj interface{}) int {
 
 var (
 	userAbnormalTrueConditionTypesOnce sync.Once
-	userAbnormalTrueConditionTypes     map[string]bool
+	userAbnormalTrueConditionTypes     userAbnormalTrueConditionTypeMatcher
 )
 
-// userAbnormalTrueConditionTypeSet loads condition types from
+// userAbnormalTrueConditionTypeMatcher holds condition types loaded from the user provided
+// abnormal-true-condition-types file, split by match kind.
+type userAbnormalTrueConditionTypeMatcher struct {
+	exact    map[string]bool
+	prefixes []string // from lines like "Unhealthy*"
+	suffixes []string // from lines like "*Problematic"
+}
+
+func (m userAbnormalTrueConditionTypeMatcher) matches(conditionType string) bool {
+	if m.exact[conditionType] {
+		return true
+	}
+	for _, prefix := range m.prefixes {
+		if strings.HasPrefix(conditionType, prefix) {
+			return true
+		}
+	}
+	for _, suffix := range m.suffixes {
+		if strings.HasSuffix(conditionType, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// userAbnormalTrueConditionTypeMatchers loads condition types from
 // ~/.kubectl-status/abnormal-true-condition-types, one per line, so users can extend the
 // hardcoded list of condition types below without recompiling. Blank lines and lines starting
-// with "#" are ignored. Read once and cached for the lifetime of the process.
-func userAbnormalTrueConditionTypeSet() map[string]bool {
+// with "#" are ignored. A line may be an exact condition type, a suffix pattern like
+// "*Problematic", or a prefix pattern like "Unhealthy*". Read once and cached for the lifetime
+// of the process.
+func userAbnormalTrueConditionTypeMatchers() userAbnormalTrueConditionTypeMatcher {
 	userAbnormalTrueConditionTypesOnce.Do(func() {
-		userAbnormalTrueConditionTypes = map[string]bool{}
+		userAbnormalTrueConditionTypes = userAbnormalTrueConditionTypeMatcher{exact: map[string]bool{}}
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			klog.V(3).ErrorS(err, "error getting user home dir, ignoring")
@@ -322,10 +349,16 @@ func userAbnormalTrueConditionTypeSet() map[string]bool {
 		}
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "#") {
+			switch {
+			case line == "" || strings.HasPrefix(line, "#"):
 				continue
+			case strings.HasPrefix(line, "*"):
+				userAbnormalTrueConditionTypes.suffixes = append(userAbnormalTrueConditionTypes.suffixes, strings.TrimPrefix(line, "*"))
+			case strings.HasSuffix(line, "*"):
+				userAbnormalTrueConditionTypes.prefixes = append(userAbnormalTrueConditionTypes.prefixes, strings.TrimSuffix(line, "*"))
+			default:
+				userAbnormalTrueConditionTypes.exact[line] = true
 			}
-			userAbnormalTrueConditionTypes[line] = true
 		}
 	})
 	return userAbnormalTrueConditionTypes
@@ -381,7 +414,7 @@ func isStatusConditionHealthy(condition map[string]interface{}) bool {
 		condition["type"] == "OutOfDisk",      // deprecated legacy Node condition, same polarity as DiskPressure
 
 		// User provided additions, see ~/.kubectl-status/abnormal-true-condition-types
-		userAbnormalTrueConditionTypeSet()[fmt.Sprint(condition["type"])]:
+		userAbnormalTrueConditionTypeMatchers().matches(fmt.Sprint(condition["type"])):
 		switch condition["status"] {
 		case "False":
 			return true

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -355,12 +355,11 @@ func isStatusConditionHealthy(condition map[string]interface{}) bool {
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Flapping"),
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Unhealthy"),
 		strings.HasSuffix(fmt.Sprint(condition["type"]), "Failed"), // Failed Jobs has this condition
+		strings.HasSuffix(fmt.Sprint(condition["type"]), "Warning"),
+		strings.HasPrefix(fmt.Sprint(condition["type"]), "Corrupt"),
 
 		// Conditions from "Node Problem Detector"
-		condition["type"] == "CorruptDockerImage",
-		condition["type"] == "CorruptDockerOverlay2",
 		condition["type"] == "DockerContainerStartupFailure",
-		condition["type"] == "Ext4Warning",
 		condition["type"] == "FilesystemIsReadOnly",
 		condition["type"] == "KernelDeadlock",
 		condition["type"] == "KernelOops",

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -9,7 +9,10 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -1181,6 +1184,46 @@ func TestCertificateRequestInCSR(t *testing.T) {
 		got := certificateRequestInCSR(RenderableObject{Unstructured: unstructured.Unstructured{Object: obj}})
 		if got["ParseError"] == "" {
 			t.Errorf("expected ParseError for malformed base64, got %#v", got)
+		}
+	})
+}
+
+func TestIsStatusConditionHealthyUserProvidedTypes(t *testing.T) {
+	resetUserAbnormalTrueConditionTypes := func() {
+		userAbnormalTrueConditionTypesOnce = sync.Once{}
+		userAbnormalTrueConditionTypes = nil
+	}
+	t.Cleanup(resetUserAbnormalTrueConditionTypes)
+
+	t.Run("no user file present", func(t *testing.T) {
+		resetUserAbnormalTrueConditionTypes()
+		t.Setenv("HOME", t.TempDir())
+		condition := map[string]interface{}{"type": "CustomAbnormalTrue", "status": "True"}
+		if !isStatusConditionHealthy(condition) {
+			t.Errorf("expected condition type unknown to kubectl-status to follow the default 'True is healthy' polarity")
+		}
+	})
+
+	t.Run("user provided condition type overrides default polarity", func(t *testing.T) {
+		resetUserAbnormalTrueConditionTypes()
+		home := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(home, ".kubectl-status"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "# comment\n\nCustomAbnormalTrue\nAnotherOne\n"
+		path := filepath.Join(home, ".kubectl-status", "abnormal-true-condition-types")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HOME", home)
+
+		trueCondition := map[string]interface{}{"type": "CustomAbnormalTrue", "status": "True"}
+		if isStatusConditionHealthy(trueCondition) {
+			t.Errorf("expected user provided abnormal-true condition type with status True to be unhealthy")
+		}
+		falseCondition := map[string]interface{}{"type": "CustomAbnormalTrue", "status": "False"}
+		if !isStatusConditionHealthy(falseCondition) {
+			t.Errorf("expected user provided abnormal-true condition type with status False to be healthy")
 		}
 	})
 }

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -1191,7 +1191,7 @@ func TestCertificateRequestInCSR(t *testing.T) {
 func TestIsStatusConditionHealthyUserProvidedTypes(t *testing.T) {
 	resetUserAbnormalTrueConditionTypes := func() {
 		userAbnormalTrueConditionTypesOnce = sync.Once{}
-		userAbnormalTrueConditionTypes = nil
+		userAbnormalTrueConditionTypes = userAbnormalTrueConditionTypeMatcher{}
 	}
 	t.Cleanup(resetUserAbnormalTrueConditionTypes)
 
@@ -1224,6 +1224,33 @@ func TestIsStatusConditionHealthyUserProvidedTypes(t *testing.T) {
 		falseCondition := map[string]interface{}{"type": "CustomAbnormalTrue", "status": "False"}
 		if !isStatusConditionHealthy(falseCondition) {
 			t.Errorf("expected user provided abnormal-true condition type with status False to be healthy")
+		}
+	})
+
+	t.Run("user provided suffix and prefix patterns", func(t *testing.T) {
+		resetUserAbnormalTrueConditionTypes()
+		home := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(home, ".kubectl-status"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		content := "*Problematic\nUnhealthy*\n"
+		path := filepath.Join(home, ".kubectl-status", "abnormal-true-condition-types")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HOME", home)
+
+		suffixMatch := map[string]interface{}{"type": "DiskProblematic", "status": "True"}
+		if isStatusConditionHealthy(suffixMatch) {
+			t.Errorf("expected type matching the '*Problematic' suffix pattern with status True to be unhealthy")
+		}
+		prefixMatch := map[string]interface{}{"type": "UnhealthyDisk", "status": "True"}
+		if isStatusConditionHealthy(prefixMatch) {
+			t.Errorf("expected type matching the 'Unhealthy*' prefix pattern with status True to be unhealthy")
+		}
+		noMatch := map[string]interface{}{"type": "SomethingElse", "status": "True"}
+		if !isStatusConditionHealthy(noMatch) {
+			t.Errorf("expected type not matching any user pattern to keep the default 'True is healthy' polarity")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Users can now list extra condition types in `~/.kubectl-status/abnormal-true-condition-types` (one per line) to extend the hardcoded set that treats `status: "True"` as unhealthy, without recompiling.
- Expands the hardcoded list itself with several additional node/NPD condition types seen in the wild (e.g. `GPUXIDErrors`, `XIDErrors`, `NVLinkStatusInactive`, `KubeletUnhealthy`, `ContainerRuntimeUnhealthy`, `OutOfDisk`, etc).
- Documents the new file in the README next to the existing `~/.kubectl-status/templates/` override docs.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `TestIsStatusConditionHealthyUserProvidedTypes`, which writes a real file under a temp `HOME` and asserts the polarity flip for user-provided types