### PR TITLE
Only show container logs for failures, not successful completions

### DIFF
--- a/pkg/plugin/pod_test.go
+++ b/pkg/plugin/pod_test.go
@@ -16,13 +16,22 @@ import (
 func renderContainerStatusSummary(t *testing.T, containerStatus map[string]interface{}) string {
 	t.Helper()
 	cfg := NewRenderConfig(viper.New())
-	tmpl, _ := getTemplate(cfg)
+	tmpl, err := getTemplate(cfg)
+	if err != nil {
+		t.Fatalf("getTemplate() error = %v", err)
+	}
 	f := cmdtesting.NewTestFactory().WithNamespace("test")
 	f.Client = &fake.RESTClient{}
 	f.UnstructuredClient = f.Client
 	t.Cleanup(func() { f.Cleanup() })
-	repo, _ := input.NewResourceRepo(f, cfg.Viper)
-	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	repo, err := input.NewResourceRepo(f, cfg.Viper)
+	if err != nil {
+		t.Fatalf("NewResourceRepo() error = %v", err)
+	}
+	e, err := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	if err != nil {
+		t.Fatalf("newRenderEngine() error = %v", err)
+	}
 	e.Template = *tmpl
 	pod := newRenderableObject(map[string]interface{}{
 		"apiVersion": "v1",

--- a/pkg/plugin/pod_test.go
+++ b/pkg/plugin/pod_test.go
@@ -1,0 +1,133 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	"github.com/bergerx/kubectl-status/pkg/input"
+)
+
+func renderContainerStatusSummary(t *testing.T, containerStatus map[string]interface{}) string {
+	t.Helper()
+	cfg := NewRenderConfig(viper.New())
+	tmpl, _ := getTemplate(cfg)
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f, cfg.Viper)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	pod := newRenderableObject(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]interface{}{"name": "test-pod", "namespace": "test"},
+	}, e, repo)
+	got, err := pod.renderTemplate("container_status_summary", map[string]interface{}{
+		"pod":             pod,
+		"containerStatus": containerStatus,
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	return got
+}
+
+// TestContainerStatusSummaryTerminatedLogs covers the current-instance "Last failure logs" block:
+// a clean (Completed) exit is never shown, a crash is always shown, regardless of container type.
+func TestContainerStatusSummaryTerminatedLogs(t *testing.T) {
+	tests := []struct {
+		name          string
+		reason        string
+		wantLogsBlock bool
+	}{
+		{name: "successful completion", reason: "Completed", wantLogsBlock: false},
+		{name: "crash", reason: "Error", wantLogsBlock: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderContainerStatusSummary(t, map[string]interface{}{
+				"name":  "some-container",
+				"image": "busybox:latest",
+				"state": map[string]interface{}{
+					"terminated": map[string]interface{}{
+						"reason":    tt.reason,
+						"exitCode":  1,
+						"startedAt": "2026-07-16T18:10:29Z",
+					},
+				},
+			})
+			gotLogsBlock := strings.Contains(got, "Last failure logs:") || strings.Contains(got, "has no logs")
+			if gotLogsBlock != tt.wantLogsBlock {
+				t.Errorf("logs block present = %v, want %v; rendered = %q", gotLogsBlock, tt.wantLogsBlock, got)
+			}
+		})
+	}
+}
+
+// TestContainerStatusSummaryPreviousInstanceLogs covers the lastState "Last failure logs" block: a
+// container still waiting to retry always shows it (no recency gate, since it's the current
+// unresolved problem), a recovered (running) container only shows it while recent, and a currently
+// terminated container never triggers this block (the current-instance block already covers it).
+func TestContainerStatusSummaryPreviousInstanceLogs(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         map[string]interface{}
+		finishedAt    string
+		wantLogsBlock bool
+	}{
+		{
+			name:          "still waiting to retry (e.g. CrashLoopBackOff), old failure",
+			state:         map[string]interface{}{"waiting": map[string]interface{}{"reason": "CrashLoopBackOff"}},
+			finishedAt:    time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			wantLogsBlock: true,
+		},
+		{
+			name:          "recovered (running), recent failure",
+			state:         map[string]interface{}{"running": map[string]interface{}{"startedAt": time.Now().Format(time.RFC3339)}},
+			finishedAt:    time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+			wantLogsBlock: true,
+		},
+		{
+			name:          "recovered (running), stale failure",
+			state:         map[string]interface{}{"running": map[string]interface{}{"startedAt": time.Now().Format(time.RFC3339)}},
+			finishedAt:    time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			wantLogsBlock: false,
+		},
+		{
+			name: "currently terminated (current-instance block already covers this)",
+			state: map[string]interface{}{"terminated": map[string]interface{}{
+				"reason": "Error", "exitCode": 1, "startedAt": time.Now().Format(time.RFC3339),
+			}},
+			finishedAt:    time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			wantLogsBlock: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderContainerStatusSummary(t, map[string]interface{}{
+				"name":  "some-container",
+				"image": "busybox:latest",
+				"state": tt.state,
+				"lastState": map[string]interface{}{
+					"terminated": map[string]interface{}{
+						"reason":     "Error",
+						"exitCode":   1,
+						"startedAt":  "2026-07-16T18:09:00Z",
+						"finishedAt": tt.finishedAt,
+					},
+				},
+			})
+			gotLogsBlock := strings.Contains(got, "Last failure logs:") || strings.Contains(got, "has no previous logs")
+			if gotLogsBlock != tt.wantLogsBlock {
+				t.Errorf("logs block present = %v, want %v; rendered = %q", gotLogsBlock, tt.wantLogsBlock, got)
+			}
+		})
+	}
+}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -531,6 +531,20 @@
            * podPullSecretsBroken (optional): Boolean, true if any podImagePullSecrets entry doesn't resolve to a usable Secret
            * metricsUnavailableReason (optional): non-empty string explaining why there's no containerMetrics
         */ -}}
+    {{- /* Failure log visibility, by current/previous container state (applies uniformly to init,
+           sidecar, regular and Job/CronJob containers -- there's no per-type special-casing):
+             current state.terminated, reason Completed (success)   -> never show
+             current state.terminated, reason != Completed (crash)  -> always show current instance's logs
+             current state.running, lastState.terminated recent     -> show previous instance's logs, gated by withinLastHour
+             current state.running, lastState.terminated stale      -> don't show (already recovered, old news)
+             current state.waiting (e.g. CrashLoopBackOff)          -> always show previous instance's logs, no recency gate (still unresolved)
+           A successful completion is never shown regardless of container type: whether the
+           container is one-shot (plain init container, Job/CronJob container under
+           OnFailure/Never) or gets restarted by the kubelet after exiting (sidecar, regular
+           container under a pod's default restartPolicy: Always), "it finished cleanly" isn't
+           interesting. Only the latest failure is ever shown, and only one of the two blocks
+           below fires for a given container: state.terminated and lastState.terminated are
+           mutually exclusive on how they gate. */ -}}
     {{- .containerStatus.name | bold }}{{ if .sidecar }}{{ " [sidecar]" | cyan }}{{ end }} ({{ .containerStatus.image | markYellow "latest" }}) {{ template "container_state_summary" .containerStatus.state }}
     {{- if .containerStatus.state.running }}{{ if .containerStatus.ready }} and {{ "Ready" | green }}{{ else }} but {{ "Not Ready" | red | bold }}{{ end }}{{ end }}
     {{- if gt (.containerStatus.restartCount | int ) 0 }}, {{ printf "restarted %d times" (.containerStatus.restartCount | int) | yellow | bold }}{{ end }}
@@ -559,10 +573,10 @@
         {{- "previously:" | yellow | nindent 2 }} {{ template "container_state_summary" . }}
     {{- end }}
     {{- with .containerStatus.state.terminated }}
-        {{- if and .startedAt (not ($.pod.Config.GetBool "shallow")) }}
+        {{- if and .startedAt (ne .reason "Completed") (not ($.pod.Config.GetBool "shallow")) }}
             {{- $logs := $.pod.KubeGetContainerLogs $.pod.Namespace $.pod.Name $.containerStatus.name false 20 }}
             {{- if $logs }}
-                {{- "Last 20 lines of logs:" | bold | nindent 2 }}
+                {{- "Last failure logs:" | yellow | bold | nindent 2 }}
                 {{- $logs | nindent 4 }}
             {{- else }}
                 {{- ", " }}{{ "has no logs" | yellow }}
@@ -570,10 +584,11 @@
         {{- end }}
     {{- end }}
     {{- with .containerStatus.lastState.terminated }}
-        {{- if and (withinLastHour .finishedAt) (not ($.pod.Config.GetBool "shallow")) }}
+        {{- $unresolved := not $.containerStatus.state.running }}
+        {{- if and (not $.containerStatus.state.terminated) (or $unresolved (withinLastHour .finishedAt)) (not ($.pod.Config.GetBool "shallow")) }}
             {{- $logs := $.pod.KubeGetContainerLogs $.pod.Namespace $.pod.Name $.containerStatus.name true 20 }}
             {{- if $logs }}
-                {{- "Last 20 lines of logs from previous instance (restarted within last hour):" | bold | nindent 2 }}
+                {{- "Last failure logs:" | yellow | bold | nindent 2 }}
                 {{- $logs | nindent 4 }}
             {{- else }}
                 {{- ", " }}{{ "has no previous logs" | yellow }}

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -8,13 +8,11 @@ Pod/e2e-pod-container-logs -n e2e-pod-container-logs, created 1m ago, gen:1, sta
   Standalone POD\.
   InitContainers:
     init-setup \(busybox:latest\) Started 1m ago and Completed after 1m
-      Last 20 lines of logs:
-        init-setup-log-line
-    init-silent \(busybox:latest\) Started 1m ago and Completed after 1m, has no logs
+    init-silent \(busybox:latest\) Started 1m ago and Completed after 1m
   Containers:
     crasher \(busybox:latest\) Waiting CrashLoopBackOff: back-off [0-9smh]+ restarting failed container=crasher pod=e2e-pod-container-logs_e2e-pod-container-logs\([0-9a-f-]+\), restarted [0-9]+ times(?: \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
       previously: Started 1m ago and Error after 1m with exit code exit with 1
-      Last 20 lines of logs from previous instance \(restarted within last hour\):
+      Last failure logs:
         crasher-log-line
     healthy \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
       (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))


### PR DESCRIPTION
## Summary
- A container that terminated with reason `Completed` (a clean exit) previously still printed its tail logs — noise for init containers, Job/CronJob containers, sidecars, and regular containers alike.
- Log visibility is now decided purely by whether the most recent attempt *failed*, applied uniformly regardless of container type:
  - current state terminated, reason `Completed` → never show
  - current state terminated, reason != `Completed` (crash) → always show current instance's logs
  - current state running, previous instance failed recently → show, gated by the existing `withinLastHour` recency check
  - current state waiting to retry (e.g. `CrashLoopBackOff`) → always show the previous instance's logs, no recency gate (it's the current unresolved problem, not history)
- Both log blocks are relabeled from the generic "Last 20 lines of logs" to an explicit yellow "Last failure logs:", and the decision table is embedded as a template comment in `Pod.tmpl` since the guard conditions alone don't make the intent obvious.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (465 passed, including new `pkg/plugin/pod_test.go` covering both the current-instance and previous-instance log gating logic)
- [x] Updated `tests/e2e-artifacts/pod-container-logs.regex` to match the new behavior/labels
- [ ] `make test-e2e` (minikube) — not run in this session; pre-push hook was skipped per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)