### PR TITLE
Validate ConfigMap/Secret volumes exist and referenced keys are present

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1330,6 +1330,56 @@ func TestE2EDynamicManifests(t *testing.T) {
 			}.assert(t, nil)
 		})
 	})
+	t.Run("pod-volume-configmap-secret", func(t *testing.T) {
+		// --shallow (used by the offline golden-file tests) makes KubeGetFirst a no-op, so
+		// this e2e suite is the only place that exercises the configMap/secret volume
+		// existence and key-presence checks in Pod.tmpl's pod_volumes/pod_volume_line.
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/pod-volume-configmap-secret.yaml")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-configmap", "main", "ContainerCreating")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-secret", "main", "ContainerCreating")
+		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-key", "main", "ContainerCreating")
+		waitFor(t, "pod/e2e-pod-volume-optional-missing", "condition=Ready")
+		waitFor(t, "pod/e2e-pod-volume-optional-missing-key", "condition=Ready")
+		waitFor(t, "pod/e2e-pod-volume-healthy", "condition=Ready")
+
+		t.Run("pod referencing a non-existent ConfigMap volume flags it without --include-all-volumes", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-missing-configmap", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex",
+			}.assert(t, nil)
+		})
+		t.Run("pod referencing a non-existent Secret volume flags it without --include-all-volumes", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-missing-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex",
+			}.assert(t, nil)
+		})
+		t.Run("pod referencing an existing ConfigMap but a missing key flags it", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-missing-key", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-key.regex",
+			}.assert(t, nil)
+		})
+		t.Run("optional configMap volume referencing a non-existent ConfigMap shows no warning", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-optional-missing", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex",
+			}.assert(t, nil)
+		})
+		t.Run("optional configMap volume with items referencing a missing key shows no warning", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-optional-missing-key", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex",
+			}.assert(t, nil)
+		})
+		t.Run("healthy configMap and secret volumes show no warnings", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"pod/e2e-pod-volume-healthy", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-healthy.regex",
+			}.assert(t, nil)
+		})
+	})
 	t.Run("pod-container-logs", func(t *testing.T) {
 		// --shallow (used by the offline golden-file tests) makes KubeGetContainerLogs a
 		// no-op, so this e2e suite is the only place that exercises real log fetching: a

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -189,7 +189,7 @@
 {{- end }}
 
 {{- define "pod_volume_line" }}
-    {{- /* Renders a single volume spec entry. Expects dict "vol" (spec entry) "stats" (kubelet VolumeStats or nil) "pvcStorage" (optional PVC requested storage) */ -}}
+    {{- /* Renders a single volume spec entry. Expects dict "vol" (spec entry) "stats" (kubelet VolumeStats or nil) "pvcStorage" (optional PVC requested storage) "problem" (optional string, existence/key validation failure for a configMap/secret volume) */ -}}
     {{- .vol.name | bold }}
     {{- $inner := "" }}
     {{- $isPVC := false }}
@@ -227,6 +227,39 @@
         {{- end }}
     {{- end }}
     {{- if $inner }} ({{ $inner }}){{ end }}
+    {{- with .problem }} {{ . | red | bold }}{{ end }}
+{{- end }}
+
+{{- define "pod_volume_configmap_secret_problem" }}
+    {{- /* Checks a configMap/secret volume source for existence and (when items are listed) key
+           presence, returning a short problem string or "" -- the caller already renders the
+           "(ConfigMap: name)"/"(Secret: name)" part, so this only needs the tail. Expects dict
+           "kind" ("ConfigMap" or "Secret") "ctx" (Pod RenderableObject) "name" (object name)
+           "optional" (bool) "items" (list of KeyToPath, or nil). */ -}}
+    {{- $obj := $.ctx.KubeGetFirst $.ctx.Namespace $.kind $.name }}
+    {{- $problem := "" }}
+    {{- if not $obj.Object }}
+        {{- if not $.optional }}{{ $problem = "doesn't exist" }}{{ end }}
+    {{- else if not $.optional }}
+        {{- /* "optional" on the volume source governs both the object's existence and its keys
+               (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#configmapvolumesource-v1-core)
+               -- there's no per-item override, so a missing key is only a problem when the whole
+               source isn't optional. */ -}}
+        {{- $keys := keys ($obj.Object.data | default dict) }}
+        {{- if eq $.kind "ConfigMap" }}
+            {{- $keys = concat $keys (keys ($obj.Object.binaryData | default dict)) }}
+        {{- end }}
+        {{- $missingKeys := list }}
+        {{- range $.items }}
+            {{- if not ($keys | has .key) }}
+                {{- $missingKeys = append $missingKeys (.key | quote) }}
+            {{- end }}
+        {{- end }}
+        {{- with $missingKeys }}
+            {{- $problem = printf "missing key%s %s" (ternary "s" "" (gt (len .) 1)) (join ", " .) }}
+        {{- end }}
+    {{- end }}
+    {{- $problem }}
 {{- end }}
 
 {{- define "pod_volumes" }}
@@ -237,6 +270,23 @@
         {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $.Metadata.uid) }}
     {{- end }}
     {{- $ephemeralStorage := index $podStatsSummary "ephemeral-storage" }}
+    {{- /* Check configMap/secret volumes for existence and (when items are listed) key presence.
+           Gated behind "shallow" like the imagePullSecrets check above -- offline golden tests run
+           --shallow, making KubeGetFirst a no-op there; only the live e2e suite exercises this. */ -}}
+    {{- $volProblems := dict }}
+    {{- if not ($.Config.GetBool "shallow") }}
+        {{- range $.Spec.volumes }}
+            {{- if hasKey . "configMap" }}
+                {{- $cm := .configMap }}
+                {{- $problem := $.Include "pod_volume_configmap_secret_problem" (dict "kind" "ConfigMap" "ctx" $ "name" $cm.name "optional" ($cm.optional | default false) "items" ($cm.items | default list)) }}
+                {{- if $problem }}{{ $volProblems = set $volProblems .name $problem }}{{ end }}
+            {{- else if hasKey . "secret" }}
+                {{- $sec := .secret }}
+                {{- $problem := $.Include "pod_volume_configmap_secret_problem" (dict "kind" "Secret" "ctx" $ "name" $sec.secretName "optional" ($sec.optional | default false) "items" ($sec.items | default list)) }}
+                {{- if $problem }}{{ $volProblems = set $volProblems .name $problem }}{{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- /* Build the list of volumes to show by default (size-relevant) and under the gate */ -}}
     {{- $displayVols := list }}
     {{- range $.Spec.volumes }}
@@ -248,6 +298,9 @@
             {{- with $podStatsSummary.volume | default list | getMatchingItemInMapList (dict "name" $vol.name) }}
                 {{- $displayVols = append $displayVols $vol }}
             {{- end }}
+        {{- else if hasKey $volProblems $vol.name }}
+            {{- /* a broken configMap/secret volume must surface even without --include-all-volumes */ -}}
+            {{- $displayVols = append $displayVols . }}
         {{- else if $.Config.GetBool "include-all-volumes" }}
             {{- $displayVols = append $displayVols . }}
         {{- end }}
@@ -277,7 +330,7 @@
                         {{- $pvcStorage = index $pvcRequests "storage" | default "" }}
                     {{- end }}
                 {{- end }}
-                {{- " " }}{{ template "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage) }}
+                {{- " " }}{{ template "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage "problem" (index $volProblems $vol.name)) }}
                 {{- if and $deep $pvc.Metadata }}
                     {{- $.Include "PersistentVolumeClaim" $pvc | nindent 4 }}
                 {{- end }}
@@ -302,7 +355,7 @@
                         {{- $pvcStorage = index $pvcRequests "storage" | default "" }}
                     {{- end }}
                 {{- end }}
-                {{- $.Include "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage) | nindent 4 }}
+                {{- $.Include "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage "problem" (index $volProblems $vol.name)) | nindent 4 }}
                 {{- if and $deep $pvc.Metadata }}
                     {{- $.Include "PersistentVolumeClaim" $pvc | nindent 6 }}
                 {{- end }}

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
@@ -4,7 +4,7 @@ Pod/e2e-pod-volume-healthy -n default, created 1m ago, gen:1, started after 1m R
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volume Mounts:
     /cfg from cfg
     /sec from sec

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
@@ -1,0 +1,17 @@
+\A
+Pod/e2e-pod-volume-healthy -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+  Current: Pod is Ready
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  Volume Mounts:
+    /cfg from cfg
+    /sec from sec
+    /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)
+  Volumes:(?:
+    ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
+    cfg \(ConfigMap: e2e-cm-with-data(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+    sec \(Secret: e2e-secret-healthy-vol(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+    kube-api-access-[a-z0-9]+ \(Projected(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
@@ -1,0 +1,12 @@
+\A
+Pod/e2e-pod-volume-missing-configmap -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    PodReadyToStartContainers for 1m
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
+  Volumes: cfg \(ConfigMap: e2e-cm-does-not-exist\) doesn't exist
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
@@ -1,0 +1,12 @@
+\A
+Pod/e2e-pod-volume-missing-key -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    PodReadyToStartContainers for 1m
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
+  Volumes: cfg \(ConfigMap: e2e-cm-with-data\) missing key "missing-key"
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
@@ -1,0 +1,12 @@
+\A
+Pod/e2e-pod-volume-missing-secret -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
+    PodReadyToStartContainers for 1m
+    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
+  Volumes: sec \(Secret: e2e-secret-does-not-exist\) doesn't exist
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
@@ -4,7 +4,7 @@ Pod/e2e-pod-volume-optional-missing-key -n default, created 1m ago, gen:1, start
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volume Mounts:
     /cfg from cfg
     /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
@@ -1,0 +1,15 @@
+\A
+Pod/e2e-pod-volume-optional-missing-key -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+  Current: Pod is Ready
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  Volume Mounts:
+    /cfg from cfg
+    /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)
+  Volumes:(?:
+    ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
+    cfg \(ConfigMap: e2e-cm-with-data(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+    kube-api-access-[a-z0-9]+ \(Projected(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
@@ -1,0 +1,15 @@
+\A
+Pod/e2e-pod-volume-optional-missing -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+  Current: Pod is Ready
+  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  Standalone POD\.
+  Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  Volume Mounts:
+    /cfg from cfg
+    /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)
+  Volumes:(?:
+    ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
+    cfg \(ConfigMap: e2e-cm-optional-missing(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+    kube-api-access-[a-z0-9]+ \(Projected(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+\z

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
@@ -4,7 +4,7 @@ Pod/e2e-pod-volume-optional-missing -n default, created 1m ago, gen:1, started a
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\)
+  (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volume Mounts:
     /cfg from cfg
     /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)

--- a/tests/e2e-artifacts/pod-volume-configmap-secret.yaml
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-cm-with-data
+  namespace: default
+data:
+  existing-key: hello
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-secret-healthy-vol
+  namespace: default
+type: Opaque
+data:
+  key1: aGVsbG8=
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-missing-configmap
+  namespace: default
+spec:
+  volumes:
+  - name: cfg
+    configMap:
+      name: e2e-cm-does-not-exist
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: cfg
+      mountPath: /cfg
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-missing-secret
+  namespace: default
+spec:
+  volumes:
+  - name: sec
+    secret:
+      secretName: e2e-secret-does-not-exist
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: sec
+      mountPath: /sec
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-missing-key
+  namespace: default
+spec:
+  volumes:
+  - name: cfg
+    configMap:
+      name: e2e-cm-with-data
+      items:
+      - key: missing-key
+        path: out.txt
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: cfg
+      mountPath: /cfg
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-optional-missing
+  namespace: default
+spec:
+  volumes:
+  - name: cfg
+    configMap:
+      name: e2e-cm-optional-missing
+      optional: true
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: cfg
+      mountPath: /cfg
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-optional-missing-key
+  namespace: default
+spec:
+  volumes:
+  - name: cfg
+    configMap:
+      name: e2e-cm-with-data
+      optional: true
+      items:
+      - key: also-missing-key
+        path: out.txt
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: cfg
+      mountPath: /cfg
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: e2e-pod-volume-healthy
+  namespace: default
+spec:
+  volumes:
+  - name: cfg
+    configMap:
+      name: e2e-cm-with-data
+  - name: sec
+    secret:
+      secretName: e2e-secret-healthy-vol
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    volumeMounts:
+    - name: cfg
+      mountPath: /cfg
+    - name: sec
+      mountPath: /sec


### PR DESCRIPTION
## Summary
- `Pod.tmpl`'s `pod_volume_line` used to render `configMap`/`secret` volumes as a bare name with no existence or key check, so a Pod stuck in `CreateContainerConfigError` from a missing ConfigMap/Secret (or key) was invisible from `kubectl status`, forcing a manual `kubectl describe` round-trip.
- `pod_volumes` now checks existence and (when `items` are listed) key presence for each configMap/secret volume, honoring the volume source's `optional` flag (which governs both object and key existence per the Kubernetes API — there's no per-item override).
- A broken volume now surfaces by default even without `--include-all-volumes`, since otherwise the flag would stay invisible unless a user already suspected a volume problem.
- Scope: volumes only, per the issue title. `envFrom`/`env.valueFrom` and projected-volume sources are deliberately out of scope for this change.

Closes #676

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./... -count=1` all clean
- [x] New live e2e suite `TestE2EDynamicManifests/pod-volume-configmap-secret` (`cmd/main_test.go`) covers 6 cases against a real cluster, run repeatedly for stability:
  - missing ConfigMap volume → flagged
  - missing Secret volume → flagged
  - existing ConfigMap with a missing key → flagged
  - `optional: true` + missing object → no flag
  - `optional: true` + missing key (via `items`) → no flag
  - fully healthy ConfigMap + Secret volumes → no flags
- [x] Confirmed via exhaustive grep that no other `tests/e2e-artifacts/*.yaml` fixture has a Pod referencing a `configMap`/`secret` volume, so the new default-visible-problem behavior can't regress an existing fixture.
- [x] Fixtures tolerate the metrics-server/volume-stats availability race already handled elsewhere in the suite (e.g. `pdb-empty-selector-conflict.pod.regex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)