### PR TITLE
Fetch and surface ServiceAccount referenced by Pod/workloads

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -550,6 +550,64 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/pod-on-bad-node.regex",
 		}.assert(t, nil)
 	})
+	t.Run("pod's serviceAccountName resolves to the ServiceAccount and surfaces automount/imagePullSecrets", func(t *testing.T) {
+		viperTestHack(t)
+		f := false
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubectl-status-test-sa",
+				Namespace: "default",
+			},
+			AutomountServiceAccountToken: &f,
+			ImagePullSecrets:             []corev1.LocalObjectReference{{Name: "regcred"}},
+		}
+		_, err := clientset.CoreV1().ServiceAccounts("default").Create(context.TODO(), sa, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().ServiceAccounts("default").Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
+
+		// The ServiceAccount admission plugin merges its imagePullSecrets onto every Pod that
+		// uses it, so Pod.tmpl's own (pre-existing) imagePullSecrets check will flag "regcred" as
+		// missing unless it actually exists with the expected type.
+		regcred := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "regcred", Namespace: "default"},
+			Type:       corev1.SecretTypeDockerConfigJson,
+			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
+		}
+		_, err = clientset.CoreV1().Secrets("default").Create(context.TODO(), regcred, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Secrets("default").Delete(context.TODO(), regcred.Name, metav1.DeleteOptions{})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-custom-sa",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: sa.Name,
+				Containers:         []corev1.Container{{Name: "app", Image: "busybox"}},
+			},
+		}
+		_, err = clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args:            []string{"pod/pod-with-custom-sa", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-with-custom-sa.regex",
+		}.assert(t, nil)
+	})
+	t.Run("pod referencing a missing ServiceAccount surfaces a doesn't-exist warning", func(t *testing.T) {
+		// Rendered with --local (rather than created on the cluster) since a real cluster's
+		// ServiceAccount admission plugin rejects a Pod at creation time when its
+		// serviceAccountName doesn't resolve -- --local still resolves the reference against the
+		// real API server (only the Pod object itself is local), so the not-found check is
+		// exercised the same way, without needing admission to allow the invalid Pod through.
+		viperTestHack(t)
+		cmdTest{
+			args:            []string{"-f", "../tests/e2e-artifacts/pod-missing-service-account.yaml", "--local", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-missing-service-account.regex",
+		}.assert(t, nil)
+	})
 	t.Run("workload's matching pod on a cordoned node surfaces a compact node-problem flag", func(t *testing.T) {
 		viperTestHack(t)
 		nodeName := createBadNode(t, clientset)

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -52,6 +52,7 @@
     {{- $podTemplate := $jobTemplateSpec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
     {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" false "serviceExpected" false) }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -9,6 +9,7 @@
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
     {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" true "serviceExpected" true) }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- template "daemonset_replicas_status" . }}
     {{- template "conditions_summary" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -20,6 +20,7 @@
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
     {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "vpaTargetable" true "serviceExpected" true) }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- template "conditions_summary" . }}
     {{- template "suspended" . }}
     {{- $rolloutStatus := .RolloutStatus . }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -69,6 +69,7 @@
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
     {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" false "vpaTargetable" false "serviceExpected" false) }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -42,6 +42,7 @@
             {{- end }}
         {{- end }}
     {{- end }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" .Spec.serviceAccountName) }}
     {{- template "pod_init_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_ephemeral_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -9,6 +9,7 @@
     {{- $podTemplate := .Spec.template | default dict }}
     {{- $podMeta := $podTemplate.metadata | default dict }}
     {{- template "matching_workload_resources" (dict "ctx" . "namespace" .Namespace "labels" ($podMeta.labels | default dict) "scalable" true "vpaTargetable" true "serviceExpected" true) }}
+    {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
     {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -55,6 +55,39 @@
     {{- with .namespace }} -n {{ if eq . "default" }}{{ . | red }}{{ else }}{{ . | cyan }}{{ end }}{{ end }}
 {{- end -}}
 
+{{- define "service_account_summary" }}
+    {{- /* Expects dict "ctx" (RenderableObject, used for KubeGetFirst/Config/Include -- a Pod for
+           Pod.tmpl, or the owning workload for workload templates, since a bare pod template spec
+           has none of these methods) "namespace" "serviceAccountName"
+           (Pod.spec.serviceAccountName / podTemplate.spec.serviceAccountName, empty meaning the
+           "default" ServiceAccount every namespace has). Surfaces the SA itself since its
+           annotations commonly drive cloud IAM binding (IRSA/Workload Identity) and its
+           automountServiceAccountToken/imagePullSecrets affect the pod even when nothing on the
+           pod spec looks wrong. The ubiquitous "default" SA with nothing noteworthy set on it is
+           suppressed -- it's not worth a line on nearly every pod. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if not ($ctx.Config.GetBool "shallow") }}
+        {{- $name := .serviceAccountName | default "default" }}
+        {{- $sa := $ctx.KubeGetFirst .namespace "ServiceAccount" $name }}
+        {{- if not $sa.Object }}
+            {{- "ServiceAccount" | bold | nindent 2 }}/{{ $name }} {{ "doesn't exist" | red | bold }}, but it's referenced as the serviceAccountName.
+        {{- else }}
+            {{- /* "| default true" would be wrong here: sprig's default treats false as an empty
+                   value, so it would silently turn an explicit "false" back into "true". */ -}}
+            {{- $automountFalse := and (hasKey $sa.Object "automountServiceAccountToken") (not $sa.Object.automountServiceAccountToken) }}
+            {{- $pullSecrets := $sa.Object.imagePullSecrets }}
+            {{- if or (ne $name "default") $automountFalse $pullSecrets }}
+                {{- $ctx.Include "resource_ref" (dict "kind" "ServiceAccount" "name" $name) | nindent 2 }}
+                {{- if $automountFalse }}, {{ "automountServiceAccountToken: false" | yellow }}{{ end }}
+                {{- with $pullSecrets }}, imagePullSecrets: {{ range $i, $s := . }}{{ if $i }}, {{ end }}{{ $s.name | cyan }}{{ end }}{{ end }}
+                {{- if $ctx.Config.GetBool "deep" }}
+                    {{- $ctx.IncludeRenderableObject $sa | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- define "status_summary_line" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- if (.Object | default dict).inline }}

--- a/tests/e2e-artifacts/pod-missing-service-account.regex
+++ b/tests/e2e-artifacts/pod-missing-service-account.regex
@@ -1,0 +1,1 @@
+ServiceAccount/does-not-exist doesn't exist, but it's referenced as the serviceAccountName\.

--- a/tests/e2e-artifacts/pod-missing-service-account.yaml
+++ b/tests/e2e-artifacts/pod-missing-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-missing-service-account
+  namespace: default
+spec:
+  serviceAccountName: does-not-exist
+  containers:
+    - name: app
+      image: busybox

--- a/tests/e2e-artifacts/pod-with-custom-sa.regex
+++ b/tests/e2e-artifacts/pod-with-custom-sa.regex
@@ -1,0 +1,1 @@
+ServiceAccount/kubectl-status-test-sa, automountServiceAccountToken: false, imagePullSecrets: regcred


### PR DESCRIPTION
## Summary
- Adds a shared `service_account_summary` template (`common.tmpl`) that resolves `.spec.serviceAccountName` via `KubeGetFirst` and surfaces the ServiceAccount, since its annotations commonly drive cloud IAM binding (IRSA, Workload Identity) and its `automountServiceAccountToken`/`imagePullSecrets` affect the pod even when nothing on the pod spec looks wrong.
- Wired into `Pod.tmpl` and all workload templates (`Deployment`, `DaemonSet`, `StatefulSet`, `Job`, `CronJob`).
- Stays silent for the ubiquitous `default` ServiceAccount when it has nothing noteworthy set (custom name, `automountServiceAccountToken: false`, or `imagePullSecrets` are the trigger conditions) — avoids adding a line to nearly every pod render.
- Output form: `ServiceAccount/name[, automountServiceAccountToken: false][, imagePullSecrets: ...]`, or `ServiceAccount/name doesn't exist, but it's referenced as the serviceAccountName.` when missing. `--deep` renders the full object.

Closes #674

## Test plan
- [x] `make test` (vet, staticcheck, offline golden fixtures) passes
- [x] New live e2e coverage in `cmd/main_test.go` + `tests/e2e-artifacts/pod-with-custom-sa.regex` / `pod-missing-service-account.regex` for the found-with-attributes and not-found cases
- [x] Verified against a live cluster that the change doesn't alter output for pods/workloads using the default ServiceAccount with nothing noteworthy set

🤖 Generated with [Claude Code](https://claude.com/claude-code)