### PR TITLE
e2e: dedicate namespaces for subtests still using the shared default namespace

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1367,15 +1367,22 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// "issued by <CA>" rather than "Self-signed" -- the same cert-manager chain used for
 		// the demo screenshot's Secret example, but exercised here as a regular e2e fixture.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/web-cert.yaml")
-		waitFor(t, "certificate/web-ca", "condition=Ready")
-		waitFor(t, "certificate/web-tls", "condition=Ready")
+		ns := "e2e-web-cert"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/web-cert.yaml", ns)
+		waitForInNamespace(t, "certificate/web-ca", "condition=Ready", ns)
+		waitForInNamespace(t, "certificate/web-tls", "condition=Ready", ns)
 		cmdTest{
-			args:            []string{"secret/web-tls", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"secret/web-tls", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/web-cert.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"secret/web-tls", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"secret/web-tls", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/web-cert.deep.regex",
 		}.assert(t, nil, opts...)
 	})
@@ -1383,12 +1390,19 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// A PodDisruptionBudget and NetworkPolicy both selecting the same Deployment's Pods --
 		// the same fixture used for the demo screenshot's matching-PDB/NetworkPolicy example.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/web.yaml")
-		applyManifest(t, "e2e-artifacts/web-policies.yaml")
-		waitFor(t, "deployment/web", "condition=Available")
-		waitFor(t, "pdb/web", "jsonpath={.status.observedGeneration}=1")
+		ns := "e2e-web-policies"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/web.yaml", ns)
+		applyManifestInNamespace(t, "e2e-artifacts/web-policies.yaml", ns)
+		waitForInNamespace(t, "deployment/web", "condition=Available", ns)
+		waitForInNamespace(t, "pdb/web", "jsonpath={.status.observedGeneration}=1", ns)
 		cmdTest{
-			args:            []string{"deployment/web", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"deployment/web", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/web-policies.regex",
 		}.assert(t, nil, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -988,10 +988,17 @@ func TestE2EDynamicManifests(t *testing.T) {
 
 		t.Run("deployment", func(t *testing.T) {
 			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-blocked-deployment"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
 			name := "e2e-rollouts-blocked-deployment"
 			one := int32(1)
 			dep := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: &one,
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
@@ -1001,23 +1008,30 @@ func TestE2EDynamicManifests(t *testing.T) {
 					},
 				},
 			}
-			_, err := clientset.AppsV1().Deployments("default").Create(context.TODO(), dep, metav1.CreateOptions{})
+			_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
 			require.NoError(t, err)
-			defer clientset.AppsV1().Deployments("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
-			podName := waitForPodByLabel(t, "default", "app="+name)
-			waitForContainerWaitingReason(t, "pod/"+podName, "app", "ImagePullBackOff")
+			defer clientset.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			podName := waitForPodByLabel(t, ns, "app="+name)
+			waitForContainerWaitingReasonInNamespace(t, "pod/"+podName, "app", "ImagePullBackOff", ns)
 
 			cmdTest{
-				args:            []string{"deployment/" + name, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"deployment/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-single-blocked-deployment.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("statefulset", func(t *testing.T) {
 			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-blocked-statefulset"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
 			name := "e2e-rollouts-blocked-statefulset"
 			one := int32(1)
 			sts := &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 				Spec: appsv1.StatefulSetSpec{
 					Replicas:    &one,
 					ServiceName: name,
@@ -1028,21 +1042,28 @@ func TestE2EDynamicManifests(t *testing.T) {
 					},
 				},
 			}
-			_, err := clientset.AppsV1().StatefulSets("default").Create(context.TODO(), sts, metav1.CreateOptions{})
+			_, err = clientset.AppsV1().StatefulSets(ns).Create(context.TODO(), sts, metav1.CreateOptions{})
 			require.NoError(t, err)
-			defer clientset.AppsV1().StatefulSets("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
-			waitForContainerWaitingReason(t, "pod/"+name+"-0", "app", "ImagePullBackOff")
+			defer clientset.AppsV1().StatefulSets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			waitForContainerWaitingReasonInNamespace(t, "pod/"+name+"-0", "app", "ImagePullBackOff", ns)
 
 			cmdTest{
-				args:            []string{"statefulset/" + name, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"statefulset/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-single-blocked-statefulset.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("daemonset", func(t *testing.T) {
 			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-blocked-daemonset"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
 			name := "e2e-rollouts-blocked-daemonset"
 			ds := &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 				Spec: appsv1.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
 					Template: corev1.PodTemplateSpec{
@@ -1051,23 +1072,30 @@ func TestE2EDynamicManifests(t *testing.T) {
 					},
 				},
 			}
-			_, err := clientset.AppsV1().DaemonSets("default").Create(context.TODO(), ds, metav1.CreateOptions{})
+			_, err = clientset.AppsV1().DaemonSets(ns).Create(context.TODO(), ds, metav1.CreateOptions{})
 			require.NoError(t, err)
-			defer clientset.AppsV1().DaemonSets("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
-			podName := waitForPodByLabel(t, "default", "app="+name)
-			waitForContainerWaitingReason(t, "pod/"+podName, "app", "ImagePullBackOff")
+			defer clientset.AppsV1().DaemonSets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			podName := waitForPodByLabel(t, ns, "app="+name)
+			waitForContainerWaitingReasonInNamespace(t, "pod/"+podName, "app", "ImagePullBackOff", ns)
 
 			cmdTest{
-				args:            []string{"daemonset/" + name, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"daemonset/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-single-blocked-daemonset.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("healthy single rollout stays suppressed", func(t *testing.T) {
 			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-healthy-deployment"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
 			name := "e2e-rollouts-healthy-deployment"
 			one := int32(1)
 			dep := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: &one,
 					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
@@ -1077,13 +1105,13 @@ func TestE2EDynamicManifests(t *testing.T) {
 					},
 				},
 			}
-			_, err := clientset.AppsV1().Deployments("default").Create(context.TODO(), dep, metav1.CreateOptions{})
+			_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
 			require.NoError(t, err)
-			defer clientset.AppsV1().Deployments("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
-			waitFor(t, "deployment/"+name, "condition=Available")
+			defer clientset.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
 
 			cmdTest{
-				args:            []string{"deployment/" + name, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"deployment/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-single-healthy-deployment.regex",
 			}.assert(t, nil, opts...)
 		})
@@ -1092,26 +1120,33 @@ func TestE2EDynamicManifests(t *testing.T) {
 			// there are two consecutive pairs to diff, not just the one covered by the
 			// "--include-rollout-diffs shows the diff between revisions" test above.
 			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-three-revisions"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
 			name := "e2e-rollouts-three-revisions"
-			applyManifest(t, "e2e-artifacts/rollouts-three-revisions.yaml")
-			waitFor(t, "deployment/"+name, "condition=Available")
+			applyManifestInNamespace(t, "e2e-artifacts/rollouts-three-revisions.yaml", ns)
+			waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
 
-			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", "default").Run())
-			rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", "default", "--timeout=2m")
+			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", ns).Run())
+			rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=2m")
 			output, err := rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.26): %s", name, output)
 			require.NoError(t, err)
-			waitForSinglePod(t, "default", "app="+name)
+			waitForSinglePod(t, ns, "app="+name)
 
-			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", "default").Run())
-			rolloutCmd = exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", "default", "--timeout=2m")
+			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", ns).Run())
+			rolloutCmd = exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=2m")
 			output, err = rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.27): %s", name, output)
 			require.NoError(t, err)
-			waitForSinglePod(t, "default", "app="+name)
+			waitForSinglePod(t, ns, "app="+name)
 
 			cmdTest{
-				args:            []string{"deployment/" + name, "--include-events=false", "--include-managed-fields=false", "--include-rollout-diffs", "--v", "5"},
+				args:            []string{"deployment/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--include-rollout-diffs", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-three-revisions-with-diffs.regex",
 			}.assert(t, nil, opts...)
 		})
@@ -1923,14 +1958,8 @@ func waitForPodByLabel(t *testing.T, namespace, labelSelector string) string {
 	return ""
 }
 
-func waitForContainerWaitingReason(t *testing.T, resource, containerName, reason string) {
-	t.Helper()
-	waitForContainerWaitingReasonInNamespace(t, resource, containerName, reason, "")
-}
-
-// waitForContainerWaitingReasonInNamespace is waitForContainerWaitingReason, but targets a
-// namespace explicitly via `kubectl -n` instead of the kubeconfig's default; pass "" to behave
-// exactly like waitForContainerWaitingReason.
+// waitForContainerWaitingReasonInNamespace targets a namespace explicitly via `kubectl -n`
+// instead of the kubeconfig's default; pass "" to use the kubeconfig's default namespace.
 func waitForContainerWaitingReasonInNamespace(t *testing.T, resource, containerName, reason, namespace string) {
 	t.Helper()
 	jsonpath := fmt.Sprintf(`{.status.containerStatuses[?(@.name=="%s")].state.waiting.reason}`, containerName)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1153,21 +1153,28 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("sts-with-ingress", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-sts-with-ingress"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
 		// using sts here as the pod name is predictable in that case, not true for deployments and ds
-		applyManifest(t, "e2e-artifacts/sts-with-ingress.yaml")
-		waitFor(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1")
+		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress.yaml", ns)
+		waitForInNamespace(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1", ns)
 		cmdTest{
 			// Log/volume usage bytes come from live kubelet stats and aren't reproducible
 			// across runs, so this is matched as a regex rather than exact text.
-			args:            []string{"pod/sts-with-ingress-0", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/sts-with-ingress-0", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.pod.regex",
 		}.assert(t, nodeNameModifier, opts...)
 		cmdTest{
-			args:            []string{"service/sts-with-ingress", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"service/sts-with-ingress", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.service.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"service/sts-with-ingress", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"service/sts-with-ingress", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress.service-deep.regex",
 		}.assert(t, nil, opts...)
 	})
@@ -1176,15 +1183,22 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// same Service, so its "Routes matching this Service" section shows up alongside the
 		// Ingress already covered there.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/sts-with-ingress.yaml")
-		applyManifest(t, "e2e-artifacts/sts-with-ingress-routes.yaml")
-		waitFor(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1")
+		ns := "e2e-sts-with-ingress-routes"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress.yaml", ns)
+		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress-routes.yaml", ns)
+		waitForInNamespace(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1", ns)
 		cmdTest{
-			args:            []string{"service/sts-with-ingress", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"service/sts-with-ingress", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress-routes.regex",
 		}.assert(t, nodeNameModifier, opts...)
 		cmdTest{
-			args:            []string{"service/sts-with-ingress", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"service/sts-with-ingress", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-ingress-routes.deep.regex",
 		}.assert(t, nodeNameModifier, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -494,14 +494,22 @@ func TestE2EDynamicManifests(t *testing.T) {
 	}
 	t.Run("owners should be included with deep", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-owner-secret"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
 		owner := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "owner",
-				Namespace: "default",
+				Namespace: ns,
 			},
 		}
-		owner, err := clientset.CoreV1().Secrets("default").Create(context.TODO(), owner, metav1.CreateOptions{})
-		defer clientset.CoreV1().Secrets("default").Delete(context.TODO(), "owner", metav1.DeleteOptions{})
+		owner, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), owner, metav1.CreateOptions{})
+		defer clientset.CoreV1().Secrets(ns).Delete(context.TODO(), "owner", metav1.DeleteOptions{})
 		require.NoError(t, err)
 		uid := owner.GetUID()
 		t.Logf("owner secret is created, uid is %s", uid)
@@ -509,7 +517,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		child := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "child",
-				Namespace: "default",
+				Namespace: ns,
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion: "v1",
@@ -520,13 +528,13 @@ func TestE2EDynamicManifests(t *testing.T) {
 				},
 			},
 		}
-		_, err = clientset.CoreV1().Secrets("default").Create(context.TODO(), child, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), child, metav1.CreateOptions{})
 		t.Log("child secret is created")
-		defer clientset.CoreV1().Secrets("default").Delete(context.TODO(), "child", metav1.DeleteOptions{})
+		defer clientset.CoreV1().Secrets(ns).Delete(context.TODO(), "child", metav1.DeleteOptions{})
 		require.NoError(t, err)
 
 		test := cmdTest{
-			args: []string{"secret/child", "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "7"},
+			args: []string{"secret/child", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "7"},
 			// Secret.tmpl intentionally omits kstatus_summary (Secret is always reported
 			// "Resource is always ready" by kstatus, so the "Current:" line is redundant
 			// noise) -- see tests/artifacts/secret-tls-healthy.out for the same committed

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1155,49 +1155,70 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("svc-with-httproute", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/svc-with-httproute.yaml")
+		ns := "e2e-svc-httproute"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/svc-with-httproute.yaml", ns)
 		cmdTest{
-			args:            []string{"service/svc-with-httproute", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"service/svc-with-httproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/svc-with-httproute.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"service/svc-with-httproute", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"service/svc-with-httproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/svc-with-httproute.deep.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("sts-with-nodeport", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-sts-nodeport"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
 		// using sts here as the pod name is predictable in that case, not true for deployments and ds
-		applyManifest(t, "e2e-artifacts/sts-with-nodeport.yaml")
-		waitFor(t, "sts/sts-with-nodeport", "jsonpath={.status.readyReplicas}=1")
-		waitFor(t, "pdb/sts-with-nodeport", "jsonpath={.status.currentHealthy}=1")
+		applyManifestInNamespace(t, "e2e-artifacts/sts-with-nodeport.yaml", ns)
+		waitForInNamespace(t, "sts/sts-with-nodeport", "jsonpath={.status.readyReplicas}=1", ns)
+		waitForInNamespace(t, "pdb/sts-with-nodeport", "jsonpath={.status.currentHealthy}=1", ns)
 		cmdTest{
 			// Log/volume usage bytes come from live kubelet stats and aren't reproducible
 			// across runs, so this is matched as a regex rather than exact text.
-			args:            []string{"pod/sts-with-nodeport-0", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/sts-with-nodeport-0", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.pod.regex",
 		}.assert(t, nodeNameModifier, opts...)
 		cmdTest{
-			args:            []string{"pdb/sts-with-nodeport", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pdb/sts-with-nodeport", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.pdb.regex",
 		}.assert(t, nodeNameModifier, opts...)
 		cmdTest{
-			args:            []string{"sts/sts-with-nodeport", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"sts/sts-with-nodeport", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-with-nodeport.sts.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("pdb-empty-selector-conflict", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/pdb-empty-selector-conflict.yaml")
-		waitFor(t, "sts/pdb-conflict-test", "jsonpath={.status.readyReplicas}=1")
+		ns := "e2e-pdb-conflict"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/pdb-empty-selector-conflict.yaml", ns)
+		waitForInNamespace(t, "sts/pdb-conflict-test", "jsonpath={.status.readyReplicas}=1", ns)
 		// Kubernetes' disruption controller picks one of the two overlapping PDBs arbitrarily
 		// and leaves the other's currentHealthy permanently at 0 -- observedGeneration is the
 		// reliable "controller has made its (possibly permanent) decision" signal here, not
 		// currentHealthy, which may never reach 1 for the non-chosen budget.
-		waitFor(t, "pdb/pdb-conflict-test", "jsonpath={.status.observedGeneration}=1")
-		waitFor(t, "pdb/pdb-conflict-test-catch-all", "jsonpath={.status.observedGeneration}=1")
+		waitForInNamespace(t, "pdb/pdb-conflict-test", "jsonpath={.status.observedGeneration}=1", ns)
+		waitForInNamespace(t, "pdb/pdb-conflict-test-catch-all", "jsonpath={.status.observedGeneration}=1", ns)
 		cmdTest{
-			args:            []string{"pod/pdb-conflict-test-0", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/pdb-conflict-test-0", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pdb-empty-selector-conflict.pod.regex",
 		}.assert(t, nodeNameModifier, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1570,47 +1570,54 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// this e2e suite is the only place that exercises the configMap/secret volume
 		// existence and key-presence checks in Pod.tmpl's pod_volumes/pod_volume_line.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/pod-volume-configmap-secret.yaml")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-configmap", "main", "ContainerCreating")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-secret", "main", "ContainerCreating")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-volume-missing-key", "main", "ContainerCreating")
-		waitFor(t, "pod/e2e-pod-volume-optional-missing", "condition=Ready")
-		waitFor(t, "pod/e2e-pod-volume-optional-missing-key", "condition=Ready")
-		waitFor(t, "pod/e2e-pod-volume-healthy", "condition=Ready")
+		ns := "e2e-pod-volume-configmap-secret"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/pod-volume-configmap-secret.yaml", ns)
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-volume-missing-configmap", "main", "ContainerCreating", ns)
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-volume-missing-secret", "main", "ContainerCreating", ns)
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-volume-missing-key", "main", "ContainerCreating", ns)
+		waitForInNamespace(t, "pod/e2e-pod-volume-optional-missing", "condition=Ready", ns)
+		waitForInNamespace(t, "pod/e2e-pod-volume-optional-missing-key", "condition=Ready", ns)
+		waitForInNamespace(t, "pod/e2e-pod-volume-healthy", "condition=Ready", ns)
 
 		t.Run("pod referencing a non-existent ConfigMap volume flags it without --include-all-volumes", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-missing-configmap", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-missing-configmap", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("pod referencing a non-existent Secret volume flags it without --include-all-volumes", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-missing-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-missing-secret", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("pod referencing an existing ConfigMap but a missing key flags it", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-missing-key", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-missing-key", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-key.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("optional configMap volume referencing a non-existent ConfigMap shows no warning", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-optional-missing", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-optional-missing", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("optional configMap volume with items referencing a missing key shows no warning", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-optional-missing-key", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-optional-missing-key", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("healthy configMap and secret volumes show no warnings", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-healthy", "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-healthy.regex",
 			}.assert(t, nil, opts...)
 		})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1530,30 +1530,37 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// branches of Pod.tmpl's imagePullSecrets check (Check A) and the "broken secrets"
 		// correlation branch of the ImagePullBackOff hint (Check B).
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/pod-image-pull-secrets.yaml")
+		ns := "e2e-pod-image-pull-secrets"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/pod-image-pull-secrets.yaml", ns)
 		// waitForImagePullBackoff accepts either ErrImagePull or ImagePullBackOff, but the
 		// kubelet keeps cycling between them on its retry loop, so it doesn't give a stable
 		// render. Pin to ImagePullBackOff specifically -- it's the longer-lived of the two
 		// (exponential backoff), so it survives the gap until the subtests below observe it.
-		waitForContainerWaitingReason(t, "pod/e2e-pod-missing-pull-secret", "main", "ImagePullBackOff")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-wrong-type-pull-secret", "main", "ImagePullBackOff")
-		waitForContainerWaitingReason(t, "pod/e2e-pod-healthy-pull-secret", "main", "ImagePullBackOff")
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-missing-pull-secret", "main", "ImagePullBackOff", ns)
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-wrong-type-pull-secret", "main", "ImagePullBackOff", ns)
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-healthy-pull-secret", "main", "ImagePullBackOff", ns)
 
 		t.Run("pod referencing a non-existent Secret flags it and correlates with the pull failure", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-missing-pull-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-missing-pull-secret", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-missing.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("pod referencing a wrong-type Secret flags it and correlates with the pull failure", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-wrong-type-pull-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-wrong-type-pull-secret", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-wrong-type.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("pod referencing a healthy Secret shows no warnings", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-healthy-pull-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"pod/e2e-pod-healthy-pull-secret", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-image-pull-secrets-healthy.regex",
 			}.assert(t, nil, opts...)
 		})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -509,7 +509,9 @@ func TestE2EDynamicManifests(t *testing.T) {
 			},
 		}
 		owner, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), owner, metav1.CreateOptions{})
-		defer clientset.CoreV1().Secrets(ns).Delete(context.TODO(), "owner", metav1.DeleteOptions{})
+		t.Cleanup(func() {
+			clientset.CoreV1().Secrets(ns).Delete(context.TODO(), "owner", metav1.DeleteOptions{})
+		})
 		require.NoError(t, err)
 		uid := owner.GetUID()
 		t.Logf("owner secret is created, uid is %s", uid)
@@ -1131,14 +1133,16 @@ func TestE2EDynamicManifests(t *testing.T) {
 			applyManifestInNamespace(t, "e2e-artifacts/rollouts-three-revisions.yaml", ns)
 			waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
 
-			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", ns).Run())
+			out, err := exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", ns).CombinedOutput()
+			require.NoError(t, err, string(out))
 			rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=2m")
 			output, err := rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.26): %s", name, output)
 			require.NoError(t, err)
 			waitForSinglePod(t, ns, "app="+name)
 
-			require.NoError(t, exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", ns).Run())
+			out, err = exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", ns).CombinedOutput()
+			require.NoError(t, err, string(out))
 			rolloutCmd = exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=2m")
 			output, err = rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.27): %s", name, output)
@@ -1892,7 +1896,10 @@ func applyManifest(t *testing.T, filepath string) {
 		t.Logf("deleting manifest %s", filepath)
 		cmd := exec.Command("kubectl", "delete", "-f", filepath)
 		output, err := cmd.CombinedOutput()
-		assert.NoError(t, err)
+		if err != nil {
+			t.Logf("warning: failed to delete manifest %s: %v (output: %s)", filepath, err, string(output))
+			return
+		}
 		t.Logf("manifest deleted %s: %s", filepath, string(output))
 	})
 	require.NoError(t, err)
@@ -1913,7 +1920,10 @@ func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
 		t.Logf("deleting manifest %s from namespace %s", filepath, namespace)
 		cmd := exec.Command("kubectl", "delete", "-n", namespace, "-f", filepath)
 		output, err := cmd.CombinedOutput()
-		assert.NoError(t, err)
+		if err != nil {
+			t.Logf("warning: failed to delete manifest %s from namespace %s: %v (output: %s)", filepath, namespace, err, string(output))
+			return
+		}
 		t.Logf("manifest deleted %s from namespace %s: %s", filepath, namespace, string(output))
 	})
 	require.NoError(t, err)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1203,49 +1203,77 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("tcproute-with-gateway", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/tcproute-with-gateway.yaml")
+		ns := "e2e-tcproute"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/tcproute-with-gateway.yaml", ns)
 		cmdTest{
-			args:            []string{"tcproute/e2e-tcproute", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"tcproute/e2e-tcproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/tcproute-with-gateway.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"tcproute/e2e-tcproute", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"tcproute/e2e-tcproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/tcproute-with-gateway.deep.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("udproute-with-gateway", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/udproute-with-gateway.yaml")
+		ns := "e2e-udproute"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/udproute-with-gateway.yaml", ns)
 		cmdTest{
-			args:            []string{"udproute/e2e-udproute", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"udproute/e2e-udproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/udproute-with-gateway.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"udproute/e2e-udproute", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"udproute/e2e-udproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/udproute-with-gateway.deep.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("listenerset-with-gateway", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/listenerset-with-gateway.yaml")
+		ns := "e2e-listenerset"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/listenerset-with-gateway.yaml", ns)
 		cmdTest{
-			args:            []string{"listenerset/e2e-listenerset", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"listenerset/e2e-listenerset", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/listenerset-with-gateway.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"listenerset/e2e-listenerset", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"listenerset/e2e-listenerset", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/listenerset-with-gateway.deep.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("backendtlspolicy-with-target", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/backendtlspolicy-with-target.yaml")
+		ns := "e2e-backendtlspolicy"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/backendtlspolicy-with-target.yaml", ns)
 		cmdTest{
-			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/backendtlspolicy-with-target.regex",
 		}.assert(t, nil, opts...)
 		cmdTest{
-			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
+			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--deep", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/backendtlspolicy-with-target.deep.regex",
 		}.assert(t, nil, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -558,24 +558,32 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("pod on a cordoned node with an untolerated taint and a bad condition", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-bad-node-pod"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
 		nodeName := createBadNode(t, clientset)
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod-on-bad-node",
-				Namespace: "default",
+				Namespace: ns,
 			},
 			Spec: corev1.PodSpec{
 				NodeName:   nodeName,
 				Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
 			},
 		}
-		_, err := clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 
 		cmdTest{
-			args:            []string{"pod/pod-on-bad-node", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/pod-on-bad-node", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-on-bad-node.regex",
 		}.assert(t, nil, opts...)
 	})
@@ -647,6 +655,14 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("workload's matching pod on a cordoned node surfaces a compact node-problem flag", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-bad-node-rs"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
 		nodeName := createBadNode(t, clientset)
 
 		// The Pod's spec.nodeName is set directly at creation, bypassing the scheduler, so it
@@ -655,7 +671,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod-on-bad-node-for-rs",
-				Namespace: "default",
+				Namespace: ns,
 				Labels:    map[string]string{"app": "kubectl-status-test-bad-rs"},
 			},
 			Spec: corev1.PodSpec{
@@ -663,15 +679,15 @@ func TestE2EDynamicManifests(t *testing.T) {
 				Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
 			},
 		}
-		_, err := clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 
 		one := int32(1)
 		rs := &appsv1.ReplicaSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bad-rs",
-				Namespace: "default",
+				Namespace: ns,
 			},
 			Spec: appsv1.ReplicaSetSpec{
 				Replicas: &one,
@@ -682,12 +698,12 @@ func TestE2EDynamicManifests(t *testing.T) {
 				},
 			},
 		}
-		_, err = clientset.AppsV1().ReplicaSets("default").Create(context.TODO(), rs, metav1.CreateOptions{})
+		_, err = clientset.AppsV1().ReplicaSets(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.AppsV1().ReplicaSets("default").Delete(context.TODO(), rs.Name, metav1.DeleteOptions{})
+		defer clientset.AppsV1().ReplicaSets(ns).Delete(context.TODO(), rs.Name, metav1.DeleteOptions{})
 
 		cmdTest{
-			args:            []string{"rs/bad-rs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"rs/bad-rs", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-on-bad-node-for-rs.regex",
 		}.assert(t, nil, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -581,47 +581,55 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("pod's serviceAccountName resolves to the ServiceAccount and surfaces automount/imagePullSecrets", func(t *testing.T) {
 		opts := combineOpts(viperTestHackOpts())
+		ns := "e2e-pod-custom-sa"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
 		f := false
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kubectl-status-test-sa",
-				Namespace: "default",
+				Namespace: ns,
 			},
 			AutomountServiceAccountToken: &f,
 			ImagePullSecrets:             []corev1.LocalObjectReference{{Name: "regcred"}},
 		}
-		_, err := clientset.CoreV1().ServiceAccounts("default").Create(context.TODO(), sa, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().ServiceAccounts(ns).Create(context.TODO(), sa, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.CoreV1().ServiceAccounts("default").Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
+		defer clientset.CoreV1().ServiceAccounts(ns).Delete(context.TODO(), sa.Name, metav1.DeleteOptions{})
 
 		// The ServiceAccount admission plugin merges its imagePullSecrets onto every Pod that
 		// uses it, so Pod.tmpl's own (pre-existing) imagePullSecrets check will flag "regcred" as
 		// missing unless it actually exists with the expected type.
 		regcred := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "regcred", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "regcred", Namespace: ns},
 			Type:       corev1.SecretTypeDockerConfigJson,
 			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
 		}
-		_, err = clientset.CoreV1().Secrets("default").Create(context.TODO(), regcred, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), regcred, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.CoreV1().Secrets("default").Delete(context.TODO(), regcred.Name, metav1.DeleteOptions{})
+		defer clientset.CoreV1().Secrets(ns).Delete(context.TODO(), regcred.Name, metav1.DeleteOptions{})
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod-with-custom-sa",
-				Namespace: "default",
+				Namespace: ns,
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: sa.Name,
 				Containers:         []corev1.Container{{Name: "app", Image: "busybox"}},
 			},
 		}
-		_, err = clientset.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.CoreV1().Pods("default").Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 
 		cmdTest{
-			args:            []string{"pod/pod-with-custom-sa", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/pod-with-custom-sa", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-with-custom-sa.regex",
 		}.assert(t, nil, opts...)
 	})

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1243,6 +1243,16 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("vap-binding-resolves-policy", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		// The policy itself is cluster-scoped (ValidatingAdmissionPolicy/Binding aren't
+		// namespaced), but its matchConstraints.namespaceSelector in vap-binding.yaml scopes
+		// enforcement to this namespace specifically -- see the comment there for why.
+		ns := "e2e-vap-binding"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
 		applyManifest(t, "e2e-artifacts/vap-binding.yaml")
 		cmdTest{
 			args:            []string{"validatingadmissionpolicybinding/e2e-require-team-label-binding", "--include-events=false", "--include-managed-fields=false", "--v", "5"},

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1292,10 +1292,17 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("sts-without-service", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/sts-without-service.yaml")
-		waitFor(t, "sts/sts-without-service", "jsonpath={.status.readyReplicas}=1")
+		ns := "e2e-sts-without-service"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/sts-without-service.yaml", ns)
+		waitForInNamespace(t, "sts/sts-without-service", "jsonpath={.status.readyReplicas}=1", ns)
 		cmdTest{
-			args:            []string{"sts/sts-without-service", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"sts/sts-without-service", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/sts-without-service.regex",
 		}.assert(t, nil, opts...)
 	})
@@ -1734,11 +1741,43 @@ func applyManifest(t *testing.T, filepath string) {
 	t.Logf("applied manifest %s: %s", filepath, string(output))
 }
 
+// applyManifestInNamespace is applyManifest, but targets a namespace via `kubectl -n` instead of
+// relying on the manifest's own metadata.namespace (or the kubeconfig's default) -- used to give a
+// subtest a dedicated namespace without needing a namespace-specific copy of its fixture yaml. The
+// manifest's objects must not already set their own metadata.namespace, since that always wins
+// over `-n` and would silently defeat the isolation this is for.
+func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
+	t.Helper()
+	filepath = path.Join("..", "tests", filepath)
+	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", filepath)
+	output, err := cmd.CombinedOutput()
+	t.Cleanup(func() {
+		t.Logf("deleting manifest %s from namespace %s", filepath, namespace)
+		cmd := exec.Command("kubectl", "delete", "-n", namespace, "-f", filepath)
+		output, err := cmd.CombinedOutput()
+		assert.NoError(t, err)
+		t.Logf("manifest deleted %s from namespace %s: %s", filepath, namespace, string(output))
+	})
+	require.NoError(t, err)
+	t.Logf("applied manifest %s to namespace %s: %s", filepath, namespace, string(output))
+}
+
 func waitFor(t *testing.T, resource, forParam string) {
 	t.Helper()
 	cmd := exec.Command("kubectl", "wait", "--for", forParam, resource, "--timeout=2m")
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s: %s", resource, string(output))
+	require.NoError(t, err)
+}
+
+// waitForInNamespace is waitFor, but targets a namespace explicitly via `kubectl -n` instead of
+// the kubeconfig's default -- pairs with applyManifestInNamespace for subtests moved off the
+// shared default namespace.
+func waitForInNamespace(t *testing.T, resource, forParam, namespace string) {
+	t.Helper()
+	cmd := exec.Command("kubectl", "wait", "-n", namespace, "--for", forParam, resource, "--timeout=2m")
+	output, err := cmd.CombinedOutput()
+	t.Logf("wait result for %s in namespace %s: %s", resource, namespace, string(output))
 	require.NoError(t, err)
 }
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1444,14 +1444,21 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// KubeGetFirst a no-op, so this e2e suite is the only place in the whole test suite
 		// that exercises the found-secret validation branches of Ingress.tmpl/Gateway.tmpl.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		applyManifest(t, "e2e-artifacts/tls-validation-ca.yaml")
-		waitFor(t, "certificate/e2e-tls-root-ca", "condition=Ready")
-		waitFor(t, "issuer/e2e-tls-ca-issuer", "condition=Ready")
-		applyManifest(t, "e2e-artifacts/tls-validation-leaf.yaml")
-		waitFor(t, "certificate/e2e-tls-leaf", "condition=Ready")
+		ns := "e2e-tls-validation"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-ca.yaml", ns)
+		waitForInNamespace(t, "certificate/e2e-tls-root-ca", "condition=Ready", ns)
+		waitForInNamespace(t, "issuer/e2e-tls-ca-issuer", "condition=Ready", ns)
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-leaf.yaml", ns)
+		waitForInNamespace(t, "certificate/e2e-tls-leaf", "condition=Ready", ns)
 
 		t.Run("secret/leaf shows full non-self-signed certificate detail", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"secret/e2e-tls-leaf-tls", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"secret/e2e-tls-leaf-tls", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-secret-leaf.regex"))
 			require.NoError(t, rerr)
@@ -1464,18 +1471,18 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("secret/leaf with --deep inlines the full Certificate and Issuer detail", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"secret/e2e-tls-leaf-tls", "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"secret/e2e-tls-leaf-tls", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-secret-leaf-deep.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("secret/root-ca is flagged self-signed", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"secret/e2e-tls-root-ca-secret", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"secret/e2e-tls-root-ca-secret", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-secret-root.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("ingress with matching hostname is healthy", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"ingress/e2e-tls-ingress-healthy", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"ingress/e2e-tls-ingress-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-ingress-healthy.regex"))
 			require.NoError(t, rerr)
@@ -1493,24 +1500,24 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("ingress with mismatched hostname flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"ingress/e2e-tls-ingress-mismatch", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"ingress/e2e-tls-ingress-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-ingress-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("ingress referencing the root CA secret flags self-signed", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"ingress/e2e-tls-ingress-selfsigned", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"ingress/e2e-tls-ingress-selfsigned", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-ingress-selfsigned.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("ingress with --deep inlines the full Secret detail", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"ingress/e2e-tls-ingress-healthy", "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"ingress/e2e-tls-ingress-healthy", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-ingress-deep.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("gateway with matching hostname is healthy", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"gateway/e2e-tls-gw-healthy", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"gateway/e2e-tls-gw-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-gateway-healthy.regex"))
 			require.NoError(t, rerr)
@@ -1521,13 +1528,13 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("gateway with mismatched hostname flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"gateway/e2e-tls-gw-mismatch", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"gateway/e2e-tls-gw-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-gateway-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
-		applyManifest(t, "e2e-artifacts/tls-validation-grpcroute.yaml")
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-grpcroute.yaml", ns)
 		t.Run("grpcroute attached to healthy gateway listener shows no cert flags", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"grpcroute/e2e-tls-grpcroute-healthy", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"grpcroute/e2e-tls-grpcroute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-grpcroute-healthy.regex"))
 			require.NoError(t, rerr)
@@ -1538,13 +1545,13 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("grpcroute with its own hostname mismatching the cert SANs flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"grpcroute/e2e-tls-grpcroute-mismatch", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"grpcroute/e2e-tls-grpcroute-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-grpcroute-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
-		applyManifest(t, "e2e-artifacts/tls-validation-tlsroute.yaml")
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-tlsroute.yaml", ns)
 		t.Run("tlsroute attached to Terminate listener with matching hostname is healthy", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-healthy", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-tlsroute-healthy.regex"))
 			require.NoError(t, rerr)
@@ -1555,12 +1562,12 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("tlsroute with its own hostname mismatching the cert SANs flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"tlsroute/e2e-tlsroute-mismatch", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"tlsroute/e2e-tlsroute-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-tlsroute-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("tlsroute attached to a Passthrough listener shows no cert flags", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-passthrough", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-passthrough", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-tlsroute-passthrough.regex"))
 			require.NoError(t, rerr)
@@ -1569,9 +1576,9 @@ func TestE2EDynamicManifests(t *testing.T) {
 				assert.NotContains(t, stdout, problem)
 			}
 		})
-		applyManifest(t, "e2e-artifacts/tls-validation-httproute.yaml")
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-httproute.yaml", ns)
 		t.Run("httproute attached to a healthy listener is healthy", func(t *testing.T) {
-			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-healthy", "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
 			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-httproute-healthy.regex"))
 			require.NoError(t, rerr)
@@ -1582,7 +1589,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		})
 		t.Run("httproute attached to a mismatched-hostname listener flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"httproute/e2e-tls-httproute-mismatch", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				args:            []string{"httproute/e2e-tls-httproute-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-httproute-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
@@ -1913,17 +1920,9 @@ func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
 	t.Logf("applied manifest %s to namespace %s: %s", filepath, namespace, string(output))
 }
 
-func waitFor(t *testing.T, resource, forParam string) {
-	t.Helper()
-	cmd := exec.Command("kubectl", "wait", "--for", forParam, resource, "--timeout=2m")
-	output, err := cmd.CombinedOutput()
-	t.Logf("wait result for %s: %s", resource, string(output))
-	require.NoError(t, err)
-}
-
-// waitForInNamespace is waitFor, but targets a namespace explicitly via `kubectl -n` instead of
-// the kubeconfig's default -- pairs with applyManifestInNamespace for subtests moved off the
-// shared default namespace.
+// waitForInNamespace targets a namespace explicitly via `kubectl -n` instead of the kubeconfig's
+// default -- pairs with applyManifestInNamespace for subtests moved off the shared default
+// namespace.
 func waitForInNamespace(t *testing.T, resource, forParam, namespace string) {
 	t.Helper()
 	cmd := exec.Command("kubectl", "wait", "-n", namespace, "--for", forParam, resource, "--timeout=2m")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1623,14 +1623,21 @@ func TestE2EDynamicManifests(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts(), []func(*plugin.RenderConfig){
 			func(cfg *plugin.RenderConfig) { cfg.Now = time.Now },
 		})
-		applyManifest(t, "e2e-artifacts/pod-container-logs.yaml")
+		ns := "e2e-pod-container-logs"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+		applyManifestInNamespace(t, "e2e-artifacts/pod-container-logs.yaml", ns)
 		// Wait for a stable Waiting(CrashLoopBackOff) state rather than just restartCount > 0:
 		// the container's current state otherwise flips between Waiting and Terminated(Error)
 		// as the kubelet retries, which would make the golden regex flaky.
-		waitForContainerWaitingReason(t, "pod/e2e-pod-container-logs", "crasher", "CrashLoopBackOff")
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-container-logs", "crasher", "CrashLoopBackOff", ns)
 
 		cmdTest{
-			args:            []string{"pod/e2e-pod-container-logs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"pod/e2e-pod-container-logs", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-container-logs.regex",
 		}.assert(t, nil, opts...)
 	})
@@ -1904,10 +1911,22 @@ func waitForPodByLabel(t *testing.T, namespace, labelSelector string) string {
 
 func waitForContainerWaitingReason(t *testing.T, resource, containerName, reason string) {
 	t.Helper()
+	waitForContainerWaitingReasonInNamespace(t, resource, containerName, reason, "")
+}
+
+// waitForContainerWaitingReasonInNamespace is waitForContainerWaitingReason, but targets a
+// namespace explicitly via `kubectl -n` instead of the kubeconfig's default; pass "" to behave
+// exactly like waitForContainerWaitingReason.
+func waitForContainerWaitingReasonInNamespace(t *testing.T, resource, containerName, reason, namespace string) {
+	t.Helper()
 	jsonpath := fmt.Sprintf(`{.status.containerStatuses[?(@.name=="%s")].state.waiting.reason}`, containerName)
+	args := []string{"get", resource, "-o", "jsonpath=" + jsonpath}
+	if namespace != "" {
+		args = append([]string{"-n", namespace}, args...)
+	}
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", resource, "-o", "jsonpath="+jsonpath)
+		cmd := exec.Command("kubectl", args...)
 		output, err := cmd.CombinedOutput()
 		if err == nil && strings.TrimSpace(string(output)) == reason {
 			t.Logf("%s container %s reached waiting reason %s", resource, containerName, reason)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -932,12 +932,20 @@ func TestE2EDynamicManifests(t *testing.T) {
 	})
 	t.Run("deployment rollout with --include-rollout-diffs shows the diff between revisions", func(t *testing.T) {
 		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-rollout-diff"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
 		name := "rollout-diff-test"
 		one := int32(1)
 		dep := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: "default",
+				Namespace: ns,
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &one,
@@ -948,19 +956,19 @@ func TestE2EDynamicManifests(t *testing.T) {
 				},
 			},
 		}
-		_, err := clientset.AppsV1().Deployments("default").Create(context.TODO(), dep, metav1.CreateOptions{})
+		_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
 		require.NoError(t, err)
-		defer clientset.AppsV1().Deployments("default").Delete(context.TODO(), name, metav1.DeleteOptions{})
-		waitFor(t, "deployment/"+name, "condition=Available")
+		defer clientset.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
 
 		// Update the image so a second ReplicaSet revision is created, giving --include-rollout-diffs
 		// something to diff.
-		dep, err = clientset.AppsV1().Deployments("default").Get(context.TODO(), name, metav1.GetOptions{})
+		dep, err = clientset.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
 		require.NoError(t, err)
 		dep.Spec.Template.Spec.Containers[0].Image = "nginx:1.26"
-		_, err = clientset.AppsV1().Deployments("default").Update(context.TODO(), dep, metav1.UpdateOptions{})
+		_, err = clientset.AppsV1().Deployments(ns).Update(context.TODO(), dep, metav1.UpdateOptions{})
 		require.NoError(t, err)
-		rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", "default", "--timeout=2m")
+		rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=2m")
 		output, err := rolloutCmd.CombinedOutput()
 		t.Logf("rollout status for %s: %s", name, output)
 		require.NoError(t, err)
@@ -968,7 +976,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// The order in which the two ReplicaSet revisions are diffed (and so which side
 		// gets "-" vs "+") isn't guaranteed, so the fixture alternates both directions.
 		cmdTest{
-			args:            []string{"deployment/" + name, "--include-rollout-diffs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			args:            []string{"deployment/" + name, "-n", ns, "--include-rollout-diffs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/rollout-diff.regex",
 		}.assert(t, nil, opts...)
 	})

--- a/tests/e2e-artifacts/backendtlspolicy-with-target.deep.regex
+++ b/tests/e2e-artifacts/backendtlspolicy-with-target.deep.regex
@@ -1,8 +1,8 @@
 \A
-BackendTLSPolicy/e2e-backendtlspolicy -n default, created 1m ago, gen:1
+BackendTLSPolicy/e2e-backendtlspolicy -n e2e-backendtlspolicy, created 1m ago, gen:1
   Current: Resource is current
   Targets:
-    Service/e2e-tls-backend-svc -n default, created 1m ago
+    Service/e2e-tls-backend-svc -n e2e-backendtlspolicy, created 1m ago
       Current: Service is ready
       Missing Endpoint: Service has no matching endpoint\.
   TLS: SNI e2e-tls-backend\.example\.com

--- a/tests/e2e-artifacts/backendtlspolicy-with-target.regex
+++ b/tests/e2e-artifacts/backendtlspolicy-with-target.regex
@@ -1,5 +1,5 @@
 \A
-BackendTLSPolicy/e2e-backendtlspolicy -n default, created 1m ago, gen:1
+BackendTLSPolicy/e2e-backendtlspolicy -n e2e-backendtlspolicy, created 1m ago, gen:1
   Current: Resource is current
   Targets:
     Service/e2e-tls-backend-svc

--- a/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
@@ -1,8 +1,8 @@
 \A
-ListenerSet/e2e-listenerset -n default, created 1m ago, gen:1
+ListenerSet/e2e-listenerset -n e2e-listenerset, created 1m ago, gen:1
   Current: Resource is current
   Gateway:
-    Gateway/e2e-lset-gw -n default, created 1m ago, gen:1
+    Gateway/e2e-lset-gw -n e2e-listenerset, created 1m ago, gen:1
       Current: Resource is current
       Accepted Pending, Waiting for controller for 1m
       Programmed Pending, Waiting for controller for 1m

--- a/tests/e2e-artifacts/listenerset-with-gateway.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.regex
@@ -1,5 +1,5 @@
 \A
-ListenerSet/e2e-listenerset -n default, created 1m ago, gen:1
+ListenerSet/e2e-listenerset -n e2e-listenerset, created 1m ago, gen:1
   Current: Resource is current
   Gateway:
     Gateway/e2e-lset-gw

--- a/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
+++ b/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
@@ -1,5 +1,5 @@
 \A
-Pod/pdb-conflict-test-0 -n default, created 1m ago by StatefulSet/pdb-conflict-test, gen:1, started after 1m Running BestEffort
+Pod/pdb-conflict-test-0 -n e2e-pdb-conflict, created 1m ago by StatefulSet/pdb-conflict-test, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by pdb-conflict-test application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
@@ -8,5 +8,5 @@ Pod/pdb-conflict-test-0 -n default, created 1m ago by StatefulSet/pdb-conflict-t
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   2 PodDisruptionBudgets match — evictions of these pods will fail \(Kubernetes doesn't support a pod covered by multiple PDBs\)
   PodDisruptionBudgets:
-    (?:PodDisruptionBudget/pdb-conflict-test -n default, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))\n    PodDisruptionBudget/pdb-conflict-test-catch-all -n default, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))|PodDisruptionBudget/pdb-conflict-test-catch-all -n default, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))\n    PodDisruptionBudget/pdb-conflict-test -n default, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\)))
+    (?:PodDisruptionBudget/pdb-conflict-test -n e2e-pdb-conflict, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))\n    PodDisruptionBudget/pdb-conflict-test-catch-all -n e2e-pdb-conflict, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))|PodDisruptionBudget/pdb-conflict-test-catch-all -n e2e-pdb-conflict, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\))\n    PodDisruptionBudget/pdb-conflict-test -n e2e-pdb-conflict, created 1m ago, min available=1, (?:evictions/drains currently blocked|budget violated \(0/1 healthy, 1 required\)))
 \z

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+Pod/e2e-pod-container-logs -n e2e-pod-container-logs, created 1m ago, gen:1, started after 1m Running BestEffort
   Failed: Containers in CrashLoop state: crasher
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: crasher
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
@@ -12,7 +12,7 @@ Pod/e2e-pod-container-logs -n default, created 1m ago, gen:1, started after 1m R
         init-setup-log-line
     init-silent \(busybox:latest\) Started 1m ago and Completed after 1m, has no logs
   Containers:
-    crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_default\([0-9a-f-]+\), restarted [0-9]+ times(?: \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
+    crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_e2e-pod-container-logs\([0-9a-f-]+\), restarted [0-9]+ times(?: \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
       previously: Started 1m ago and Error after 1m with exit code exit with 1
       Last 20 lines of logs from previous instance \(restarted within last hour\):
         crasher-log-line

--- a/tests/e2e-artifacts/pod-container-logs.yaml
+++ b/tests/e2e-artifacts/pod-container-logs.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-container-logs
-  namespace: default
 spec:
   restartPolicy: Always
   initContainers:

--- a/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-healthy-pull-secret -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-healthy-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-missing-pull-secret -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-missing-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-wrong-type-pull-secret -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-wrong-type-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-image-pull-secrets.yaml
+++ b/tests/e2e-artifacts/pod-image-pull-secrets.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: e2e-pull-secret-wrong-type
-  namespace: default
 type: Opaque
 data:
   foo: aGVsbG8=
@@ -11,7 +10,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: e2e-pull-secret-healthy
-  namespace: default
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: eyJhdXRocyI6e319
@@ -20,7 +18,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-missing-pull-secret
-  namespace: default
 spec:
   imagePullSecrets:
   - name: e2e-pull-secret-does-not-exist
@@ -33,7 +30,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-wrong-type-pull-secret
-  namespace: default
 spec:
   imagePullSecrets:
   - name: e2e-pull-secret-wrong-type
@@ -46,7 +42,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-healthy-pull-secret
-  namespace: default
 spec:
   imagePullSecrets:
   - name: e2e-pull-secret-healthy

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -1,1 +1,1 @@
-Pod/pod-on-bad-node-for-rs -n default[^\n]*, node cordoned, node NotReady, node MemoryPressure, untolerated node taint
+Pod/pod-on-bad-node-for-rs -n e2e-bad-node-rs[^\n]*, node cordoned, node NotReady, node MemoryPressure, untolerated node taint

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-healthy -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+Pod/e2e-pod-volume-healthy -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-missing-configmap -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-volume-missing-configmap -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-missing-key -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-volume-missing-key -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-missing-secret -n default, created 1m ago, gen:1, started after 1m Pending BestEffort
+Pod/e2e-pod-volume-missing-secret -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled -> Initialized -> Not ContainersReady -> Not Ready

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-optional-missing-key -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+Pod/e2e-pod-volume-optional-missing-key -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
@@ -1,5 +1,5 @@
 \A
-Pod/e2e-pod-volume-optional-missing -n default, created 1m ago, gen:1, started after 1m Running BestEffort
+Pod/e2e-pod-volume-optional-missing -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Standalone POD\.

--- a/tests/e2e-artifacts/pod-volume-configmap-secret.yaml
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: e2e-cm-with-data
-  namespace: default
 data:
   existing-key: hello
 ---
@@ -10,7 +9,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: e2e-secret-healthy-vol
-  namespace: default
 type: Opaque
 data:
   key1: aGVsbG8=
@@ -19,7 +17,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-missing-configmap
-  namespace: default
 spec:
   volumes:
   - name: cfg
@@ -36,7 +33,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-missing-secret
-  namespace: default
 spec:
   volumes:
   - name: sec
@@ -53,7 +49,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-missing-key
-  namespace: default
 spec:
   volumes:
   - name: cfg
@@ -73,7 +68,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-optional-missing
-  namespace: default
 spec:
   volumes:
   - name: cfg
@@ -91,7 +85,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-optional-missing-key
-  namespace: default
 spec:
   volumes:
   - name: cfg
@@ -112,7 +105,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: e2e-pod-volume-healthy
-  namespace: default
 spec:
   volumes:
   - name: cfg

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -1,9 +1,9 @@
 \A
-Deployment/rollout-diff-test -n default, created \d+[a-z]+ ago, gen:\d+ rev:\d+
+Deployment/rollout-diff-test -n e2e-rollout-diff, created \d+[a-z]+ ago, gen:\d+ rev:\d+
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=rollout-diff-test
-(?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+ -n default, created \d+[a-z]+ ago Running, 1/1 ready
+(?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+ -n e2e-rollout-diff, created \d+[a-z]+ ago Running, 1/1 ready
 )+  Not matched by any Service
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
   Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+

--- a/tests/e2e-artifacts/rollouts-single-blocked-daemonset.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-daemonset.regex
@@ -1,9 +1,9 @@
 \A
-DaemonSet/e2e-rollouts-blocked-daemonset -n default, created 1m ago, gen:1
+DaemonSet/e2e-rollouts-blocked-daemonset -n e2e-rollouts-blocked-daemonset, created 1m ago, gen:1
   InProgress: Available: 0/1
     Reconciling: LessAvailable, Available: 0/1
   Selector: app=e2e-rollouts-blocked-daemonset
-    Pod/e2e-rollouts-blocked-daemonset-[a-z0-9]+ -n default, created 1m ago Pending, 0/1 ready
+    Pod/e2e-rollouts-blocked-daemonset-[a-z0-9]+ -n e2e-rollouts-blocked-daemonset, created 1m ago Pending, 0/1 ready
   Not matched by any Service
   desired:1, current:1, ready:0, updated:1
   Ongoing Rollout: Waiting for daemon set "e2e-rollouts-blocked-daemonset" rollout to finish: 0 of 1 updated pods are available\.\.\.

--- a/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
@@ -1,10 +1,10 @@
 \A
-Deployment/e2e-rollouts-blocked-deployment -n default, created 1m ago, gen:1 rev:1
+Deployment/e2e-rollouts-blocked-deployment -n e2e-rollouts-blocked-deployment, created 1m ago, gen:1 rev:1
   InProgress: Available: 0/1
     Reconciling: LessAvailable, Available: 0/1
   desired:1, existing:1, ready:0, updated:1, available:0, unavailable:1
   Selector: app=e2e-rollouts-blocked-deployment
-    Pod/e2e-rollouts-blocked-deployment-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Pending, 0/1 ready
+    Pod/e2e-rollouts-blocked-deployment-[a-z0-9]+-[a-z0-9]+ -n e2e-rollouts-blocked-deployment, created 1m ago Pending, 0/1 ready
   Not matched by any Service
   Available MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
   Progressing ReplicaSetUpdated, ReplicaSet "e2e-rollouts-blocked-deployment-[a-z0-9]+" is progressing\. for 1m

--- a/tests/e2e-artifacts/rollouts-single-blocked-statefulset.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-statefulset.regex
@@ -1,9 +1,9 @@
 \A
-StatefulSet/e2e-rollouts-blocked-statefulset -n default, created 1m ago, gen:1
+StatefulSet/e2e-rollouts-blocked-statefulset -n e2e-rollouts-blocked-statefulset, created 1m ago, gen:1
   InProgress: Ready: 0/1
     Reconciling: LessReady, Ready: 0/1
   Selector: app=e2e-rollouts-blocked-statefulset
-    Pod/e2e-rollouts-blocked-statefulset-0 -n default, created 1m ago Pending, 0/1 ready
+    Pod/e2e-rollouts-blocked-statefulset-0 -n e2e-rollouts-blocked-statefulset, created 1m ago Pending, 0/1 ready
   Not matched by any Service
   desired:1, existing:1, ready:0, current:1, updated:1, available:0
   Outage: StatefulSet has no Ready replicas\.

--- a/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
@@ -1,9 +1,9 @@
 \A
-Deployment/e2e-rollouts-healthy-deployment -n default, created 1m ago, gen:1 rev:1
+Deployment/e2e-rollouts-healthy-deployment -n e2e-rollouts-healthy-deployment, created 1m ago, gen:1 rev:1
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=e2e-rollouts-healthy-deployment
-    Pod/e2e-rollouts-healthy-deployment-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready
+    Pod/e2e-rollouts-healthy-deployment-[a-z0-9]+-[a-z0-9]+ -n e2e-rollouts-healthy-deployment, created 1m ago Running, 1/1 ready
   Not matched by any Service
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
   Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-healthy-deployment-[a-z0-9]+" has successfully progressed\. for 1m

--- a/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
+++ b/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
@@ -1,9 +1,9 @@
 \A
-Deployment/e2e-rollouts-three-revisions -n default, created 1m ago, gen:3 rev:3
+Deployment/e2e-rollouts-three-revisions -n e2e-rollouts-three-revisions, created 1m ago, gen:3 rev:3
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=e2e-rollouts-three-revisions
-    Pod/e2e-rollouts-three-revisions-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready
+    Pod/e2e-rollouts-three-revisions-[a-z0-9]+-[a-z0-9]+ -n e2e-rollouts-three-revisions, created 1m ago Running, 1/1 ready
   Not matched by any Service
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
   Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-three-revisions-[a-z0-9]+" has successfully progressed\. for 1m

--- a/tests/e2e-artifacts/rollouts-three-revisions.yaml
+++ b/tests/e2e-artifacts/rollouts-three-revisions.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: e2e-rollouts-three-revisions
-  namespace: default
 spec:
   replicas: 1
   selector:

--- a/tests/e2e-artifacts/secret-child-with-owner.regex
+++ b/tests/e2e-artifacts/secret-child-with-owner.regex
@@ -1,5 +1,5 @@
 \A
-Secret\/child -n default, created 1m ago by Secret/owner
+Secret\/child -n e2e-owner-secret, created 1m ago by Secret/owner
   Owners:
-    Secret\/owner -n default, created 1m ago
+    Secret\/owner -n e2e-owner-secret, created 1m ago
 \z

--- a/tests/e2e-artifacts/sts-with-ingress-routes.deep.regex
+++ b/tests/e2e-artifacts/sts-with-ingress-routes.deep.regex
@@ -1,17 +1,17 @@
 \A
-Service/sts-with-ingress -n default, created 1m ago, last endpoint change was 1m ago
+Service/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, last endpoint change was 1m ago
   Current: Service is ready
-  Ready: Pod/sts-with-ingress-0 -n default on Node/minikube, [0-9.]+:80/TCP
+  Ready: Pod/sts-with-ingress-0 -n e2e-sts-with-ingress-routes on Node/minikube, [0-9.]+:80/TCP
   Ingresses matching this Service:
-    Ingress/sts-with-ingress -n default, created 1m ago, gen:1
+    Ingress/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, gen:1
       Current: Resource is current
-      Service/sts-with-ingress -n default, created 1m ago, ClusterIP, 1 ready, 80/TCP
+      Service/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, ClusterIP, 1 ready, 80/TCP
   Routes matching this Service:
-    HTTPRoute/sts-http -n default, created 1m ago, gen:1
+    HTTPRoute/sts-http -n e2e-sts-with-ingress-routes, created 1m ago, gen:1
       Current: Resource is current
       Hostnames: sts\.example\.com
       Parents:
-        Gateway/sts-gw -n default, created 1m ago, gen:1
+        Gateway/sts-gw -n e2e-sts-with-ingress-routes, created 1m ago, gen:1
           Current: Resource is current
           Accepted Pending, Waiting for controller for 1m
           Programmed Pending, Waiting for controller for 1m
@@ -20,11 +20,11 @@ Service/sts-with-ingress -n default, created 1m ago, last endpoint change was 1m
             tcp: port=8080/TCP, namespaces=Same
       Rules:
         PathPrefix /
-        Service/sts-with-ingress\[default\] is already printed
-    TCPRoute/sts-tcp -n default, created 1m ago, gen:1
+        Service/sts-with-ingress\[e2e-sts-with-ingress-routes\] is already printed
+    TCPRoute/sts-tcp -n e2e-sts-with-ingress-routes, created 1m ago, gen:1
       Current: Resource is current
       Parents:
-        Gateway/sts-gw\[default\] is already printed
+        Gateway/sts-gw\[e2e-sts-with-ingress-routes\] is already printed
       Rules:
         → Service/sts-with-ingress:80
 \z

--- a/tests/e2e-artifacts/sts-with-ingress-routes.regex
+++ b/tests/e2e-artifacts/sts-with-ingress-routes.regex
@@ -1,10 +1,10 @@
 \A
-Service/sts-with-ingress -n default, created 1m ago, last endpoint change was 1m ago
+Service/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, last endpoint change was 1m ago
   Current: Service is ready
-  Ready: Pod/sts-with-ingress-0 -n default on Node/minikube, [0-9.]+:80/TCP
+  Ready: Pod/sts-with-ingress-0 -n e2e-sts-with-ingress-routes on Node/minikube, [0-9.]+:80/TCP
   Ingresses matching this Service:
-    Ingress/sts-with-ingress -n default, created 1m ago, sts-with-ingress\.com, Pending LoadBalancer, Current
+    Ingress/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, sts-with-ingress\.com, Pending LoadBalancer, Current
   Routes matching this Service:
-    HTTPRoute/sts-http -n default, created 1m ago, sts\.example\.com, Current
-    TCPRoute/sts-tcp -n default, created 1m ago, Current
+    HTTPRoute/sts-http -n e2e-sts-with-ingress-routes, created 1m ago, sts\.example\.com, Current
+    TCPRoute/sts-tcp -n e2e-sts-with-ingress-routes, created 1m ago, Current
 \z

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -1,10 +1,10 @@
 \A
-Pod/sts-with-ingress-0 -n default, created 1m ago by StatefulSet/sts-with-ingress, gen:1, started after 1m Running BestEffort
+Pod/sts-with-ingress-0 -n e2e-sts-with-ingress, created 1m ago by StatefulSet/sts-with-ingress, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-ingress application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  Services: Service/sts-with-ingress -n default, created 1m ago, ClusterIP, 1 ready, 80/TCP
+  Services: Service/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, ClusterIP, 1 ready, 80/TCP
 \z

--- a/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
@@ -1,3 +1,3 @@
 Ingresses matching this Service:
-    Ingress/sts-with-ingress -n default, created 1m ago, gen:1
+    Ingress/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, gen:1
       Current: Resource is current

--- a/tests/e2e-artifacts/sts-with-ingress.service.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service.regex
@@ -1,2 +1,2 @@
 Ingresses matching this Service:
-    Ingress/sts-with-ingress -n default, created 1m ago, sts-with-ingress\.com, [^\n]*Current
+    Ingress/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, sts-with-ingress\.com, [^\n]*Current

--- a/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
@@ -1,10 +1,10 @@
 \A
-PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, gen:1
+PodDisruptionBudget/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, gen:1
   Current: AllowedDisruptions has been computed.
   Budget: min available=1, Constrained
   Selector: app=sts-with-nodeport
-    Service/sts-with-nodeport -n default, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
-    Pod/sts-with-nodeport-0 -n default, created 1m ago Running, 1/1 ready
+    Service/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
+    Pod/sts-with-nodeport-0 -n e2e-sts-nodeport, created 1m ago Running, 1/1 ready
   healthy:1/expected:1, disruptions allowed:0
     no disruptions allowed — all pods must stay healthy to meet the budget
   DisruptionAllowed InsufficientPods for 1m

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -1,11 +1,11 @@
 \A
-Pod/sts-with-nodeport-0 -n default, created 1m ago by StatefulSet/sts-with-nodeport, gen:1, started after 1m Running BestEffort
+Pod/sts-with-nodeport-0 -n e2e-sts-nodeport, created 1m ago by StatefulSet/sts-with-nodeport, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-nodeport application
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
-  Services: Service/sts-with-nodeport -n default, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
-  PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, min available=1, evictions/drains currently blocked
+  Services: Service/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
+  PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, min available=1, evictions/drains currently blocked
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.sts.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.sts.regex
@@ -1,4 +1,4 @@
   Selector: app=sts-with-nodeport
-    Pod/sts-with-nodeport-0 -n default, created 1m ago Running, 1/1 ready
-  Services: Service/sts-with-nodeport -n default, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
-  PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n default, created 1m ago, min available=1, evictions/drains currently blocked
+    Pod/sts-with-nodeport-0 -n e2e-sts-nodeport, created 1m ago Running, 1/1 ready
+  Services: Service/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
+  PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, min available=1, evictions/drains currently blocked

--- a/tests/e2e-artifacts/sts-without-service.regex
+++ b/tests/e2e-artifacts/sts-without-service.regex
@@ -1,8 +1,8 @@
 \A
-StatefulSet/sts-without-service -n default, created 1m ago, gen:1
+StatefulSet/sts-without-service -n e2e-sts-without-service, created 1m ago, gen:1
   Current: Partition rollout complete\. updated: 1
   Selector: app=sts-without-service
-    Pod/sts-without-service-0 -n default, created 1m ago Running, 1/1 ready
+    Pod/sts-without-service-0 -n e2e-sts-without-service, created 1m ago Running, 1/1 ready
   Not matched by any Service
   desired:1, existing:1, ready:1, current:1, updated:1, available:1
 \z

--- a/tests/e2e-artifacts/svc-with-httproute.deep.regex
+++ b/tests/e2e-artifacts/svc-with-httproute.deep.regex
@@ -1,9 +1,9 @@
 \A
-Service/svc-with-httproute -n default, created 1m ago
+Service/svc-with-httproute -n e2e-svc-httproute, created 1m ago
   Current: Service is ready
   Missing Endpoint: Service has no matching endpoint.
   Routes matching this Service:
-    HTTPRoute/svc-with-httproute -n default, created 1m ago, gen:1
+    HTTPRoute/svc-with-httproute -n e2e-svc-httproute, created 1m ago, gen:1
       Current: Resource is current
       Hostnames: svc-with-httproute\.example\.com
       Parents:

--- a/tests/e2e-artifacts/svc-with-httproute.deep.regex
+++ b/tests/e2e-artifacts/svc-with-httproute.deep.regex
@@ -9,5 +9,5 @@ Service/svc-with-httproute -n e2e-svc-httproute, created 1m ago
       Parents:
       Rules:
         PathPrefix /
-        Service/svc-with-httproute\[default\] is already printed
+        Service/svc-with-httproute\[e2e-svc-httproute\] is already printed
 \z

--- a/tests/e2e-artifacts/svc-with-httproute.regex
+++ b/tests/e2e-artifacts/svc-with-httproute.regex
@@ -1,7 +1,7 @@
 \A
-Service/svc-with-httproute -n default, created 1m ago
+Service/svc-with-httproute -n e2e-svc-httproute, created 1m ago
   Current: Service is ready
   Missing Endpoint: Service has no matching endpoint.
   Routes matching this Service:
-    HTTPRoute/svc-with-httproute -n default, created 1m ago, svc-with-httproute\.example\.com, Current
+    HTTPRoute/svc-with-httproute -n e2e-svc-httproute, created 1m ago, svc-with-httproute\.example\.com, Current
 \z

--- a/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
@@ -1,8 +1,8 @@
 \A
-TCPRoute/e2e-tcproute -n default, created 1m ago, gen:1
+TCPRoute/e2e-tcproute -n e2e-tcproute, created 1m ago, gen:1
   Current: Resource is current
   Parents:
-    Gateway/e2e-tcp-gw -n default, created 1m ago, gen:1
+    Gateway/e2e-tcp-gw -n e2e-tcproute, created 1m ago, gen:1
       Current: Resource is current
       Accepted Pending, Waiting for controller for 1m
       Programmed Pending, Waiting for controller for 1m

--- a/tests/e2e-artifacts/tcproute-with-gateway.regex
+++ b/tests/e2e-artifacts/tcproute-with-gateway.regex
@@ -1,5 +1,5 @@
 \A
-TCPRoute/e2e-tcproute -n default, created 1m ago, gen:1
+TCPRoute/e2e-tcproute -n e2e-tcproute, created 1m ago, gen:1
   Current: Resource is current
   Parents:
     Gateway/e2e-tcp-gw \[tcp\]

--- a/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
@@ -1,1 +1,1 @@
-HTTPRoute/e2e-tls-httproute-healthy -n default, created .* ago, gen:1
+HTTPRoute/e2e-tls-httproute-healthy -n e2e-tls-validation, created .* ago, gen:1

--- a/tests/e2e-artifacts/tls-validation-ingress-deep.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-deep.regex
@@ -1,3 +1,3 @@
-Ingress/e2e-tls-ingress-healthy -n default, created .* ago, gen:1.*
-    Secret/e2e-tls-leaf-tls -n default, created .* ago.*
+Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created .* ago, gen:1.*
+    Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created .* ago.*
       Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca

--- a/tests/e2e-artifacts/tls-validation-ingress-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-healthy.regex
@@ -1,1 +1,1 @@
-Ingress/e2e-tls-ingress-healthy -n default, created .* ago, gen:1
+Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created .* ago, gen:1

--- a/tests/e2e-artifacts/tls-validation-secret-leaf-deep.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-leaf-deep.regex
@@ -1,9 +1,9 @@
-Secret/e2e-tls-leaf-tls -n default, created .* ago
+Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created .* ago
   Managed by
-    Certificate/e2e-tls-leaf -n default, created .* ago, gen:1
+    Certificate/e2e-tls-leaf -n e2e-tls-validation, created .* ago, gen:1
       Current: Resource is Ready
       Issued by Issuer/e2e-tls-ca-issuer for "e2e-tls\.example\.com" · stored in secret/e2e-tls-leaf-tls.*
-    Issuer/e2e-tls-ca-issuer -n default, created .* ago, gen:1
+    Issuer/e2e-tls-ca-issuer -n e2e-tls-validation, created .* ago, gen:1
       Current: Resource is Ready
       Backend: CA · signing key in secret/e2e-tls-root-ca-secret.*
   Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca

--- a/tests/e2e-artifacts/tls-validation-secret-leaf.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-leaf.regex
@@ -1,5 +1,5 @@
 Secret/e2e-tls-leaf-tls.*
-  Managed by Certificate/e2e-tls-leaf -n default via Issuer/e2e-tls-ca-issuer -n default \(cert-manager\.io\)
+  Managed by Certificate/e2e-tls-leaf -n e2e-tls-validation via Issuer/e2e-tls-ca-issuer -n e2e-tls-validation \(cert-manager\.io\)
   Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca
     Also valid for: e2e-tls-alt\.example\.com
     Valid [^,]+, expires \d{4}-\d{2}-\d{2}

--- a/tests/e2e-artifacts/tls-validation-secret-root.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-root.regex
@@ -1,4 +1,4 @@
 Secret/e2e-tls-root-ca-secret.*
-  Managed by Certificate/e2e-tls-root-ca -n default via Issuer/e2e-tls-root-issuer -n default \(cert-manager\.io\)
+  Managed by Certificate/e2e-tls-root-ca -n e2e-tls-validation via Issuer/e2e-tls-root-issuer -n e2e-tls-validation \(cert-manager\.io\)
   Certificate for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
     Self-signed: issuer and subject match, not issued by a separate CA

--- a/tests/e2e-artifacts/udproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/udproute-with-gateway.deep.regex
@@ -1,8 +1,8 @@
 \A
-UDPRoute/e2e-udproute -n default, created 1m ago, gen:1
+UDPRoute/e2e-udproute -n e2e-udproute, created 1m ago, gen:1
   Current: Resource is current
   Parents:
-    Gateway/e2e-udp-gw -n default, created 1m ago, gen:1
+    Gateway/e2e-udp-gw -n e2e-udproute, created 1m ago, gen:1
       Current: Resource is current
       Accepted Pending, Waiting for controller for 1m
       Programmed Pending, Waiting for controller for 1m

--- a/tests/e2e-artifacts/udproute-with-gateway.regex
+++ b/tests/e2e-artifacts/udproute-with-gateway.regex
@@ -1,5 +1,5 @@
 \A
-UDPRoute/e2e-udproute -n default, created 1m ago, gen:1
+UDPRoute/e2e-udproute -n e2e-udproute, created 1m ago, gen:1
   Current: Resource is current
   Parents:
     Gateway/e2e-udp-gw \[udp\]

--- a/tests/e2e-artifacts/vap-binding.yaml
+++ b/tests/e2e-artifacts/vap-binding.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   failurePolicy: Fail
   matchConstraints:
+    # Scoped to this subtest's own namespace via the built-in kubernetes.io/metadata.name label
+    # (every Namespace object carries it automatically) -- without this, denying Deployments
+    # without a "team" label applies cluster-wide, breaking any other subtest that creates a
+    # Deployment concurrently.
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: e2e-vap-binding
     resourceRules:
       - apiGroups: ["apps"]
         apiVersions: ["v1"]

--- a/tests/e2e-artifacts/web-cert.deep.regex
+++ b/tests/e2e-artifacts/web-cert.deep.regex
@@ -1,12 +1,12 @@
 \A
-Secret/web-tls -n default, created 1m ago
+Secret/web-tls -n e2e-web-cert, created 1m ago
   Managed by
-    Certificate/web-tls -n default, created 1m ago, gen:1
+    Certificate/web-tls -n e2e-web-cert, created 1m ago, gen:1
       Current: Resource is Ready
       Issued by Issuer/web-ca-issuer for "web\.ks-demo\.svc" · stored in secret/web-tls
       Issued \d{4}-\d{2}-\d{2} \(1m ago\), expires \d{4}-\d{2}-\d{2}, auto-renews \d{4}-\d{2}-\d{2}(?: · rev [0-9]+)?
       Ready Ready, Certificate is up to date and has not expired for 1m
-    Issuer/web-ca-issuer -n default, created 1m ago, gen:1
+    Issuer/web-ca-issuer -n e2e-web-cert, created 1m ago, gen:1
       Current: Resource is Ready
       Backend: CA · signing key in secret/web-ca-secret
       Ready KeyPairVerified, Signing CA verified for 1m

--- a/tests/e2e-artifacts/web-cert.regex
+++ b/tests/e2e-artifacts/web-cert.regex
@@ -1,6 +1,6 @@
 \A
-Secret/web-tls -n default, created 1m ago
-  Managed by Certificate/web-tls -n default via Issuer/web-ca-issuer -n default \(cert-manager\.io\)
+Secret/web-tls -n e2e-web-cert, created 1m ago
+  Managed by Certificate/web-tls -n e2e-web-cert via Issuer/web-ca-issuer -n e2e-web-cert \(cert-manager\.io\)
   Certificate for CN=web\.ks-demo\.svc · issued by CN=kubectl-status-demo-ca
     Valid 1m ago, expires \d{4}-\d{2}-\d{2}
     Key: RSA · serial [0-9]+

--- a/tests/e2e-artifacts/web-policies.regex
+++ b/tests/e2e-artifacts/web-policies.regex
@@ -1,13 +1,13 @@
 \A
-Deployment/web -n default, created 1m ago, gen:1 rev:1
+Deployment/web -n e2e-web-policies, created 1m ago, gen:1 rev:1
   Current: Deployment is available\. Replicas: 3
   desired:3, existing:3, ready:3, updated:3, available:3
   Selector: app=web
-    Pod/web-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready, netpol: ingress restricted
-    Pod/web-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready, netpol: ingress restricted
-    Pod/web-[a-z0-9]+-[a-z0-9]+ -n default, created 1m ago Running, 1/1 ready, netpol: ingress restricted
+    Pod/web-[a-z0-9]+-[a-z0-9]+ -n e2e-web-policies, created 1m ago Running, 1/1 ready, netpol: ingress restricted
+    Pod/web-[a-z0-9]+-[a-z0-9]+ -n e2e-web-policies, created 1m ago Running, 1/1 ready, netpol: ingress restricted
+    Pod/web-[a-z0-9]+-[a-z0-9]+ -n e2e-web-policies, created 1m ago Running, 1/1 ready, netpol: ingress restricted
   Not matched by any Service
-  PodDisruptionBudgets: PodDisruptionBudget/web -n default, created 1m ago, min available=1, disruptions allowed
+  PodDisruptionBudgets: PodDisruptionBudget/web -n e2e-web-policies, created 1m ago, min available=1, disruptions allowed
   NetworkPolicy: selected by NetworkPolicy web \(ingress restricted\)
   Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
   Progressing NewReplicaSetAvailable, ReplicaSet "web-[a-z0-9]+" has successfully progressed\. for 1m(?:, last update was 1m ago)?


### PR DESCRIPTION
## Summary
- Part of #695: audits identified ~subtests still creating resources directly in the shared `default` namespace. Gives each its own dedicated namespace (or a shared one where subtests intentionally build on each other's resources), removing that cross-test hazard as a prerequisite for eventually moving them into the parallel-safe test function (#696).
- Adds `applyManifestInNamespace`/`waitForInNamespace`/`waitForContainerWaitingReasonInNamespace` helpers alongside the existing non-namespaced ones, and drops the wrapper helpers that ended up with zero remaining callers once every subtest migrated.
- Scopes the `vap-binding-resolves-policy` ValidatingAdmissionPolicy to its own namespace via `matchConstraints.namespaceSelector` — previously it denied Deployment creates cluster-wide.

## Follow-ups filed
- #701 — two more process-global sinks (`cmdutil.BehaviorOnFatal`, `slog.SetDefault`) block real `t.Parallel()` use regardless of namespace isolation; also covers a cluster-scoped-name re-audit.
- Commented on #696 with the two subtests namespace fixes alone can't make parallel-safe (global APIService deletion, and an assumption about being the only real Node in the cluster).

## Test plan
- [x] `go build ./...` / `go vet ./...` / staticcheck clean on every commit
- [x] Pre-commit hooks (`make test`) passed on every commit
- [ ] `make test-e2e` against a live cluster (not run in this environment — no minikube access here; needs a real run before merge)