### PR TITLE
Silence per-call sprout deprecation-signature WARN logs

### DIFF
--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -1,7 +1,9 @@
 package plugin
 
 import (
+	"context"
 	"embed"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -13,6 +15,70 @@ import (
 
 //go:embed templates
 var templatesFS embed.FS
+
+// go-sprout (our sprig replacement) logs a WARN via slog on every call to a
+// function whose signature changed during the sprig->sprout migration (e.g.
+// get, hasKey, append). These fire once per template execution per call site,
+// so they flood the output; sprigin gives no way to disable them other than
+// filtering the global slog default handler. See
+// https://github.com/bergerx/kubectl-status/issues/688 for migrating the
+// templates to the new signatures, at which point this filter can go away.
+//
+// The fallback handler is built fresh (not by wrapping the pre-existing
+// slog.Default().Handler()): the zero-value default handler bridges back
+// into the standard "log" package's global, mutex-protected logger, and
+// re-installing a wrapper around it as the new default causes that bridge
+// to call back into itself, deadlocking on the mutex.
+func init() {
+	slog.SetDefault(slog.New(deprecationNoticeFilter{Handler: slog.NewTextHandler(os.Stderr, nil)}))
+}
+
+// deprecationNoticeFilter drops log records tagged with a "notice"="deprecated"
+// attribute. go-sprout's deprecated.SignatureWarn attaches that attribute via
+// Logger.With(...) rather than as a Record attribute, so WithAttrs must be
+// overridden explicitly here too: without it, Go's method promotion on the
+// embedded slog.Handler returns the *inner* handler from WithAttrs, silently
+// discarding this wrapper for every subsequent Handle call.
+type deprecationNoticeFilter struct {
+	slog.Handler
+	drop bool
+}
+
+func isDeprecatedNoticeAttr(a slog.Attr) bool {
+	return a.Key == "notice" && a.Value.Kind() == slog.KindString && a.Value.String() == "deprecated"
+}
+
+func (h deprecationNoticeFilter) Handle(ctx context.Context, r slog.Record) error {
+	if h.drop {
+		return nil
+	}
+	drop := false
+	r.Attrs(func(a slog.Attr) bool {
+		if isDeprecatedNoticeAttr(a) {
+			drop = true
+			return false
+		}
+		return true
+	})
+	if drop {
+		return nil
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h deprecationNoticeFilter) WithAttrs(attrs []slog.Attr) slog.Handler {
+	drop := h.drop
+	for _, a := range attrs {
+		if isDeprecatedNoticeAttr(a) {
+			drop = true
+		}
+	}
+	return deprecationNoticeFilter{Handler: h.Handler.WithAttrs(attrs), drop: drop}
+}
+
+func (h deprecationNoticeFilter) WithGroup(name string) slog.Handler {
+	return deprecationNoticeFilter{Handler: h.Handler.WithGroup(name), drop: h.drop}
+}
 
 // renderEngine provides methods to build kubernetes api queries from provided cli options.
 // Also holds the parsed templates.

--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"embed"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -16,6 +17,9 @@ import (
 //go:embed templates
 var templatesFS embed.FS
 
+// setupDeprecationFilter configures the default slog handler to drop go-sprout's
+// per-call deprecation-signature warnings, writing anything else to w.
+//
 // go-sprout (our sprig replacement) logs a WARN via slog on every call to a
 // function whose signature changed during the sprig->sprout migration (e.g.
 // get, hasKey, append). These fire once per template execution per call site,
@@ -24,13 +28,13 @@ var templatesFS embed.FS
 // https://github.com/bergerx/kubectl-status/issues/688 for migrating the
 // templates to the new signatures, at which point this filter can go away.
 //
-// The fallback handler is built fresh (not by wrapping the pre-existing
+// The handler is built fresh (not by wrapping the pre-existing
 // slog.Default().Handler()): the zero-value default handler bridges back
 // into the standard "log" package's global, mutex-protected logger, and
 // re-installing a wrapper around it as the new default causes that bridge
 // to call back into itself, deadlocking on the mutex.
-func init() {
-	slog.SetDefault(slog.New(deprecationNoticeFilter{Handler: slog.NewTextHandler(os.Stderr, nil)}))
+func setupDeprecationFilter(w io.Writer) {
+	slog.SetDefault(slog.New(deprecationNoticeFilter{Handler: slog.NewTextHandler(w, nil)}))
 }
 
 // deprecationNoticeFilter drops log records tagged with a "notice"="deprecated"
@@ -46,6 +50,13 @@ type deprecationNoticeFilter struct {
 
 func isDeprecatedNoticeAttr(a slog.Attr) bool {
 	return a.Key == "notice" && a.Value.Kind() == slog.KindString && a.Value.String() == "deprecated"
+}
+
+func (h deprecationNoticeFilter) Enabled(ctx context.Context, level slog.Level) bool {
+	if h.drop {
+		return false
+	}
+	return h.Handler.Enabled(ctx, level)
 }
 
 func (h deprecationNoticeFilter) Handle(ctx context.Context, r slog.Record) error {
@@ -89,6 +100,7 @@ type renderEngine struct {
 
 func newRenderEngine(streams genericiooptions.IOStreams) (*renderEngine, error) {
 	klog.V(5).InfoS("Creating new render engine instance...")
+	setupDeprecationFilter(streams.ErrOut)
 	tmpl, err := getTemplate()
 	if err != nil {
 		klog.V(3).ErrorS(err, "Error parsing templates")


### PR DESCRIPTION
## Summary
- #577 bumped `go-sprout/sprout` to v1.0.3. Its sprig-compat shim (`sprigin`) logs a `WARN` via slog on every call to a template function still using the old sprig argument order (`get`, `hasKey`, `append`, `set`). Since these are called inside per-pod/per-node/per-container template loops, a single `kubectl status` run could emit the same warning dozens of times.
- `sprigin` gives no built-in way to disable these notices, so this filters them out of the global `slog` default handler in `pkg/plugin/render_engine.go`.
- Actually migrating the templates to the new signatures is a much larger, separate effort (~200 call sites across most template files) and is tracked in #688.

## Note on implementation
The first version of this filter wrapped the pre-existing `slog.Default().Handler()`. That handler bridges back into the standard `log` package's global, mutex-protected logger, and re-installing a wrapper around it as the new default caused that bridge to call back into itself — a deadlock that only showed up under `go test` (`TestSuspendTemplate` hung). Fixed by building a fresh handler instead of reusing the old default's bridge, and by explicitly overriding `WithAttrs`/`WithGroup` (the deprecation notice's `notice=deprecated` tag is attached via `Logger.With(...)`, which funnels through `WithAttrs` rather than through the `Record` — without an override, Go's method promotion on the embedded `slog.Handler` silently drops the wrapper on the first `.With()` call).

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (428 tests, no hangs)
- [x] `go run ./cmd -n cert-manager pods` and `go run ./cmd -n cert-manager pod <name>` against a live cluster: clean stderr, no deprecation warnings, normal output produced
- [x] `make test` via the pre-commit hook passes