### PR TITLE
Surface kubelet configz/healthz on Node, merge allocatable/capacity line

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,7 +196,7 @@ func addRenderFlags(flags *pflag.FlagSet) {
 	flags.Bool("include-node-lease", false,
 		"Include node lease details.")
 	flags.Bool("include-node-kubelet-api-summary", true,
-		"Include Kubelet API stats/summary in the output.")
+		"Include Kubelet API healthz, configz and stats/summary in the output.")
 	flags.Bool("include-node-detailed-usage", true,
 		"Include details about Pods' resource usage on a node. Does lots of queries against API Server and causes dramatic slow down.")
 	flags.Bool("shallow", false,

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -71,6 +71,8 @@ func NewResourceRepo(factory util.Factory) (*ResourceRepo, error) {
 		dynamicClient:         dynamicClient,
 		kubernetesClientSet:   kubernetesClientSet,
 		nodeStatsSummaryCache: make(map[string]nodeStatsSummaryCacheEntry),
+		nodeConfigzCache:      make(map[string]nodeConfigzCacheEntry),
+		nodeHealthzCache:      make(map[string]nodeHealthzCacheEntry),
 		objectsCache:          make(map[string]objectsCacheEntry),
 		endpointSlicesCache:   make(map[string]endpointSlicesCacheEntry),
 		ownerCache:            make(map[string]ownerCacheEntry),
@@ -82,6 +84,8 @@ type ResourceRepo struct {
 	dynamicClient                 dynamic.Interface
 	kubernetesClientSet           *kubernetes.Clientset
 	nodeStatsSummaryCache         map[string]nodeStatsSummaryCacheEntry
+	nodeConfigzCache              map[string]nodeConfigzCacheEntry
+	nodeHealthzCache              map[string]nodeHealthzCacheEntry
 	objectsCache                  map[string]objectsCacheEntry
 	endpointSlicesCache           map[string]endpointSlicesCacheEntry
 	allNamespacesPodMetricsCache  *objectsCacheEntry
@@ -91,6 +95,16 @@ type ResourceRepo struct {
 
 type nodeStatsSummaryCacheEntry struct {
 	summary Object
+	err     error
+}
+
+type nodeConfigzCacheEntry struct {
+	configz Object
+	err     error
+}
+
+type nodeHealthzCacheEntry struct {
+	healthz string
 	err     error
 }
 
@@ -484,6 +498,68 @@ func (r *ResourceRepo) kubeGetNodeStatsSummaryUncached(nodeName string) (Object,
 	nodeStatsSummary := make(Object)
 	err = json.Unmarshal(getBytes, &nodeStatsSummary)
 	return nodeStatsSummary, err
+}
+
+// KubeGetNodeConfigz returns this structure
+// > kubectl get --raw /api/v1/nodes/{nodeName}/proxy/configz
+// This surfaces the effective KubeletConfiguration, including settings not otherwise visible on the
+// Node object (eviction thresholds, per-node QoS manager policies, pids limits, etc).
+func (r *ResourceRepo) KubeGetNodeConfigz(nodeName string) (Object, error) {
+	if entry, ok := r.nodeConfigzCache[nodeName]; ok {
+		return entry.configz, entry.err
+	}
+	nodeConfigz, err := r.kubeGetNodeConfigzUncached(nodeName)
+	if r.nodeConfigzCache == nil {
+		r.nodeConfigzCache = make(map[string]nodeConfigzCacheEntry)
+	}
+	r.nodeConfigzCache[nodeName] = nodeConfigzCacheEntry{configz: nodeConfigz, err: err}
+	return nodeConfigz, err
+}
+
+func (r *ResourceRepo) kubeGetNodeConfigzUncached(nodeName string) (Object, error) {
+	getBytes, err := r.kubernetesClientSet.CoreV1().RESTClient().Get().
+		Resource("nodes").
+		SubResource("proxy").
+		Name(nodeName).
+		Suffix("configz").
+		DoRaw(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+	nodeConfigz := make(Object)
+	err = json.Unmarshal(getBytes, &nodeConfigz)
+	return nodeConfigz, err
+}
+
+// KubeGetNodeHealthz returns the raw body of
+// > kubectl get --raw /api/v1/nodes/{nodeName}/proxy/healthz
+// Unlike the Node's Ready condition (which reflects the kubelet's self-reported heartbeat to the
+// apiserver), this exercises the apiserver->kubelet proxy path directly, the same path used by
+// kubectl logs/exec/attach, metrics-server and any node-hosted admission webhooks. A Ready node can
+// still fail this check if that path is blocked (e.g. port 10250 unreachable).
+func (r *ResourceRepo) KubeGetNodeHealthz(nodeName string) (string, error) {
+	if entry, ok := r.nodeHealthzCache[nodeName]; ok {
+		return entry.healthz, entry.err
+	}
+	nodeHealthz, err := r.kubeGetNodeHealthzUncached(nodeName)
+	if r.nodeHealthzCache == nil {
+		r.nodeHealthzCache = make(map[string]nodeHealthzCacheEntry)
+	}
+	r.nodeHealthzCache[nodeName] = nodeHealthzCacheEntry{healthz: nodeHealthz, err: err}
+	return nodeHealthz, err
+}
+
+func (r *ResourceRepo) kubeGetNodeHealthzUncached(nodeName string) (string, error) {
+	getBytes, err := r.kubernetesClientSet.CoreV1().RESTClient().Get().
+		Resource("nodes").
+		SubResource("proxy").
+		Name(nodeName).
+		Suffix("healthz").
+		DoRaw(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	return string(getBytes), nil
 }
 
 func (r *ResourceRepo) NonTerminatedPodsOnTheNode(nodeName string) (Objects, error) {

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -537,6 +537,35 @@ func (r RenderableObject) KubeGetNodeStatsSummary(nodeName string) map[string]in
 	return nodeStatsSummary
 }
 
+func (r RenderableObject) KubeGetNodeConfigz(nodeName string) map[string]interface{} {
+	if viper.GetBool("shallow") {
+		return nil
+	}
+	klog.V(5).InfoS("called KubeGetNodeConfigz", "r", r, "node", nodeName)
+	nodeConfigz, err := r.repo.KubeGetNodeConfigz(nodeName)
+	if err != nil {
+		klog.V(3).ErrorS(err, "failed to get node configz", "r", r, "node", nodeName)
+		return nil
+	}
+	return nodeConfigz
+}
+
+// KubeGetNodeHealthz returns the kubelet proxy healthz body, or a description of the failure if the
+// apiserver->kubelet proxy path is unreachable. The error is surfaced (not swallowed) since a failure
+// here is the whole point of the check.
+func (r RenderableObject) KubeGetNodeHealthz(nodeName string) string {
+	if viper.GetBool("shallow") {
+		return ""
+	}
+	klog.V(5).InfoS("called KubeGetNodeHealthz", "r", r, "node", nodeName)
+	nodeHealthz, err := r.repo.KubeGetNodeHealthz(nodeName)
+	if err != nil {
+		klog.V(3).ErrorS(err, "failed to get node healthz", "r", r, "node", nodeName)
+		return fmt.Sprintf("unreachable: %v", err)
+	}
+	return strings.TrimSpace(nodeHealthz)
+}
+
 // KubeGetPodMetrics returns the PodMetrics for the named pod. It first tries a single cluster-wide
 // PodMetrics list, reused for every pod/node in the render (see AllNamespacesPodMetrics). If that's
 // not available (e.g. RBAC only allows namespace-scoped access), it falls back to fetching

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -81,6 +81,7 @@ func funcMap() template.FuncMap {
 		"percent":                   percent,
 		"colorPercent":              colorPercent,
 		"humanizeSI":                humanizeSI,
+		"humanizeSIPair":            humanizeSIPair,
 		"getMatchingItemInMapList":  getMatchingItemInMapList,
 		"sortMapListByKeysValue":    sortMapListByKeysValue,
 		"sortByRevisionAnnotation":  sortByRevisionAnnotation,
@@ -132,6 +133,17 @@ func divFloat64(a, b float64) float64 {
 
 func humanizeSI(unit string, input float64) string {
 	return strings.Replace(humanize.SIWithDigits(input, 1, unit), " ", "", -1)
+}
+
+// humanizeSIPair renders two related values (e.g. allocatable/capacity) under a single shared SI
+// unit, scaled to the larger of the two, e.g. humanizeSIPair("B", 32.8e9, 33.6e9) -> "32.8/33.6GB".
+func humanizeSIPair(unit string, a, b float64) string {
+	scaledB, prefix := humanize.ComputeSI(b)
+	scale := 1.0
+	if scaledB != 0 {
+		scale = b / scaledB
+	}
+	return fmt.Sprintf("%s/%s%s", humanize.FtoaWithDigits(a/scale, 1), humanize.FtoaWithDigits(scaledB, 1), prefix+unit)
 }
 
 func quantityToFloat64(str string) float64 {

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -68,7 +68,7 @@
         {{- with $kc.cpuManagerPolicy }}{{ if ne . "none" }} cpuManager:{{ . }}{{ end }}{{ end }}
         {{- with $kc.memoryManagerPolicy }}{{ if ne . "None" }} memoryManager:{{ . }}{{ end }}{{ end }}
         {{- with $kc.topologyManagerPolicy }}{{ if ne . "none" }} topologyManager:{{ . }}{{ end }}{{ end }}
-        {{- with $kc.shutdownGracePeriod }}{{ if ne . "0s" }} shutdownGracePeriod:{{ . }}/{{ $kc.shutdownGracePeriodCriticalPods }}(critical){{ end }}{{ end }}
+        {{- with $kc.shutdownGracePeriod }}{{ if ne . "0s" }} shutdownGracePeriod:{{ . }}{{ with $kc.shutdownGracePeriodCriticalPods }}/{{ . }}{{ end }}(critical){{ end }}{{ end }}
         {{- with $kc.evictionHard }}
             {{- "eviction-hard" | nindent 4 }}:
             {{- if hasKey . "memory.available" }} mem.available<{{ index . "memory.available" }}{{ end }}

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -44,12 +44,56 @@
 
 {{- define "kubelet_api_summary" }}
     {{- if .Config.GetBool "include-node-kubelet-api-summary" }}
+        {{- with .KubeGetNodeHealthz .Name }}
+            {{- "kubelet-api/healthz" | nindent 2 }}: {{ if eq . "ok" }}{{ . }}{{ else }}{{ . | red | bold }}{{ end }}
+        {{- end }}
+        {{- with .KubeGetNodeConfigz .Name }}
+            {{- template "kubelet_configz_summary" . }}
+        {{- end }}
         {{- with .KubeGetNodeStatsSummary .Name }}
             {{- "kubelet-api/stats/summary"  | nindent 2 }}:
             {{- "node overall" | nindent 4 }}: {{ template "node_stats_summary_resources" .node }}
             {{- range .node.systemContainers }}
                 {{- .name | nindent 4 }}: {{ template "node_stats_summary_resources" . }}
             {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "kubelet_configz_summary" }}
+    {{- /* Expects kubelet-api/configz -> kubeletconfig */ -}}
+    {{- with $kc := .kubeletconfig }}
+        {{- "kubelet-api/configz" | nindent 2 }}:
+        {{- with $kc.podPidsLimit }}{{ if ge (. | float64) 0.0 }} podPidsLimit:{{ . }}{{ end }}{{ end }}
+        {{- with $kc.cpuManagerPolicy }}{{ if ne . "none" }} cpuManager:{{ . }}{{ end }}{{ end }}
+        {{- with $kc.memoryManagerPolicy }}{{ if ne . "None" }} memoryManager:{{ . }}{{ end }}{{ end }}
+        {{- with $kc.topologyManagerPolicy }}{{ if ne . "none" }} topologyManager:{{ . }}{{ end }}{{ end }}
+        {{- with $kc.shutdownGracePeriod }}{{ if ne . "0s" }} shutdownGracePeriod:{{ . }}/{{ $kc.shutdownGracePeriodCriticalPods }}(critical){{ end }}{{ end }}
+        {{- with $kc.evictionHard }}
+            {{- "eviction-hard" | nindent 4 }}:
+            {{- if hasKey . "memory.available" }} mem.available<{{ index . "memory.available" }}{{ end }}
+            {{- if hasKey . "nodefs.available" }} nodefs.available<{{ index . "nodefs.available" }}{{ end }}
+            {{- if hasKey . "nodefs.inodesFree" }} nodefs.inodesFree<{{ index . "nodefs.inodesFree" }}{{ end }}
+            {{- if hasKey . "imagefs.available" }} imagefs.available<{{ index . "imagefs.available" }}{{ end }}
+            {{- if hasKey . "imagefs.inodesFree" }} imagefs.inodesFree<{{ index . "imagefs.inodesFree" }}{{ end }}
+            {{- if hasKey . "pid.available" }} pid.available<{{ index . "pid.available" }}{{ end }}
+        {{- end }}
+        {{- with $kc.containerLogMaxSize }}
+            {{- "container log rotation" | nindent 4 }}: {{ . }} cap, {{ $kc.containerLogMaxFiles }} files, {{ $kc.containerLogMaxWorkers }} worker, {{ $kc.containerLogMonitorInterval }} monitor
+        {{- end }}
+        {{- with $kc.systemReserved }}
+            {{- "systemReserved" | nindent 4 }}:
+            {{- with .cpu }} cpu:{{ . }}{{ end }}
+            {{- with .memory }} mem:{{ . }}{{ end }}
+            {{- with index . "ephemeral-storage" }} ephemeral-storage:{{ . }}{{ end }}
+            {{- with .pid }} pid:{{ . }}{{ end }}
+        {{- end }}
+        {{- with $kc.kubeReserved }}
+            {{- "kubeReserved" | nindent 4 }}:
+            {{- with .cpu }} cpu:{{ . }}{{ end }}
+            {{- with .memory }} mem:{{ . }}{{ end }}
+            {{- with index . "ephemeral-storage" }} ephemeral-storage:{{ . }}{{ end }}
+            {{- with .pid }} pid:{{ . }}{{ end }}
         {{- end }}
     {{- end }}
 {{- end -}}
@@ -150,14 +194,15 @@
 {{- end }}
 
 {{- define "node_capacity" }}
-    {{- "allocatable" | nindent 2 }}: pods:{{ .Status.allocatable.pods -}}
-    , cpu:{{ .Status.allocatable.cpu | quantityToFloat64 | printf "%g" -}}
-    , mem:{{ .Status.allocatable.memory | quantityToFloat64 | humanizeSI "B" }}
-    {{- with index .Status.allocatable "ephemeral-storage" }}, ephemeral-storage:{{ . | quantityToFloat64 | humanizeSI "B" }}{{ end }}
-    {{- "capacity" | nindent 2 }}: pods:{{ .Status.capacity.pods -}}
-    , cpu:{{ .Status.capacity.cpu | quantityToFloat64 | printf "%g" -}}
-    , mem:{{ .Status.capacity.memory | quantityToFloat64 | humanizeSI "B" -}}
-    {{- with index .Status.capacity "ephemeral-storage" }}, ephemeral-storage:{{ . | quantityToFloat64 | humanizeSI "B" }}{{ end }}
+    {{- "allocatable/capacity" | nindent 2 }}: pods {{ .Status.allocatable.pods }}/{{ .Status.capacity.pods -}}
+    , cpu {{ .Status.allocatable.cpu | quantityToFloat64 | printf "%g" }}/{{ .Status.capacity.cpu | quantityToFloat64 | printf "%g" -}}
+    , mem {{ humanizeSIPair "B" (.Status.allocatable.memory | quantityToFloat64) (.Status.capacity.memory | quantityToFloat64) }}
+    {{- with index .Status.capacity "ephemeral-storage" }}
+        {{- $capacityEphemeral := . }}
+        {{- with index $.Status.allocatable "ephemeral-storage" }}
+            {{- ", ephemeral-storage " }}{{ humanizeSIPair "B" (. | quantityToFloat64) ($capacityEphemeral | quantityToFloat64) }}
+        {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "node_stats_summary_fs" }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -542,3 +542,94 @@ func TestNodePodDetailsMetricsNotInstalledWarningTemplate(t *testing.T) {
 	}
 	checkTemplate(t, "node_pod_details", obj, "not installed", true)
 }
+
+// aksKubeletConfigzObj mirrors a real AKS node's `kubectl get --raw
+// /api/v1/nodes/{node}/proxy/configz` response (trimmed to the fields the
+// "kubelet_configz_summary" template reads). It exercises fields that other fixtures/clusters seen
+// so far didn't have set: eviction on pid.available, and kubeReserved without ephemeral-storage.
+// The live proxy call itself isn't reachable in these offline tests, so the template is rendered
+// directly against this static payload instead of going through KubeGetNodeConfigz.
+func aksKubeletConfigzObj() map[string]interface{} {
+	return map[string]interface{}{
+		"kubeletconfig": map[string]interface{}{
+			"evictionHard": map[string]interface{}{
+				"memory.available":  "100Mi",
+				"nodefs.available":  "10%",
+				"nodefs.inodesFree": "5%",
+				"pid.available":     "2000",
+			},
+			"containerLogMaxSize":         "50M",
+			"containerLogMaxFiles":        float64(5),
+			"containerLogMaxWorkers":      float64(1),
+			"containerLogMonitorInterval": "10s",
+			"kubeReserved": map[string]interface{}{
+				"cpu":    "180m",
+				"memory": "650Mi",
+				"pid":    "1000",
+			},
+			"podPidsLimit":                    float64(-1),
+			"cpuManagerPolicy":                "none",
+			"memoryManagerPolicy":             "None",
+			"topologyManagerPolicy":           "none",
+			"shutdownGracePeriod":             "0s",
+			"shutdownGracePeriodCriticalPods": "0s",
+		},
+	}
+}
+
+func TestKubeletConfigzSummaryTemplateAKSEvictionHard(t *testing.T) {
+	got := renderConfigzSummary(t, aksKubeletConfigzObj())
+	want := "eviction-hard: mem.available<100Mi nodefs.available<10% nodefs.inodesFree<5% pid.available<2000"
+	if !strings.Contains(got, want) {
+		t.Errorf("got = %q, want substring %q", got, want)
+	}
+}
+
+func TestKubeletConfigzSummaryTemplateAKSContainerLogRotation(t *testing.T) {
+	got := renderConfigzSummary(t, aksKubeletConfigzObj())
+	want := "container log rotation: 50M cap, 5 files, 1 worker, 10s monitor"
+	if !strings.Contains(got, want) {
+		t.Errorf("got = %q, want substring %q", got, want)
+	}
+}
+
+func TestKubeletConfigzSummaryTemplateAKSKubeReservedWithoutEphemeralStorage(t *testing.T) {
+	got := renderConfigzSummary(t, aksKubeletConfigzObj())
+	want := "kubeReserved: cpu:180m mem:650Mi pid:1000"
+	if !strings.Contains(got, want) {
+		t.Errorf("got = %q, want substring %q", got, want)
+	}
+	if strings.Contains(got, "systemReserved") {
+		t.Errorf("expected no systemReserved line when absent from configz, got = %q", got)
+	}
+}
+
+// TestKubeletConfigzSummaryTemplateDefaultPoliciesHidden asserts the manager-policy/pidsLimit/
+// shutdownGracePeriod fields stay hidden when they're at their default values, matching the
+// codebase's convention of only calling out settings that deviate from the norm.
+func TestKubeletConfigzSummaryTemplateDefaultPoliciesHidden(t *testing.T) {
+	got := renderConfigzSummary(t, aksKubeletConfigzObj())
+	for _, unwanted := range []string{"podPidsLimit", "cpuManager", "memoryManager", "topologyManager", "shutdownGracePeriod"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("expected %q to stay hidden at default value, got = %q", unwanted, got)
+		}
+	}
+}
+
+func renderConfigzSummary(t *testing.T, configz map[string]interface{}) string {
+	t.Helper()
+	tmpl, _ := getTemplate()
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard())
+	e.Template = *tmpl
+	r := newRenderableObject(map[string]interface{}{}, e, repo)
+	got, err := r.renderTemplate("kubelet_configz_summary", configz)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	return got
+}

--- a/tests/artifacts/node-aks.out
+++ b/tests/artifacts/node-aks.out
@@ -9,5 +9,4 @@ Node/aks-cpuworkers-41776494-vmss00006u, created 1m ago
   PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready KubeletReady, kubelet is posting ready status. AppArmor enabled for 1m
   addresses: Hostname=aks-cpuworkers-41776494-vmss00006u InternalIP=10.250.4.65
-  allocatable: pods:30, cpu:7.82, mem:29.1GB, ephemeral-storage:59.7GB
-  capacity: pods:30, cpu:8, mem:33.7GB, ephemeral-storage:66.4GB
+  allocatable/capacity: pods 30/30, cpu 7.82/8, mem 29.1/33.7GB, ephemeral-storage 59.7/66.4GB

--- a/tests/artifacts/node-and-service.out
+++ b/tests/artifacts/node-and-service.out
@@ -8,8 +8,7 @@ Node/minikube, created 1m ago
   PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.49.2 Hostname=minikube
-  allocatable: pods:110, cpu:16, mem:33.3GB, ephemeral-storage:997.3GB
-  capacity: pods:110, cpu:16, mem:33.3GB, ephemeral-storage:997.3GB
+  allocatable/capacity: pods 110/110, cpu 16/16, mem 33.3/33.3GB, ephemeral-storage 997.3/997.3GB
 
 Service/kubernetes -n default, created 1m ago
   Current: Service is ready

--- a/tests/artifacts/node-minikube-with-metrics.out
+++ b/tests/artifacts/node-minikube-with-metrics.out
@@ -8,5 +8,4 @@ Node/minikube, created 1m ago
   PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.105 Hostname=minikube
-  allocatable: pods:110, cpu:2, mem:1.9GB, ephemeral-storage:16.3GB
-  capacity: pods:110, cpu:2, mem:2GB, ephemeral-storage:18.2GB
+  allocatable/capacity: pods 110/110, cpu 2/2, mem 1.9/2GB, ephemeral-storage 16.3/18.2GB

--- a/tests/artifacts/node-minikube.out
+++ b/tests/artifacts/node-minikube.out
@@ -8,5 +8,4 @@ Node/minikube, created 1m ago
   PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.102 Hostname=minikube
-  allocatable: pods:110, cpu:2, mem:1.9GB, ephemeral-storage:16.3GB
-  capacity: pods:110, cpu:2, mem:2GB, ephemeral-storage:18.2GB
+  allocatable/capacity: pods 110/110, cpu 2/2, mem 1.9/2GB, ephemeral-storage 16.3/18.2GB

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -8,13 +8,16 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
   PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for \d+[a-z]+
   Ready KubeletReady, kubelet is posting ready status for \d+[a-z]+
   addresses: InternalIP=[\d.]+ Hostname=[a-z0-9.-]+
-  allocatable: pods:\d+, cpu:\d+, mem:[\d.]+[A-Za-z]+, ephemeral-storage:[\d.]+[A-Za-z]+
-  capacity: pods:\d+, cpu:\d+, mem:[\d.]+[A-Za-z]+, ephemeral-storage:[\d.]+[A-Za-z]+
+  allocatable/capacity: pods \d+/\d+, cpu [\d.]+/[\d.]+, mem [\d.]+/[\d.]+[A-Za-z]+, ephemeral-storage [\d.]+/[\d.]+[A-Za-z]+
   Inferred memory limits for BestEffort: [\d.]+[A-Za-z]+, for Burstable: [\d.]+[A-Za-z]+
   pods: usage/allocatable:\d+/\d+\(\d+%\)
   cpu: usage/allocatable:[\d.]+/\d+\(\d+%\), allocated usage:[\d.]+\(\d+% of allocatable\)/\[req:[\d.]+\(\d+% of allocatable\), lim:[\d.]+\(\d+% of allocatable\)\]
   mem: usage/allocatable:[\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+\(\d+%\), allocated usage:[\d.]+[A-Za-z]+\(\d+% of allocatable\)/\[req:[\d.]+[A-Za-z]+\(\d+% of allocatable\), lim:[\d.]+[A-Za-z]+\(\d+% of allocatable\)\]
   ephemeral-storage: [\d.]+[A-Za-z]+
+  kubelet-api/healthz: ok
+  kubelet-api/configz:
+    eviction-hard: nodefs.available<\d+% nodefs.inodesFree<\d+% imagefs.available<\d+%
+    container log rotation: [\d.]+[A-Za-z]+ cap, \d+ files, \d+ worker, \S+ monitor
   kubelet-api/stats/summary:
     node overall: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+, processes \S+/\S+ \(rlimit\)
       network: rx/tx [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, rx/tx errors \d+/\d+


### PR DESCRIPTION
## Summary
- Surface the kubelet's live `configz` and `healthz` proxy endpoints (`kubectl get --raw /api/v1/nodes/{node}/proxy/{configz,healthz}`) under the existing `include-node-kubelet-api-summary` flag:
  - `kubelet-api/healthz` exercises the apiserver→kubelet proxy path directly (distinct from the Node's self-reported `Ready` condition), catching cases where a Ready node still can't serve `kubectl logs`/`exec`, metrics-server scraping, or node-hosted admission webhooks.
  - `kubelet-api/configz` surfaces eviction-hard thresholds (including `pid.available`, `imagefs.inodesFree`), container log rotation settings, non-default QoS manager policies, and `systemReserved`/`kubeReserved` — none of which are derivable from the Node object elsewhere.
- Merge the previously separate `allocatable:`/`capacity:` lines into one `allocatable/capacity: pods 30/30, cpu 7.82/8, mem 32.8/33.6GB, ephemeral-storage 280.7/311.9GB` line, via a new `humanizeSIPair` helper that scales both values to a shared SI unit.
- Add unit tests (`templates_common_test.go`) rendering `kubelet_configz_summary` directly against a real AKS node's `kubeletconfig` payload, since the live proxy calls aren't reachable from the offline `--local` fixture tests.
- Update the `node-metrics-multi-namespace` e2e regex fixture for the new/merged Node output lines.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (432 passed)
- [x] `go vet ./...`
- [x] Verified live against a real minikube node (`kubectl-status node <name>`)
- [x] Re-ran the affected e2e test (`node_correctly_resolves_pod_metrics_for_pods_in_multiple_namespaces...`) against a live cluster after updating the regex fixture — passes
- [ ] Full `make test-e2e` — the local pre-push hook run hit repeated minikube apiserver crashes from local memory pressure (verified via `minikube status`/`free -h`, unrelated to this change); pushed with `SKIP=make-test-e2e` per user direction. CI's `test-e2e` job should be the authoritative run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)