### PR TITLE
e2e: de-globalize BehaviorOnFatal and slog default handler sinks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,6 +152,9 @@ func checkErr(err error) error {
 		out = errors.New(msg)
 	})
 	cmdutil.CheckErr(err)
+	if out == nil {
+		return err
+	}
 	return out
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,13 +137,16 @@ var fatalMu sync.Mutex
 
 // checkErr runs err through cmdutil.CheckErr's formatting (installing a scoped BehaviorOnFatal
 // handler instead of letting CheckErr's default os.Exit tear down the process) and returns the
-// formatted error instead of exiting, so RunE can propagate it normally.
+// formatted error instead of exiting, so RunE can propagate it normally. The handler is restored
+// to the default before returning, so it doesn't leak into unrelated later calls.
 func checkErr(err error) error {
 	if err == nil {
 		return nil
 	}
 	fatalMu.Lock()
 	defer fatalMu.Unlock()
+	// restore under lock, before Unlock, so a waiting caller's handler isn't clobbered
+	defer cmdutil.DefaultBehaviorOnFatal()
 	var out error
 	cmdutil.BehaviorOnFatal(func(msg string, _ int) {
 		out = errors.New(msg)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/spf13/cobra"
@@ -108,21 +109,47 @@ func RootCmd(cfgOpts ...func(*plugin.RenderConfig)) *cobra.Command {
 	cmd.ValidArgsFunction = completion.ResourceTypeAndNameCompletionFunc(f)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		klog.V(5).InfoS("running the cobra.Command ...")
-		var err error
-		cmdutil.BehaviorOnFatal(func(msg string, i int) {
-			err = errors.New(msg)
-		})
-		cmdutil.CheckErr(complete(f, v))
-		cmdutil.CheckErr(validate(v))
+		if err := checkErr(complete(f, v)); err != nil {
+			return err
+		}
+		if err := checkErr(validate(v)); err != nil {
+			return err
+		}
 		if b, _ := cmd.Flags().GetBool("test-hack"); b {
 			v.Set("test-hack", true)
 			cfg.DurationRound = func(_ interface{}) string { return "1m" }
 		}
 		ioStreams := genericiooptions.IOStreams{In: cmd.InOrStdin(), Out: cmd.OutOrStdout(), ErrOut: cmd.ErrOrStderr()}
-		cmdutil.CheckErr(plugin.Run(f, ioStreams, args, cfg))
-		return err
+		return checkErr(plugin.Run(f, ioStreams, args, cfg))
 	}
 	return cmd
+}
+
+// fatalMu serializes installing and consuming cmdutil's process-global fatal handler
+// (BehaviorOnFatal + CheckErr). We keep routing errors through CheckErr for its user-friendly
+// formatting (e.g. NoResourceMatchError phrasing, the "error: " prefix some e2e assertions pin
+// on) rather than returning them raw. The lock is only held around the install-and-consume step in
+// checkErr, not around whatever produced err, so it doesn't serialize concurrent RootCmd().Execute()
+// calls' actual work (e.g. plugin.Run) -- only this narrow reformatting step, which is what made
+// BehaviorOnFatal a process-global race in the first place: two concurrent invocations installing
+// their own closure could catch each other's fatal error instead of their own.
+var fatalMu sync.Mutex
+
+// checkErr runs err through cmdutil.CheckErr's formatting (installing a scoped BehaviorOnFatal
+// handler instead of letting CheckErr's default os.Exit tear down the process) and returns the
+// formatted error instead of exiting, so RunE can propagate it normally.
+func checkErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	fatalMu.Lock()
+	defer fatalMu.Unlock()
+	var out error
+	cmdutil.BehaviorOnFatal(func(msg string, _ int) {
+		out = errors.New(msg)
+	})
+	cmdutil.CheckErr(err)
+	return out
 }
 
 func initFlags(cmd *cobra.Command) *genericclioptions.ConfigFlags {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -449,11 +449,13 @@ func e2eMinikubeTest(t *testing.T) {
 // viper singleton or package-level Now/DurationRound/StartedAfterClause overrides -- each RootCmd()
 // call owns its own *viper.Viper and plugin.RenderConfig (see #694), and testHackOpts/
 // viperTestHackOpts just build option values rather than mutating shared state, so calling them
-// from concurrent subtests is safe. Two process-global sinks remain on the render path and still
-// need addressing before a subtest touching them is parallel-safe: cmdutil.BehaviorOnFatal in
-// RootCmd's RunE (installs a global fatal handler capturing that invocation's err) and
-// slog.SetDefault in newRenderEngine's setupDeprecationFilter (rebinds the global slog default per
-// render). A subtest qualifies for t.Parallel() once it:
+// from concurrent subtests is safe. The two remaining process-global sinks on the render path --
+// cmdutil.BehaviorOnFatal in RootCmd's RunE and slog.SetDefault in newRenderEngine's
+// setupDeprecationFilter -- are also now safe under concurrent RootCmd().Execute() calls: the
+// former is guarded by cmd/main.go's fatalMu, held only around installing/consuming the handler
+// rather than around the render itself; the latter installs its filtering handler once per
+// process (sync.Once) instead of rebinding it on every render (see #701). A subtest qualifies for
+// t.Parallel() once it:
 //   - needs no namespace, or creates/uses a namespace dedicated to that subtest (never `default`,
 //     and never a namespace another subtest might also touch)
 //   - never relies on a fixed cluster-scoped resource name (Node, CustomResourceDefinition,

--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -3,10 +3,10 @@ package plugin
 import (
 	"context"
 	"embed"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"text/template"
 
 	"github.com/go-sprout/sprout/sprigin"
@@ -17,8 +17,10 @@ import (
 //go:embed templates
 var templatesFS embed.FS
 
-// setupDeprecationFilter configures the default slog handler to drop go-sprout's
-// per-call deprecation-signature warnings, writing anything else to w.
+var deprecationFilterOnce sync.Once
+
+// setupDeprecationFilter installs, once for the life of the process, a slog handler that drops
+// go-sprout's per-call deprecation-signature warnings and forwards anything else to os.Stderr.
 //
 // go-sprout (our sprig replacement) logs a WARN via slog on every call to a
 // function whose signature changed during the sprig->sprout migration (e.g.
@@ -28,13 +30,24 @@ var templatesFS embed.FS
 // https://github.com/bergerx/kubectl-status/issues/688 for migrating the
 // templates to the new signatures, at which point this filter can go away.
 //
+// This used to reinstall a fresh handler (writing to that invocation's streams.ErrOut) on every
+// newRenderEngine call. sprigin reads slog.Default() again on every single template function
+// call, not just once when the funcMap is built, so two renders in flight at once (e.g. parallel
+// e2e subtests) would race rebinding the global default and could route one render's output
+// through another's ErrOut. The only thing this handler is known to ever emit is the
+// deprecation-tagged warnings it drops (see #688), so installing it once and forwarding the
+// (currently unreachable) non-deprecated case to os.Stderr rather than a per-render writer is
+// behaviorally identical to before, without serializing renders against each other.
+//
 // The handler is built fresh (not by wrapping the pre-existing
 // slog.Default().Handler()): the zero-value default handler bridges back
 // into the standard "log" package's global, mutex-protected logger, and
 // re-installing a wrapper around it as the new default causes that bridge
 // to call back into itself, deadlocking on the mutex.
-func setupDeprecationFilter(w io.Writer) {
-	slog.SetDefault(slog.New(deprecationNoticeFilter{Handler: slog.NewTextHandler(w, nil)}))
+func setupDeprecationFilter() {
+	deprecationFilterOnce.Do(func() {
+		slog.SetDefault(slog.New(deprecationNoticeFilter{Handler: slog.NewTextHandler(os.Stderr, nil)}))
+	})
 }
 
 // deprecationNoticeFilter drops log records tagged with a "notice"="deprecated"
@@ -102,7 +115,7 @@ type renderEngine struct {
 
 func newRenderEngine(streams genericiooptions.IOStreams, cfg *RenderConfig) (*renderEngine, error) {
 	klog.V(5).InfoS("Creating new render engine instance...")
-	setupDeprecationFilter(streams.ErrOut)
+	setupDeprecationFilter()
 	tmpl, err := getTemplate(cfg)
 	if err != nil {
 		klog.V(3).ErrorS(err, "Error parsing templates")


### PR DESCRIPTION
## Summary
- `cmdutil.BehaviorOnFatal` was reinstalled by every `RootCmd().Execute()` call, overwriting a shared closure — concurrent invocations could capture each other's error. Replaced with a `checkErr()` helper that still uses `cmdutil.CheckErr` for its message formatting, but scopes the lock (`fatalMu`) tightly around install-and-consume rather than around the render itself, so it doesn't re-serialize `plugin.Run` for parallel subtests.
- `setupDeprecationFilter` rebound the global slog default handler on every render; go-sprout's sprigin reads `slog.Default()` fresh on every template function call, so concurrent renders would race that rebind. Installed once per process (`sync.Once`) instead — every record this handler is known to emit carries the deprecated-notice tag it drops, so this is behaviorally identical to before.
- Neither sink can be literally "threaded through the call path" — both are process-global by design in the vendored libraries that own them (kubectl's `cmdutil`, go-sprout's `sprigin`), so this scopes/serializes access narrowly instead of eliminating the global.
- Re-audited for other shared cluster-scoped resource names beyond `createBadNode` and `vap-binding.yaml` (both already handled) — no other e2e subtest hardcodes a cluster-scoped name another subtest could collide with.

Fixes #701.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`
- [x] `go test ./...` (457 tests, non-e2e suite) — includes `TestRootCmdWithoutACluster`, which exercises the exact `checkErr` "error: ..." formatting path
- [ ] e2e suite against a live minikube cluster (not run in this environment) — routes through the identical `checkErr` code path, so expected to behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)