### PR TITLE
Service.tmpl: show LoadBalancer IP mode and dual-stack status

### DIFF
--- a/pkg/plugin/templates/Ingress.tmpl
+++ b/pkg/plugin/templates/Ingress.tmpl
@@ -90,10 +90,21 @@
 {{- define "load_balancer_ingress" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- with .Status.loadBalancer.ingress }}
-        {{- if or (index . 0).hostname (index . 0).ip }}
-            {{- with (index . 0).hostname }} {{ "LoadBalancer" | green }}:{{ . }}{{ end }}
-            {{- with (index . 0).ip }} {{ "LoadBalancer" | green }}:{{ . }}{{ end }}
-        {{- else }} {{ "Pending LoadBalancer" | red | bold }}
+        {{- $hasAddress := false }}
+        {{- range . }}{{- if or .hostname .ip }}{{- $hasAddress = true }}{{- end }}{{- end }}
+        {{- if not $hasAddress }} {{ "Pending LoadBalancer" | red | bold }}
+        {{- else }}
+            {{- $printed := 0 }}
+            {{- range . }}
+                {{- $entry := . }}
+                {{- range list $entry.hostname $entry.ip }}
+                    {{- with . }}
+                        {{- if $printed }}, {{ else }} {{ end }}{{ "LoadBalancer" | green }}:{{ . }}
+                        {{- with $entry.ipMode }} (ipMode:{{ . | cyan }}){{ end }}
+                        {{- $printed = add $printed 1 }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end -}}

--- a/pkg/plugin/templates/Service.tmpl
+++ b/pkg/plugin/templates/Service.tmpl
@@ -75,6 +75,10 @@
     {{- $itp := .Spec.internalTrafficPolicy | default "Cluster" }}
     {{- $showEtp := ne $etp "Cluster" }}
     {{- $showItp := ne $itp "Cluster" }}
+    {{- $ifp := .Spec.ipFamilyPolicy | default "SingleStack" }}
+    {{- if ne $ifp "SingleStack" }}
+        {{- "IP families" | bold | nindent 2 }}: {{ join ", " .Spec.ipFamilies | cyan }} ({{ $ifp | cyan }})
+    {{- end }}
     {{- if or $showEtp $showItp }}
         {{- "Traffic policy" | bold | nindent 2 }}:
         {{- if $showEtp }} external={{ $etp | cyan }}{{ with .Spec.healthCheckNodePort }} (healthCheckNodePort:{{ . | toString | cyan }}){{ end }}{{ end }}

--- a/tests/artifacts/service-loadbalancer-dualstack.out
+++ b/tests/artifacts/service-loadbalancer-dualstack.out
@@ -1,0 +1,5 @@
+
+Service/svc-dualstack-lb -n kubectl-status-svc-test, created 1m ago LoadBalancer:203.0.113.50 (ipMode:VIP), LoadBalancer:2001:db8::50 (ipMode:VIP)
+  Current: Service is ready
+  IP families: IPv4, IPv6 (PreferDualStack)
+  Missing Endpoint: Service has no matching endpoint.

--- a/tests/artifacts/service-loadbalancer-dualstack.yaml
+++ b/tests/artifacts/service-loadbalancer-dualstack.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2026-07-06T15:21:33Z"
+  name: svc-dualstack-lb
+  namespace: kubectl-status-svc-test
+  resourceVersion: "133728"
+  uid: 3a2f9c1e-5a4b-4e2a-9c1e-5a4b4e2a9c1e
+spec:
+  allocateLoadBalancerNodePorts: true
+  clusterIP: 10.96.200.10
+  clusterIPs:
+  - 10.96.200.10
+  - fd00::200:10
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: svc-dualstack-lb
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 203.0.113.50
+      ipMode: VIP
+    - ip: 2001:db8::50
+      ipMode: VIP


### PR DESCRIPTION
## Summary
- `load_balancer_ingress` (shared by `Service.tmpl`/`Ingress.tmpl`) now ranges over all `status.loadBalancer.ingress` entries instead of just index 0, so dual-stack LoadBalancer Services show both address families, and displays each entry's `ipMode` (beta since 1.29).
- `service_traffic_config` in `Service.tmpl` adds an `IP families: IPv4, IPv6 (PreferDualStack)` line, gated on `ipFamilyPolicy != SingleStack` so single-stack services (the common case) render unchanged.
- New static fixture `tests/artifacts/service-loadbalancer-dualstack.{yaml,out}` covering a dual-stack LoadBalancer Service with two provisioned ingress IPs and `ipMode`.

Fixes #680

## Test plan
- [x] `make test` (`go test ./...`, 458 tests) passes
- [x] `make update-artifacts` produces zero diffs on existing fixtures (confirms the dual-stack gate doesn't affect single-stack services)
- [x] Manually verified both-hostname-and-ip ingress entries still render both addresses (preserves prior behavior)
- [ ] CI e2e suite (local pre-push e2e run hit unrelated resource-contention flakiness on this machine — different unrelated tests failed on two consecutive local retries; none touch Service/Ingress LoadBalancer rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)