### PR TITLE
Fix e2e minikube profile identity collision, add worktree reaper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,13 @@ test: vet staticcheck
 # branch (worktrees can't share a branch, so this covers parallel worktrees) and,
 # when running under Claude Code, by session id too (so two sessions working the
 # same branch/worktree don't step on each other's cluster either). The branch name
-# is kept as a readable prefix; a hash carries the actual uniqueness so truncating
-# long/ULID-suffixed branch names (e.g. worktree-*-<ulid>) can't collide.
+# is kept as a readable prefix (cosmetic only, safe to truncate). Uniqueness comes
+# from two hashes: BRANCH_HASH is a function of the branch name alone, so the
+# reference-transaction hook -- which only ever sees a deleted branch name, never a
+# session id -- can recompute it and match *only* that branch's profiles, even when
+# several branches share a truncated slug (e.g. worktree-*-<ulid> branches all
+# collapse to the same 20-char prefix). SESSION_HASH additionally folds in the
+# session id so parallel sessions on the same branch still get separate clusters.
 E2E_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 ifeq ($(E2E_GIT_BRANCH),HEAD)
 E2E_GIT_BRANCH := $(shell git rev-parse --short HEAD 2>/dev/null)
@@ -60,8 +65,9 @@ ifeq ($(E2E_GIT_BRANCH),)
 E2E_GIT_BRANCH := local
 endif
 E2E_BRANCH_SLUG := $(shell ./hack/e2e-branch-slug.sh '$(E2E_GIT_BRANCH)')
-E2E_IDENTITY_HASH := $(shell printf '%s' '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)' | (sha1sum 2>/dev/null || shasum) | cut -c1-8)
-E2E_PROFILE := kstat-e2e-$(E2E_BRANCH_SLUG)-$(E2E_IDENTITY_HASH)
+E2E_BRANCH_HASH := $(shell ./hack/e2e-hash.sh '$(E2E_GIT_BRANCH)')
+E2E_SESSION_HASH := $(shell ./hack/e2e-hash.sh '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)')
+E2E_PROFILE := kstat-e2e-$(E2E_BRANCH_SLUG)-$(E2E_BRANCH_HASH)-$(E2E_SESSION_HASH)
 E2E_KUBECONFIG := $(CURDIR)/.e2e/$(E2E_PROFILE).kubeconfig
 
 # CI (and anyone else who already has a suitable cluster configured) sets
@@ -80,6 +86,14 @@ endif
 print-e2e-profile:
 	@echo "profile:   $(E2E_PROFILE)"
 	@echo "kubeconfig: $(E2E_KUBECONFIG)"
+
+.PHONY: reap
+reap:
+	./hack/reap-worktrees.sh
+
+.PHONY: reap-apply
+reap-apply:
+	./hack/reap-worktrees.sh --apply
 
 .PHONY: install-hooks
 install-hooks:

--- a/hack/e2e-hash.sh
+++ b/hack/e2e-hash.sh
@@ -5,4 +5,4 @@
 # compute it identically.
 set -euo pipefail
 
-printf '%s' "$1" | (sha1sum 2>/dev/null || shasum) | cut -c1-8
+printf '%s' "${1:-}" | (sha1sum 2>/dev/null || shasum) | cut -c1-8

--- a/hack/e2e-hash.sh
+++ b/hack/e2e-hash.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Shared 8-hex-char hash used to build/match e2e minikube profile names (see the
+# E2E_* variables in the Makefile and hack/git-hooks/reference-transaction).
+# Kept as its own script, alongside hack/e2e-branch-slug.sh, so both places
+# compute it identically.
+set -euo pipefail
+
+printf '%s' "$1" | (sha1sum 2>/dev/null || shasum) | cut -c1-8

--- a/hack/git-hooks/reference-transaction
+++ b/hack/git-hooks/reference-transaction
@@ -16,8 +16,8 @@ stage="${1:-}"
 [ "$stage" = "committed" ] || exit 0
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-slug_script="$repo_root/hack/e2e-branch-slug.sh"
-[ -x "$slug_script" ] || exit 0
+hash_script="$repo_root/hack/e2e-hash.sh"
+[ -x "$hash_script" ] || exit 0
 command -v minikube >/dev/null 2>&1 || exit 0
 
 is_zero_oid() {
@@ -35,11 +35,15 @@ while read -r old_oid new_oid ref_name; do
 	is_zero_oid "$new_oid" || continue
 
 	branch="${ref_name#refs/heads/}"
-	slug="$("$slug_script" "$branch")"
-	[ -n "$slug" ] || continue
+	branch_hash="$("$hash_script" "$branch")"
+	[ -n "$branch_hash" ] || continue
 
+	# Matched on BRANCH_HASH (a function of the branch name alone), not the
+	# readable slug: several branches can share a truncated slug (e.g. all
+	# worktree-*-<ulid> branches collapse to the same 20-char prefix), and
+	# matching on the slug would delete sibling branches' still-live profiles.
 	profiles="$(minikube profile list -o json 2>/dev/null \
-		| grep -o "\"Name\"[[:space:]]*:[[:space:]]*\"kstat-e2e-${slug}-[a-f0-9]\{8\}\"" \
+		| grep -o "\"Name\"[[:space:]]*:[[:space:]]*\"kstat-e2e-[a-z0-9-]*-${branch_hash}-[a-f0-9]\{8\}\"" \
 		| cut -d'"' -f4 \
 		| sort -u || true)"
 	for profile in $profiles; do

--- a/hack/reap-worktrees.sh
+++ b/hack/reap-worktrees.sh
@@ -54,6 +54,16 @@ command -v gh >/dev/null 2>&1 || {
 	exit 1
 }
 
+command -v jq >/dev/null 2>&1 || {
+	echo "jq is required (to parse Claude session state) but not found" >&2
+	exit 1
+}
+
+if [ ! -d "$worktrees_dir" ]; then
+	echo "No worktrees directory found at $worktrees_dir. Nothing to reap."
+	exit 0
+fi
+
 git fetch origin master --quiet 2>/dev/null || true
 
 # cwd of every still-running Claude Code session on this machine (interactive
@@ -112,12 +122,23 @@ process_worktree() {
 			echo "SKIP  $br ($wt): has unpushed commits"
 			return
 		fi
-		echo "REAP  $br ($wt): PR $pr_state"
-		reap_minikube_profile "$br"
-		if $apply; then
-			git worktree unlock "$wt" 2>/dev/null || true
-			git worktree remove "$wt" || { echo "      ERROR removing worktree, leaving for manual review"; return; }
-			git branch -D "$br" || echo "      ERROR deleting branch, leaving for manual review"
+		if git merge-base --is-ancestor "$br" origin/master 2>/dev/null; then
+			echo "REAP  $br ($wt): PR $pr_state (merged into origin/master)"
+			reap_minikube_profile "$br"
+			if $apply; then
+				git worktree unlock "$wt" 2>/dev/null || true
+				git worktree remove "$wt" || { echo "      ERROR removing worktree, leaving for manual review"; return; }
+				# -D, not -d: already verified merged into origin/master above (-d checks
+				# local HEAD instead, which can lag origin and wrongly refuse).
+				git branch -D "$br" || echo "      ERROR deleting branch, leaving for manual review"
+			fi
+		else
+			echo "PARTIAL-REAP  $br ($wt): PR $pr_state but has unmerged work -- removing worktree, keeping branch for manual review"
+			reap_minikube_profile "$br"
+			if $apply; then
+				git worktree unlock "$wt" 2>/dev/null || true
+				git worktree remove "$wt" || echo "      ERROR removing worktree, leaving for manual review"
+			fi
 		fi
 		return
 		;;
@@ -128,8 +149,15 @@ process_worktree() {
 		return
 	fi
 
+	local last_commit_timestamp
+	last_commit_timestamp="$(git -C "$wt" log -1 --format=%ct 2>/dev/null || true)"
+	if [ -z "$last_commit_timestamp" ]; then
+		echo "SKIP  $br ($wt): could not determine last commit timestamp"
+		return
+	fi
+
 	local last_commit_age_days
-	last_commit_age_days=$(( ($(date +%s) - $(git -C "$wt" log -1 --format=%ct)) / 86400 ))
+	last_commit_age_days=$(( ($(date +%s) - last_commit_timestamp) / 86400 ))
 	if [ "$last_commit_age_days" -lt "$stale_days" ]; then
 		echo "SKIP  $br ($wt): no PR, session ended, but only ${last_commit_age_days}d old (< ${stale_days}d threshold)"
 		return

--- a/hack/reap-worktrees.sh
+++ b/hack/reap-worktrees.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Prunes session-driven git worktrees under .claude/worktrees/ (e.g. Claude
+# Code remote-control worktrees) that are done with, so their disk, branch
+# and e2e minikube profile don't pile up. Two ways a worktree counts as done:
+#
+#   1. Its branch has a merged/closed PR on GitHub -- reap worktree + branch.
+#   2. It's "abandoned": no live `claude agents` session has it as cwd
+#      anymore, and its last commit is older than STALE_DAYS. Sessions can be
+#      abandoned mid-work (e.g. archived by the user) with no PR at all, so
+#      this path never assumes the branch's work is safe to discard:
+#        - the worktree checkout itself is always removable (branch history
+#          survives in the ref regardless);
+#        - the branch ref, and its e2e minikube profile via the
+#          reference-transaction hook, are only deleted if the branch is
+#          fully merged into origin/master (checked explicitly with
+#          merge-base, since `git branch -d` alone checks against local HEAD,
+#          which can lag origin) -- unmerged work is left for manual review
+#          instead of being force-deleted;
+#        - a lingering minikube profile for the branch is deleted directly
+#          either way, since reclaiming host resources doesn't risk any git
+#          history.
+#   A worktree with uncommitted changes is never touched, in either path.
+#
+# Usage: hack/reap-worktrees.sh [--apply] [--stale-days N]
+# Without --apply, only prints what would happen (dry run). STALE_DAYS
+# defaults to 2.
+set -euo pipefail
+
+apply=false
+stale_days=2
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--apply)
+		apply=true
+		shift
+		;;
+	--stale-days)
+		stale_days="$2"
+		shift 2
+		;;
+	*)
+		echo "usage: $0 [--apply] [--stale-days N]" >&2
+		exit 1
+		;;
+	esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+worktrees_dir="$repo_root/.claude/worktrees"
+
+command -v gh >/dev/null 2>&1 || {
+	echo "gh CLI is required (to check PR state) but not found" >&2
+	exit 1
+}
+
+git fetch origin master --quiet 2>/dev/null || true
+
+# cwd of every still-running Claude Code session on this machine (interactive
+# processes, plus background sessions not yet finished). A worktree whose
+# path doesn't appear here has no session working on it anymore.
+live_cwds=""
+if command -v claude >/dev/null 2>&1; then
+	live_cwds="$(claude agents --json --all 2>/dev/null \
+		| jq -r '.[] | select(.kind != "background" or .state != "done") | .cwd' 2>/dev/null || true)"
+fi
+
+is_session_live() {
+	local wt="$1"
+	[ -z "$live_cwds" ] && return 1
+	printf '%s\n' "$live_cwds" | grep -qxF "$wt"
+}
+
+hash_script="$repo_root/hack/e2e-hash.sh"
+
+reap_minikube_profile() {
+	local br="$1"
+	command -v minikube >/dev/null 2>&1 || return 0
+	[ -x "$hash_script" ] || return 0
+	local branch_hash
+	branch_hash="$("$hash_script" "$br")"
+	local profiles
+	profiles="$(minikube profile list -o json 2>/dev/null \
+		| grep -o "\"Name\"[[:space:]]*:[[:space:]]*\"kstat-e2e-[a-z0-9-]*-${branch_hash}-[a-f0-9]\{8\}\"" \
+		| cut -d'"' -f4 \
+		| sort -u || true)"
+	local profile
+	for profile in $profiles; do
+		echo "      deleting e2e minikube profile '$profile'"
+		if $apply; then
+			minikube delete -p "$profile" >/dev/null 2>&1 || true
+		fi
+	done
+}
+
+process_worktree() {
+	local wt="$1" br="$2"
+
+	if [ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]; then
+		echo "SKIP  $br ($wt): has uncommitted changes"
+		return
+	fi
+
+	local pr_state
+	pr_state="$(gh pr list --head "$br" --state all --json state,number --jq '.[0] | (.state // "NONE") + " #" + (.number // 0 | tostring)' 2>/dev/null || echo "NONE")"
+
+	case "$pr_state" in
+	MERGED\ *|CLOSED\ *)
+		local upstream
+		upstream="$(git -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+		if [ -n "$upstream" ] && [ -n "$(git -C "$wt" log "$upstream.." --oneline 2>/dev/null)" ]; then
+			echo "SKIP  $br ($wt): has unpushed commits"
+			return
+		fi
+		echo "REAP  $br ($wt): PR $pr_state"
+		reap_minikube_profile "$br"
+		if $apply; then
+			git worktree unlock "$wt" 2>/dev/null || true
+			git worktree remove "$wt" || { echo "      ERROR removing worktree, leaving for manual review"; return; }
+			git branch -D "$br" || echo "      ERROR deleting branch, leaving for manual review"
+		fi
+		return
+		;;
+	esac
+
+	if is_session_live "$wt"; then
+		echo "SKIP  $br ($wt): session still running"
+		return
+	fi
+
+	local last_commit_age_days
+	last_commit_age_days=$(( ($(date +%s) - $(git -C "$wt" log -1 --format=%ct)) / 86400 ))
+	if [ "$last_commit_age_days" -lt "$stale_days" ]; then
+		echo "SKIP  $br ($wt): no PR, session ended, but only ${last_commit_age_days}d old (< ${stale_days}d threshold)"
+		return
+	fi
+
+	if git merge-base --is-ancestor "$br" origin/master 2>/dev/null; then
+		echo "REAP  $br ($wt): abandoned (${last_commit_age_days}d), merged into origin/master"
+		reap_minikube_profile "$br"
+		if $apply; then
+			git worktree unlock "$wt" 2>/dev/null || true
+			git worktree remove "$wt" || { echo "      ERROR removing worktree, leaving for manual review"; return; }
+			# -D, not -d: already verified merged into origin/master above (-d checks
+			# local HEAD instead, which can lag origin and wrongly refuse).
+			git branch -D "$br" || echo "      ERROR deleting branch, leaving for manual review"
+		fi
+	else
+		echo "PARTIAL-REAP  $br ($wt): abandoned (${last_commit_age_days}d) but has unmerged work -- removing worktree, keeping branch for manual review"
+		reap_minikube_profile "$br"
+		if $apply; then
+			git worktree unlock "$wt" 2>/dev/null || true
+			git worktree remove "$wt" || echo "      ERROR removing worktree, leaving for manual review"
+		fi
+	fi
+}
+
+for wt in "$worktrees_dir"/*/; do
+	[ -d "$wt" ] || continue
+	wt="${wt%/}"
+	branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+	[ -n "$branch" ] && [ "$branch" != "HEAD" ] || continue
+	process_worktree "$wt" "$branch"
+done


### PR DESCRIPTION
## Summary
- Fixes a bug where the `reference-transaction` hook matched a deleted branch's minikube profile by a truncated readable slug, which collapses for any `worktree-*-<ulid>` branches (they all share the same 20-char prefix). Deleting one such branch could sweep every sibling session's still-live minikube cluster. Matching now uses a hash of the full branch name (`hack/e2e-hash.sh`, shared by the Makefile and the hook), so it stays unique regardless of slug truncation.
- Adds `hack/reap-worktrees.sh` (`make reap` / `make reap-apply`) to reclaim session-driven worktrees under `.claude/worktrees/` that are done: merged/closed PR, or abandoned (no live `claude agents` session, stale past 2 days). Branch refs are only force-deleted once verified merged into `origin/master`; abandoned worktrees with unmerged work only have their checkout removed, keeping the branch for manual review. This is the piece Claude Code remote-control lacks (no session-end hook), so leaked worktrees/branches/minikube clusters don't have to be cleaned up by hand.

## Test plan
- [x] `hack/e2e-hash.sh` verified to produce distinct hashes for two `worktree-bridge-cse_<ulid>` branches that previously collapsed to the same slug
- [x] Simulated the `reference-transaction` hook against a fake `minikube` binary: deleting one branch only deletes its own profile, sibling profiles survive
- [x] Dry-run + applied `reap-worktrees.sh` against this repo's real leaked worktrees (22 -> 4 remaining: one live session, two with uncommitted changes, one in-progress)
- [x] Verified the PARTIAL-REAP path end-to-end with a synthetic backdated, unmerged, committed-but-unpushed worktree: worktree removed, branch and commit preserved
- [x] `make test` passes (via pre-push hook)

Note: after merging, run `make install-hooks` to deploy the fixed hook (the currently installed one still has the collision bug until reinstalled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)