### PR TITLE
e2e: add TestE2EParallel scaffolding for parallel-safe subtests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,17 @@ apart" threshold, and therefore whether it renders at all, is a coin flip e2e te
 after 1m`) whenever `status.startTime` is set, so fixtures can pin it as a literal instead of
 wrapping it in an optional group.
 
+### Parallel-Safe e2e Subtests
+
+`make test-e2e` currently runs `TestE2E*` as one sequential `go test` invocation.
+`TestE2EParallel` (`cmd/main_test.go`) is a dedicated home for subtests that are independent enough
+to run concurrently instead -- see the doc comment on that function for exactly what a subtest needs
+(a dedicated namespace or none at all, no shared cluster-scoped resource names, no dependency on the
+global `viper` singleton or `testHack`/`viperTestHack`) before it can move there with
+`t.Run(name, func(t *testing.T) { t.Parallel(); ... })`. Most existing `TestE2E*` subtests still call
+`testHack`/`viperTestHack` and can't move until that global state is threaded through as a parameter
+instead of a package-level singleton.
+
 ### Improving The Documentation
 
 We don't yet have a comprehensive documentation, we maintain just a few Markdown files in the repo. We aim to keep the

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -427,6 +427,30 @@ func e2eMinikubeTest(t *testing.T) {
 	}
 }
 
+// TestE2EParallel is a dedicated home for e2e subtests that are independent of each other and can
+// therefore run concurrently. A subtest qualifies once it:
+//   - needs no namespace, or creates/uses a namespace dedicated to that subtest (never `default`,
+//     and never a namespace another subtest might also touch)
+//   - never relies on a fixed cluster-scoped resource name (Node, CustomResourceDefinition,
+//     ClusterRole, ...) another subtest could also use -- generate one instead, e.g. with
+//     GenerateName (see createBadNode)
+//   - doesn't call testHack(t) or viperTestHack(t), and doesn't otherwise read or write the
+//     process-global viper singleton or pkg/plugin's package-level Now/DurationRound/
+//     StartedAfterClause overrides -- concurrent subtests would race each other's
+//     Set/Reset/override-revert calls against that shared state (see #694)
+//
+// Add a qualifying subtest with t.Run(name, func(t *testing.T) { t.Parallel(); ... }) so it
+// actually runs alongside its siblings instead of just living next to them; that subtest-level
+// t.Parallel() is what makes siblings run concurrently, regardless of this function's own.
+//
+// This function itself must NOT call t.Parallel(): e2eMinikubeTest below falls back to
+// startMinikube, which calls t.Setenv("KUBECONFIG", ...) for ad hoc `go test -run TestE2E...` runs
+// that don't set ASSUME_MINIKUBE_IS_CONFIGURED=true -- and t.Setenv panics if called on a test
+// already marked parallel.
+func TestE2EParallel(t *testing.T) {
+	e2eMinikubeTest(t)
+}
+
 func TestE2EDynamicManifests(t *testing.T) {
 	e2eMinikubeTest(t)
 	testHack(t)


### PR DESCRIPTION
## Summary
- Adds `TestE2EParallel` in `cmd/main_test.go`, an empty top-level e2e test function meant to hold subtests that are independent of each other (dedicated/no namespace, no shared cluster-scoped resource names, no dependency on the global `viper` singleton or `pkg/plugin`'s `testHack`/`viperTestHack` overrides).
- Doc comment on the function spells out the qualification criteria and how to add a parallel subtest (`t.Run(name, func(t *testing.T) { t.Parallel(); ... })`).
- Adds a matching "Parallel-Safe e2e Subtests" section to `CONTRIBUTING.md`.
- No existing subtests are moved yet — nearly all still depend on the global `viper`/test-hook state, which is tracked separately in #694 as a prerequisite.

Fixes #693

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/... -run TestE2EParallel -v` — confirms it skips cleanly without `RUN_E2E_TESTS=true`
- [ ] `make test` (via pre-commit hook)