### PR TITLE
Add ValidatingAdmissionPolicy + Binding templates

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1106,6 +1106,25 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/backendtlspolicy-with-target.deep.regex",
 		}.assert(t, nil)
 	})
+	t.Run("vap-binding-resolves-policy", func(t *testing.T) {
+		viperTestHack(t)
+		applyManifest(t, "e2e-artifacts/vap-binding.yaml")
+		cmdTest{
+			args:            []string{"validatingadmissionpolicybinding/e2e-require-team-label-binding", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/vap-binding.regex",
+		}.assert(t, nil)
+	})
+	t.Run("vapbinding referencing a missing policy is flagged not found", func(t *testing.T) {
+		// The binding is rendered with --local straight from a manifest rather than created on
+		// the cluster, mirroring the orphan-owner-reference pattern above -- --local still
+		// resolves the policyName against the real API server (only the binding object itself is
+		// local), so the not-found check is exercised the same way.
+		viperTestHack(t)
+		cmdTest{
+			args:            []string{"-f", "../tests/e2e-artifacts/vapbinding-orphan-policy.yaml", "--local", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/vapbinding-orphan-policy.regex",
+		}.assert(t, nil)
+	})
 	t.Run("web-cert", func(t *testing.T) {
 		// A self-signed local CA issuing a leaf certificate, so the leaf's Secret shows
 		// "issued by <CA>" rather than "Self-signed" -- the same cert-manager chain used for

--- a/pkg/plugin/templates/ValidatingAdmissionPolicy.tmpl
+++ b/pkg/plugin/templates/ValidatingAdmissionPolicy.tmpl
@@ -1,0 +1,51 @@
+{{- define "ValidatingAdmissionPolicy" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: admissionregistration.k8s.io/v1, Kind=ValidatingAdmissionPolicy */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- $isFail := eq (.Spec.failurePolicy | default "Fail") "Fail" }}
+    {{- "failurePolicy" | bold | nindent 2 }}: {{ .Spec.failurePolicy | default "Fail" | redBoldIf $isFail }}
+    {{- with .Spec.paramKind }}
+        {{- ", params: " }}{{ printf "%s/%s" .apiVersion .kind | cyan }}
+    {{- end }}
+    {{- with .Spec.matchConstraints }}
+        {{- "Match" | bold | nindent 2 }}:
+        {{- $.Include "match_resources_summary" . }}
+    {{- end }}
+    {{- with .Spec.matchConditions }}
+        {{- "matchConditions" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- "" | nindent 4 }}{{ .name | bold }}: {{ .expression | cyan }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec.validations }}
+        {{- "Validations" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- "" | nindent 4 }}{{ .expression | cyan }}
+            {{- with .messageExpression }} (message: {{ . | cyan }}){{ end }}
+            {{- with .message }} — {{ . }}{{ end }}
+            {{- with .reason }}{{ if ne . "Invalid" }} [{{ . | bold }}]{{ end }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec.variables }}
+        {{- "Variables" | bold | nindent 2 }}: {{ len . | toString | cyan }} defined
+    {{- end }}
+    {{- with .Spec.auditAnnotations }}
+        {{- "Audit annotations" | bold | nindent 2 }}: {{ len . | toString | cyan }} defined
+    {{- end }}
+    {{- with .Status.typeChecking }}
+        {{- with .expressionWarnings }}
+            {{- "Type-check warnings" | red | bold | nindent 2 }}:
+            {{- range . }}
+                {{- printf "%s: %s" .fieldRef .warning | red | nindent 4 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/ValidatingAdmissionPolicy.tmpl
+++ b/pkg/plugin/templates/ValidatingAdmissionPolicy.tmpl
@@ -1,8 +1,9 @@
 {{- define "ValidatingAdmissionPolicy" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* GVK: admissionregistration.k8s.io/v1, Kind=ValidatingAdmissionPolicy */ -}}
+    {{- /* kstatus_summary omitted: adds no signal beyond the Type-check warnings and
+           conditions_summary already shown below. */ -}}
     {{- template "status_summary_line" . }}
-    {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
@@ -18,15 +19,15 @@
     {{- with .Spec.matchConditions }}
         {{- "matchConditions" | bold | nindent 2 }}:
         {{- range . }}
-            {{- "" | nindent 4 }}{{ .name | bold }}: {{ .expression | cyan }}
+            {{- "" | nindent 4 }}{{ .name | bold }}: {{ .expression | trim | replace "\n" "\n    " | cyan }}
         {{- end }}
     {{- end }}
     {{- with .Spec.validations }}
         {{- "Validations" | bold | nindent 2 }}:
         {{- range . }}
-            {{- "" | nindent 4 }}{{ .expression | cyan }}
-            {{- with .messageExpression }} (message: {{ . | cyan }}){{ end }}
-            {{- with .message }} — {{ . }}{{ end }}
+            {{- "" | nindent 4 }}{{ .expression | trim | replace "\n" "\n    " | cyan }}
+            {{- with .messageExpression }} (message: {{ . | trim | replace "\n" "\n    " | cyan }}){{ end }}
+            {{- with .message }} — {{ . | trim | replace "\n" "\n    " }}{{ end }}
             {{- with .reason }}{{ if ne . "Invalid" }} [{{ . | bold }}]{{ end }}{{ end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/ValidatingAdmissionPolicyBinding.tmpl
+++ b/pkg/plugin/templates/ValidatingAdmissionPolicyBinding.tmpl
@@ -1,0 +1,40 @@
+{{- define "ValidatingAdmissionPolicyBinding" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: admissionregistration.k8s.io/v1, Kind=ValidatingAdmissionPolicyBinding */ -}}
+    {{- /* kstatus_summary omitted: this kind has no status subresource, always reported "Resource is always ready" by kstatus, same as ConfigMap/Secret. */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "application_details" . }}
+    {{- with .Spec.policyName }}
+        {{- "Policy" | bold | nindent 2 }}: {{ template "resource_ref" (dict "kind" "ValidatingAdmissionPolicy" "name" .) }}
+        {{- if not ($.Config.GetBool "shallow") }}
+            {{- $policy := $.KubeGetFirst "" "ValidatingAdmissionPolicy" . }}
+            {{- if not $policy.Object }}
+                {{- " (not found)" | red | bold }}
+            {{- else if $.Config.GetBool "deep" }}
+                {{- $.IncludeRenderableObject $policy | nindent 4 }}
+            {{- else }}
+                {{- $isFail := eq ($policy.Spec.failurePolicy | default "Fail") "Fail" }}
+                {{- printf ", failurePolicy:%s" ($policy.Spec.failurePolicy | default "Fail") | redBoldIf $isFail }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec.validationActions }}
+        {{- "Actions" | bold | nindent 2 }}: {{ join ", " . | cyan }}
+    {{- end }}
+    {{- with .Spec.paramRef }}
+        {{- $paramRef := . }}
+        {{- "Params" | bold | nindent 2 }}:
+        {{- with .name }} {{ . | cyan }}{{ end }}
+        {{- with .selector }} {{ . | labelSelector | cyan }}{{ end }}
+        {{- with $paramRef.namespace }} -n {{ . | cyan }}{{ end }}
+        {{- with .parameterNotFoundAction }}{{ if ne . "Deny" }}, if not found: {{ . | cyan }}{{ end }}{{ end }}
+    {{- end }}
+    {{- with .Spec.matchResources }}
+        {{- "Match" | bold | nindent 2 }}:
+        {{- $.Include "match_resources_summary" . }}
+    {{- end }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/ValidatingAdmissionPolicyBinding.tmpl
+++ b/pkg/plugin/templates/ValidatingAdmissionPolicyBinding.tmpl
@@ -28,7 +28,7 @@
         {{- with .name }} {{ . | cyan }}{{ end }}
         {{- with .selector }} {{ . | labelSelector | cyan }}{{ end }}
         {{- with $paramRef.namespace }} -n {{ . | cyan }}{{ end }}
-        {{- with .parameterNotFoundAction }}{{ if ne . "Deny" }}, if not found: {{ . | cyan }}{{ end }}{{ end }}
+        {{- with .parameterNotFoundAction }}{{ if ne . "Allow" }}, if not found: {{ . | cyan }}{{ end }}{{ end }}
     {{- end }}
     {{- with .Spec.matchResources }}
         {{- "Match" | bold | nindent 2 }}:

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -780,6 +780,42 @@
     {{- end }}
 {{- end }}
 
+{{- define "match_resources_summary" }}
+    {{- /* Expects a MatchResources object (matchPolicy/namespaceSelector/objectSelector/
+           resourceRules/excludeResourceRules). Shared by
+           ValidatingAdmissionPolicy.spec.matchConstraints and
+           ValidatingAdmissionPolicyBinding.spec.matchResources. */ -}}
+    {{- with .matchPolicy }}{{ if ne . "Equivalent" }}{{ "matchPolicy" | nindent 4 }}: {{ . | cyan }}{{ end }}{{ end }}
+    {{- range .resourceRules }}
+        {{- $ops := .operations | join "," }}
+        {{- $groups := .apiGroups | join "," | default "core" }}
+        {{- $resources := .resources | join "," }}
+        {{- $versions := .apiVersions | join "," }}
+        {{- "" | nindent 4 }}{{ $ops | bold }} {{ $groups }}/{{ $resources }}
+        {{- with $versions }}/{{ . }}{{ end }}
+        {{- with .scope }}{{ if not (eq . "*") }} scope:{{ . }}{{ end }}{{ end }}
+    {{- end }}
+    {{- range .excludeResourceRules }}
+        {{- $ops := .operations | join "," }}
+        {{- $groups := .apiGroups | join "," | default "core" }}
+        {{- $resources := .resources | join "," }}
+        {{- $versions := .apiVersions | join "," }}
+        {{- "exclude:" | nindent 4 }} {{ $ops | bold }} {{ $groups }}/{{ $resources }}
+        {{- with $versions }}/{{ . }}{{ end }}
+        {{- with .scope }}{{ if not (eq . "*") }} scope:{{ . }}{{ end }}{{ end }}
+    {{- end }}
+    {{- with .namespaceSelector }}
+        {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}
+            {{- "namespaceSelector" | nindent 4 }}: {{ . | labelSelector | cyan }}
+        {{- end }}
+    {{- end }}
+    {{- with .objectSelector }}
+        {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}
+            {{- "objectSelector" | nindent 4 }}: {{ . | labelSelector | cyan }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- define "workload_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "resource_ref" (dict "kind" .Kind "name" .Name "namespace" .Namespace) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -794,6 +794,7 @@
         {{- "" | nindent 4 }}{{ $ops | bold }} {{ $groups }}/{{ $resources }}
         {{- with $versions }}/{{ . }}{{ end }}
         {{- with .scope }}{{ if not (eq . "*") }} scope:{{ . }}{{ end }}{{ end }}
+        {{- with .resourceNames }} names:{{ . | join "," }}{{ end }}
     {{- end }}
     {{- range .excludeResourceRules }}
         {{- $ops := .operations | join "," }}
@@ -803,6 +804,7 @@
         {{- "exclude:" | nindent 4 }} {{ $ops | bold }} {{ $groups }}/{{ $resources }}
         {{- with $versions }}/{{ . }}{{ end }}
         {{- with .scope }}{{ if not (eq . "*") }} scope:{{ . }}{{ end }}{{ end }}
+        {{- with .resourceNames }} names:{{ . | join "," }}{{ end }}
     {{- end }}
     {{- with .namespaceSelector }}
         {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}

--- a/tests/artifacts/vap-ignore-failurepolicy.out
+++ b/tests/artifacts/vap-ignore-failurepolicy.out
@@ -1,6 +1,5 @@
 
 ValidatingAdmissionPolicy/warn-only-policy, created 1m ago, gen:1
-  Current: Resource is current
   failurePolicy: Ignore
   Match:
     CREATE core/pods/v1

--- a/tests/artifacts/vap-ignore-failurepolicy.out
+++ b/tests/artifacts/vap-ignore-failurepolicy.out
@@ -1,0 +1,8 @@
+
+ValidatingAdmissionPolicy/warn-only-policy, created 1m ago, gen:1
+  Current: Resource is current
+  failurePolicy: Ignore
+  Match:
+    CREATE core/pods/v1
+  Validations:
+    object.spec.containers.all(c, has(c.resources.limits)) — containers should set resource limits

--- a/tests/artifacts/vap-ignore-failurepolicy.yaml
+++ b/tests/artifacts/vap-ignore-failurepolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  creationTimestamp: "2026-07-03T09:00:00Z"
+  generation: 1
+  name: warn-only-policy
+  resourceVersion: "1400"
+  uid: 44444444-4444-4444-4444-444444444444
+spec:
+  failurePolicy: Ignore
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - pods
+  validations:
+  - expression: "object.spec.containers.all(c, has(c.resources.limits))"
+    message: "containers should set resource limits"
+status:
+  observedGeneration: 1

--- a/tests/artifacts/vap-multiline-validations.out
+++ b/tests/artifacts/vap-multiline-validations.out
@@ -1,0 +1,14 @@
+
+ValidatingAdmissionPolicy/multiline-validations, created 1m ago, gen:1
+  failurePolicy: Fail
+  Match:
+    CREATE apps/deployments/v1
+  matchConditions:
+    multiline-condition: !request.userInfo.username.startsWith('system:serviceaccount:') ||
+    request.userInfo.username == 'system:serviceaccount:default:admin'
+  Validations:
+    object.spec.template.spec.containers.all(c,
+      has(c.resources.limits) &&
+      has(c.resources.requests)
+    ) — containers must set both resource
+    limits and requests

--- a/tests/artifacts/vap-multiline-validations.yaml
+++ b/tests/artifacts/vap-multiline-validations.yaml
@@ -1,0 +1,34 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  creationTimestamp: "2026-07-13T10:00:00Z"
+  generation: 1
+  name: multiline-validations
+  resourceVersion: "1500"
+  uid: 66666666-6666-6666-6666-666666666666
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - deployments
+  matchConditions:
+  - name: multiline-condition
+    expression: |
+      !request.userInfo.username.startsWith('system:serviceaccount:') ||
+      request.userInfo.username == 'system:serviceaccount:default:admin'
+  validations:
+  - expression: |
+      object.spec.template.spec.containers.all(c,
+        has(c.resources.limits) &&
+        has(c.resources.requests)
+      )
+    message: |
+      containers must set both resource
+      limits and requests

--- a/tests/artifacts/vap-require-labels.out
+++ b/tests/artifacts/vap-require-labels.out
@@ -1,9 +1,8 @@
 
 ValidatingAdmissionPolicy/require-team-label, created 1m ago, gen:3
-  Current: Resource is current
   failurePolicy: Fail, params: v1/ConfigMap
   Match:
-    CREATE,UPDATE apps/deployments/v1 scope:Namespaced
+    CREATE,UPDATE apps/deployments/v1 scope:Namespaced names:frontend,backend
     namespaceSelector: kubernetes.io/metadata.name notin (kube-system)
     objectSelector: require-team-label=enabled
   matchConditions:

--- a/tests/artifacts/vap-require-labels.out
+++ b/tests/artifacts/vap-require-labels.out
@@ -1,0 +1,17 @@
+
+ValidatingAdmissionPolicy/require-team-label, created 1m ago, gen:3
+  Current: Resource is current
+  failurePolicy: Fail, params: v1/ConfigMap
+  Match:
+    CREATE,UPDATE apps/deployments/v1 scope:Namespaced
+    namespaceSelector: kubernetes.io/metadata.name notin (kube-system)
+    objectSelector: require-team-label=enabled
+  matchConditions:
+    exclude-system-serviceaccounts: !request.userInfo.username.startsWith('system:serviceaccount:kube-system:')
+  Validations:
+    'team' in variables.labels — all Deployments must carry a 'team' label
+    size(variables.labels.team) > 0 (message: 'team label must not be empty, got: ' + variables.labels.team)
+  Variables: 1 defined
+  Audit annotations: 1 defined
+  Type-check warnings:
+    spec.validations[1].expression: undeclared reference to 'team' (in container 'variables')

--- a/tests/artifacts/vap-require-labels.yaml
+++ b/tests/artifacts/vap-require-labels.yaml
@@ -1,0 +1,55 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  creationTimestamp: "2026-07-01T10:00:00Z"
+  generation: 3
+  name: require-team-label
+  resourceVersion: "1234"
+  uid: 11111111-1111-1111-1111-111111111111
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+      scope: Namespaced
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+    objectSelector:
+      matchLabels:
+        require-team-label: enabled
+  matchConditions:
+  - name: exclude-system-serviceaccounts
+    expression: "!request.userInfo.username.startsWith('system:serviceaccount:kube-system:')"
+  variables:
+  - name: labels
+    expression: "object.metadata.labels"
+  validations:
+  - expression: "'team' in variables.labels"
+    message: "all Deployments must carry a 'team' label"
+    reason: Invalid
+  - expression: "size(variables.labels.team) > 0"
+    messageExpression: "'team label must not be empty, got: ' + variables.labels.team"
+  auditAnnotations:
+  - key: "team"
+    valueExpression: "variables.labels.team"
+status:
+  observedGeneration: 3
+  typeChecking:
+    expressionWarnings:
+    - fieldRef: spec.validations[1].expression
+      warning: "undeclared reference to 'team' (in container 'variables')"

--- a/tests/artifacts/vap-require-labels.yaml
+++ b/tests/artifacts/vap-require-labels.yaml
@@ -22,6 +22,9 @@ spec:
       - UPDATE
       resources:
       - deployments
+      resourceNames:
+      - frontend
+      - backend
       scope: Namespaced
     namespaceSelector:
       matchExpressions:

--- a/tests/artifacts/vapbinding-missing-policy.out
+++ b/tests/artifacts/vapbinding-missing-policy.out
@@ -1,0 +1,5 @@
+
+ValidatingAdmissionPolicyBinding/orphan-binding, created 1m ago, gen:1
+  Policy: ValidatingAdmissionPolicy/does-not-exist
+  Actions: Deny
+  Params: my-config -n policy-params, if not found: Allow

--- a/tests/artifacts/vapbinding-missing-policy.out
+++ b/tests/artifacts/vapbinding-missing-policy.out
@@ -2,4 +2,4 @@
 ValidatingAdmissionPolicyBinding/orphan-binding, created 1m ago, gen:1
   Policy: ValidatingAdmissionPolicy/does-not-exist
   Actions: Deny
-  Params: my-config -n policy-params, if not found: Allow
+  Params: my-config -n policy-params

--- a/tests/artifacts/vapbinding-missing-policy.yaml
+++ b/tests/artifacts/vapbinding-missing-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  creationTimestamp: "2026-07-02T08:00:00Z"
+  generation: 1
+  name: orphan-binding
+  resourceVersion: "1300"
+  uid: 33333333-3333-3333-3333-333333333333
+spec:
+  policyName: does-not-exist
+  validationActions:
+  - Deny
+  paramRef:
+    name: my-config
+    namespace: policy-params
+    parameterNotFoundAction: Allow

--- a/tests/artifacts/vapbinding-param-selector.out
+++ b/tests/artifacts/vapbinding-param-selector.out
@@ -2,7 +2,7 @@
 ValidatingAdmissionPolicyBinding/warn-only-policy-binding, created 1m ago, gen:1
   Policy: ValidatingAdmissionPolicy/warn-only-policy
   Actions: Warn
-  Params: config=pod-limits -n policy-params
+  Params: config=pod-limits -n policy-params, if not found: Deny
   Match:
     matchPolicy: Exact
     CREATE core/pods/v1

--- a/tests/artifacts/vapbinding-param-selector.out
+++ b/tests/artifacts/vapbinding-param-selector.out
@@ -1,0 +1,8 @@
+
+ValidatingAdmissionPolicyBinding/warn-only-policy-binding, created 1m ago, gen:1
+  Policy: ValidatingAdmissionPolicy/warn-only-policy
+  Actions: Warn
+  Params: config=pod-limits -n policy-params
+  Match:
+    matchPolicy: Exact
+    CREATE core/pods/v1

--- a/tests/artifacts/vapbinding-param-selector.yaml
+++ b/tests/artifacts/vapbinding-param-selector.yaml
@@ -1,0 +1,29 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  creationTimestamp: "2026-07-03T09:05:00Z"
+  generation: 1
+  name: warn-only-policy-binding
+  resourceVersion: "1401"
+  uid: 55555555-5555-5555-5555-555555555555
+spec:
+  policyName: warn-only-policy
+  validationActions:
+  - Warn
+  paramRef:
+    namespace: policy-params
+    selector:
+      matchLabels:
+        config: pod-limits
+    parameterNotFoundAction: Deny
+  matchResources:
+    matchPolicy: Exact
+    resourceRules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - pods

--- a/tests/artifacts/vapbinding-require-labels.out
+++ b/tests/artifacts/vapbinding-require-labels.out
@@ -3,5 +3,5 @@ ValidatingAdmissionPolicyBinding/require-team-label-binding, created 1m ago, gen
   Policy: ValidatingAdmissionPolicy/require-team-label
   Actions: Deny, Audit
   Match:
-    exclude: * apps/deployments/v1
+    exclude: * apps/deployments/v1 names:legacy-app
     namespaceSelector: environment=production

--- a/tests/artifacts/vapbinding-require-labels.out
+++ b/tests/artifacts/vapbinding-require-labels.out
@@ -1,0 +1,7 @@
+
+ValidatingAdmissionPolicyBinding/require-team-label-binding, created 1m ago, gen:1
+  Policy: ValidatingAdmissionPolicy/require-team-label
+  Actions: Deny, Audit
+  Match:
+    exclude: * apps/deployments/v1
+    namespaceSelector: environment=production

--- a/tests/artifacts/vapbinding-require-labels.yaml
+++ b/tests/artifacts/vapbinding-require-labels.yaml
@@ -1,0 +1,28 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  creationTimestamp: "2026-07-01T10:05:00Z"
+  generation: 1
+  name: require-team-label-binding
+  resourceVersion: "1240"
+  uid: 22222222-2222-2222-2222-222222222222
+spec:
+  policyName: require-team-label
+  validationActions:
+  - Deny
+  - Audit
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        environment: production
+    excludeResourceRules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - "*"
+      resources:
+      - deployments
+      resourceNames:
+      - legacy-app

--- a/tests/e2e-artifacts/vap-binding.regex
+++ b/tests/e2e-artifacts/vap-binding.regex
@@ -1,0 +1,5 @@
+\A
+ValidatingAdmissionPolicyBinding/e2e-require-team-label-binding, created 1m ago, gen:1
+  Policy: ValidatingAdmissionPolicy/e2e-require-team-label, failurePolicy:Fail
+  Actions: Deny
+\z

--- a/tests/e2e-artifacts/vap-binding.yaml
+++ b/tests/e2e-artifacts/vap-binding.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: e2e-require-team-label
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["apps"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["deployments"]
+  validations:
+    - expression: "'team' in object.metadata.labels"
+      message: "all Deployments must carry a 'team' label"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: e2e-require-team-label-binding
+spec:
+  policyName: e2e-require-team-label
+  validationActions: ["Deny"]

--- a/tests/e2e-artifacts/vapbinding-orphan-policy.regex
+++ b/tests/e2e-artifacts/vapbinding-orphan-policy.regex
@@ -1,0 +1,5 @@
+\A
+ValidatingAdmissionPolicyBinding/e2e-orphan-binding
+  Policy: ValidatingAdmissionPolicy/e2e-does-not-exist \(not found\)
+  Actions: Deny
+\z

--- a/tests/e2e-artifacts/vapbinding-orphan-policy.yaml
+++ b/tests/e2e-artifacts/vapbinding-orphan-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: e2e-orphan-binding
+spec:
+  policyName: e2e-does-not-exist
+  validationActions: ["Deny"]


### PR DESCRIPTION
## Summary
- Adds `pkg/plugin/templates/ValidatingAdmissionPolicy.tmpl` and `ValidatingAdmissionPolicyBinding.tmpl` (admissionregistration.k8s.io/v1) — CEL-based, GA in 1.30, no existing UI tooling to fall back on.
- `ValidatingAdmissionPolicy.tmpl` shows failurePolicy, paramKind, matchConstraints, matchConditions, validations (CEL + messages), and `status.typeChecking.expressionWarnings` as the compile-time failure signal (VAP has no runtime-rejection surface in status).
- `ValidatingAdmissionPolicyBinding.tmpl` resolves `policyName` against the live policy (shows failurePolicy inline, flags orphaned bindings as `(not found)`), plus validationActions/paramRef/matchResources.
- Factored a shared `match_resources_summary` helper into `common.tmpl` since both kinds render the identical `MatchResources` structure.

Closes #673

## Test plan
- [x] `make test` (offline golden-file tests) — green
- [x] Live e2e: `TestE2EDynamicManifests/vap-binding-resolves-policy` and `.../vapbinding_referencing_a_missing_policy_is_flagged_not_found` run against a real minikube cluster (K8s v1.35.1) and pass
- [x] `make test-e2e` skipped on push per request (`SKIP=make-test-e2e`); CI will run the full e2e suite including the new subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)