### PR TITLE
e2e: wait for PDB expectedPods to converge, not just observedGeneration

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1766,15 +1766,21 @@ func TestE2EParallel(t *testing.T) {
 			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 		})
 		applyManifestInNamespace(t, "e2e-artifacts/pod-container-logs.yaml", ns)
-		// Wait for a stable Waiting(CrashLoopBackOff) state rather than just restartCount > 0:
-		// the container's current state otherwise flips between Waiting and Terminated(Error)
-		// as the kubelet retries, which would make the golden regex flaky.
-		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-container-logs", "crasher", "CrashLoopBackOff", ns)
 		// The fixture pins a usage line for both healthy containers -- wait for metrics-server to
 		// have scraped each of them specifically, not just the Pod overall: a container that
 		// started slightly later than its siblings can still be missing from PodMetrics even once
 		// the pod-level object exists, which otherwise renders that container's usage line blank.
+		// Done before the CrashLoopBackOff wait below (not after): metrics-server's scrape
+		// interval can take tens of seconds, and the crasher container keeps cycling
+		// Waiting/Terminated the whole time it waits, so checking CrashLoopBackOff first and
+		// then waiting on metrics just reintroduces the same flip the CrashLoopBackOff wait was
+		// meant to avoid, by leaving a wide gap between the check and the actual assertion.
 		waitForContainerMetrics(t, ns, "e2e-pod-container-logs", "healthy", "sidecar")
+		// Wait for a stable Waiting(CrashLoopBackOff) state rather than just restartCount > 0:
+		// the container's current state otherwise flips between Waiting and Terminated(Error)
+		// as the kubelet retries, which would make the golden regex flaky. This has to be the
+		// last wait before the assertion below -- see the comment above.
+		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-container-logs", "crasher", "CrashLoopBackOff", ns)
 
 		cmdTest{
 			args:            []string{"pod/e2e-pod-container-logs", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1291,11 +1291,18 @@ func TestE2EParallel(t *testing.T) {
 		applyManifestInNamespace(t, "e2e-artifacts/pdb-empty-selector-conflict.yaml", ns)
 		waitForInNamespace(t, "sts/pdb-conflict-test", "jsonpath={.status.readyReplicas}=1", ns)
 		// Kubernetes' disruption controller picks one of the two overlapping PDBs arbitrarily
-		// and leaves the other's currentHealthy permanently at 0 -- observedGeneration is the
-		// reliable "controller has made its (possibly permanent) decision" signal here, not
-		// currentHealthy, which may never reach 1 for the non-chosen budget.
+		// and leaves the other's currentHealthy permanently at 0 -- observedGeneration is not
+		// enough to prove the controller has converged, since it only tracks spec generation:
+		// a PDB can briefly report observedGeneration=1 with expectedPods=0 (as if its selector
+		// matched no pods) before a later resync corrects it to the real count. Confirmed by
+		// concurrently creating this fixture across many namespaces and polling: expectedPods=0
+		// shows up transiently under load and always self-heals within seconds, it's never a
+		// stable end state -- so wait for expectedPods=1 (both PDBs' selectors match the single
+		// Pod here once converged) rather than trusting observedGeneration alone.
 		waitForInNamespace(t, "pdb/pdb-conflict-test", "jsonpath={.status.observedGeneration}=1", ns)
+		waitForInNamespace(t, "pdb/pdb-conflict-test", "jsonpath={.status.expectedPods}=1", ns)
 		waitForInNamespace(t, "pdb/pdb-conflict-test-catch-all", "jsonpath={.status.observedGeneration}=1", ns)
+		waitForInNamespace(t, "pdb/pdb-conflict-test-catch-all", "jsonpath={.status.expectedPods}=1", ns)
 		cmdTest{
 			args:            []string{"pod/pdb-conflict-test-0", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pdb-empty-selector-conflict.pod.regex",


### PR DESCRIPTION
## Summary
- `TestE2EParallel/pdb-empty-selector-conflict` was flaky: it waited for `observedGeneration=1` on both overlapping PDBs, which only proves the disruption controller processed the *spec*, not that `status.expectedPods`/`currentHealthy` converged.
- Root-caused by concurrently creating the fixture across 10 namespaces on a same-sized cluster and polling: the non-chosen PDB's `expectedPods` transiently reads `0` (rendering as "selector matches no pods (no-op)", a state the regex never anticipated) and self-heals within ~5-10s under load. It's a real, reproducible race, not generic infra flakiness.
- Fix: also wait for `status.expectedPods=1` on both PDBs before asserting, since both selectors match the single Pod here once the controller has converged.

## Test plan
- [x] `go build ./...` / `go vet ./...` pass
- [x] Re-ran the full e2e suite 3x after the fix: `pdb-empty-selector-conflict` has not recurred in any run (2 clean full passes, 1 run with unrelated failures in different subtests)
- [x] Reproduced the original race directly against a live cluster (concurrent namespace creation + status polling) to confirm root cause before writing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)