### PR TITLE
Retry e2e tests on CI to reduce flakiness

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,4 +23,9 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           addons: metrics-server
-      - run: ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
+      - name: Run e2e tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e


### PR DESCRIPTION
## Summary
- The e2e suite occasionally fails on a different flaky subtest each run (e.g. `pod-container-logs` timing out waiting for CrashLoopBackOff, `node metrics` timing out waiting for metrics-server scrapes), due to shared GitHub Actions runner/minikube slowness rather than actual bugs.
- Wrap the `make test-e2e` CI step with `nick-fields/retry@v3` (2 attempts, 15 min timeout each) so a transient slow-runner day doesn't fail the whole job.

## Test plan
- [x] `make test` passes locally
- [ ] Confirm the `ci-test` workflow runs successfully on this PR