### PR TITLE
Fix make update-artifacts drifting from what tests expect

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -117,7 +117,7 @@ func RootCmd(cfgOpts ...func(*plugin.RenderConfig)) *cobra.Command {
 		}
 		if b, _ := cmd.Flags().GetBool("test-hack"); b {
 			v.Set("test-hack", true)
-			cfg.DurationRound = func(_ interface{}) string { return "1m" }
+			plugin.ApplyTestHack(cfg)
 		}
 		ioStreams := genericiooptions.IOStreams{In: cmd.InOrStdin(), Out: cmd.OutOrStdout(), ErrOut: cmd.ErrOrStderr()}
 		return checkErr(plugin.Run(f, ioStreams, args, cfg))

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -281,27 +281,12 @@ func TestE2EAgainstVanillaMinikube(t *testing.T) {
 }
 
 // testHackOpts fixes plugin.RenderConfig's Now/DurationRound/StartedAfterClause for
-// deterministic e2e output. Each RootCmd() invocation gets its own fresh RenderConfig (see
-// cmd/main.go), so unlike the old global package-var overrides this needs no revert -- see #694.
+// deterministic e2e output (see plugin.ApplyTestHack). Each RootCmd() invocation gets its own
+// fresh RenderConfig (see cmd/main.go), so unlike the old global package-var overrides this needs
+// no revert -- see #694.
 func testHackOpts(t *testing.T) []func(*plugin.RenderConfig) {
 	t.Helper()
-	fixedNow := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
-	return []func(*plugin.RenderConfig){
-		func(cfg *plugin.RenderConfig) {
-			cfg.DurationRound = func(_ interface{}) string { return "1m" }
-		},
-		func(cfg *plugin.RenderConfig) {
-			cfg.Now = func() time.Time { return fixedNow }
-		},
-		// Whether a live pod's creation and kubelet-acknowledge timestamps land in the same
-		// wall-clock second (hiding the "started after" clause) or not (showing it) is a coin
-		// flip e2e tests can't control -- both timestamps only carry 1-second resolution over
-		// the wire. Force the clause present whenever Status.startTime is set, so fixtures can
-		// pin it literally instead of making it optional.
-		func(cfg *plugin.RenderConfig) {
-			cfg.StartedAfterClause = func(_, _ string) string { return ", started after 1m" }
-		},
-	}
+	return []func(*plugin.RenderConfig){plugin.ApplyTestHack}
 }
 
 // viperTestHackOpts sets "test-hack" on this invocation's RenderConfig, which makes ip() report a

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -60,6 +60,25 @@ func DefaultDurationRound() func(duration interface{}) string {
 	return sprouttime.NewRegistry().DurationRound
 }
 
+// TestHackNow is the fixed timestamp ApplyTestHack pins RenderConfig.Now to, so relative-duration
+// output (e.g. "Ready: 15h") is deterministic instead of drifting with wall-clock time. Test
+// fixtures under tests/artifacts/ are dated relative to this.
+var TestHackNow = time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+
+// ApplyTestHack overrides cfg's time-sensitive hooks for deterministic output: a fixed Now, a
+// fixed "1m" DurationRound, and a fixed "started after" clause. Real creation and kubelet-ack
+// timestamps only carry 1-second resolution over the wire, so whether the "started after" clause
+// appears is otherwise a coin flip; this forces it present whenever Status.startTime is set.
+//
+// Both the "--test-hack" CLI flag (cmd/main.go, used by `make update-artifacts`/`make
+// new-artifact`) and the e2e test suite (cmd/main_test.go) call this, so the artifacts generated
+// on disk and the output the tests compare against can never drift apart.
+func ApplyTestHack(cfg *RenderConfig) {
+	cfg.Now = func() time.Time { return TestHackNow }
+	cfg.DurationRound = func(_ interface{}) string { return "1m" }
+	cfg.StartedAfterClause = func(_, _ string) string { return ", started after 1m" }
+}
+
 func (cfg *RenderConfig) funcMap() template.FuncMap {
 	return template.FuncMap{
 		"green":                     color.GreenString,


### PR DESCRIPTION
## Summary
- `make update-artifacts` runs the CLI's `--test-hack` flag, which only pinned `DurationRound` — the test suite additionally pins `RenderConfig.Now` and `StartedAfterClause` via closures injected directly in `cmd/main_test.go`, bypassing the CLI flag. As real time moved on from the last regen, the two paths diverged and `make update-artifacts` produced `.out` files that failed the tests it was meant to satisfy.
- Extracted `plugin.ApplyTestHack` as the single source of truth for all three hooks (fixed `Now`, `DurationRound`, `StartedAfterClause`); both the CLI flag and the test suite now call it, so they can't drift apart again.

## Test plan
- [x] Reproduced the bug on the old code: `make update-artifacts` rewrote 27 `.out` files, then `go test ./cmd/...` failed against them
- [x] Applied the fix, reran `make update-artifacts`: zero diffs in `tests/artifacts/*.out`
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)