### PR TITLE
Surface missing optional configMap/secret volumes in Pod output

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1716,9 +1716,9 @@ func TestE2EParallel(t *testing.T) {
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-missing-key.regex",
 			}.assert(t, nil, opts...)
 		})
-		t.Run("optional configMap volume referencing a non-existent ConfigMap shows no warning", func(t *testing.T) {
+		t.Run("optional configMap volume referencing a non-existent ConfigMap flags it as an optional-missing note without --include-all-volumes", func(t *testing.T) {
 			cmdTest{
-				args:            []string{"pod/e2e-pod-volume-optional-missing", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--include-all-volumes", "--v", "5"},
+				args:            []string{"pod/e2e-pod-volume-optional-missing", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex",
 			}.assert(t, nil, opts...)
 		})

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -190,7 +190,7 @@
 {{- end }}
 
 {{- define "pod_volume_line" }}
-    {{- /* Renders a single volume spec entry. Expects dict "vol" (spec entry) "stats" (kubelet VolumeStats or nil) "pvcStorage" (optional PVC requested storage) "problem" (optional string, existence/key validation failure for a configMap/secret volume) */ -}}
+    {{- /* Renders a single volume spec entry. Expects dict "vol" (spec entry) "stats" (kubelet VolumeStats or nil) "pvcStorage" (optional PVC requested storage) "problem" (optional pre-styled string, existence/key validation failure or optional-missing note for a configMap/secret volume) */ -}}
     {{- .vol.name | bold }}
     {{- $inner := "" }}
     {{- $isPVC := false }}
@@ -228,7 +228,7 @@
         {{- end }}
     {{- end }}
     {{- if $inner }} ({{ $inner }}){{ end }}
-    {{- with .problem }} {{ . | red | bold }}{{ end }}
+    {{- with .problem }} {{ . }}{{ end }}
 {{- end }}
 
 {{- define "pod_volume_configmap_secret_problem" }}
@@ -236,11 +236,14 @@
            presence, returning a short problem string or "" -- the caller already renders the
            "(ConfigMap: name)"/"(Secret: name)" part, so this only needs the tail. Expects dict
            "kind" ("ConfigMap" or "Secret") "ctx" (Pod RenderableObject) "name" (object name)
-           "optional" (bool) "items" (list of KeyToPath, or nil). */ -}}
+           "optional" (bool) "items" (list of KeyToPath, or nil).
+           A missing optional source doesn't block the pod (kubelet mounts it empty), but it's
+           still worth a diagnostic note distinct from the non-optional "doesn't exist" error. */ -}}
     {{- $obj := $.ctx.KubeGetFirst $.ctx.Namespace $.kind $.name }}
     {{- $problem := "" }}
     {{- if not $obj.Object }}
-        {{- if not $.optional }}{{ $problem = "doesn't exist" }}{{ end }}
+        {{- if $.optional }}{{ $problem = "optional, not found" | yellow }}
+        {{- else }}{{ $problem = "doesn't exist" | red | bold }}{{ end }}
     {{- else if not $.optional }}
         {{- /* "optional" on the volume source governs both the object's existence and its keys
                (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#configmapvolumesource-v1-core)
@@ -257,7 +260,7 @@
             {{- end }}
         {{- end }}
         {{- with $missingKeys }}
-            {{- $problem = printf "missing key%s %s" (ternary "s" "" (gt (len .) 1)) (join ", " .) }}
+            {{- $problem = printf "missing key%s %s" (ternary "s" "" (gt (len .) 1)) (join ", " .) | red | bold }}
         {{- end }}
     {{- end }}
     {{- $problem }}

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
@@ -5,11 +5,7 @@ Pod/e2e-pod-volume-optional-missing -n e2e-pod-volume-configmap-secret, created 
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
-  Volume Mounts:
-    /cfg from cfg
-    /var/run/secrets/kubernetes\.io/serviceaccount from kube-api-access-[a-z0-9]+ \(ro\)
-  Volumes:(?:
-    ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\))?
-    cfg \(ConfigMap: e2e-cm-optional-missing(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
-    kube-api-access-[a-z0-9]+ \(Projected(?:, [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\])?\)
+  (?:Volumes: cfg \(ConfigMap: e2e-cm-optional-missing\) optional, not found|Volumes:
+    ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
+    cfg \(ConfigMap: e2e-cm-optional-missing\) optional, not found)
 \z


### PR DESCRIPTION
## Summary
- A configMap/secret volume with `optional: true` whose referenced object is missing was previously ignored entirely, even though it's useful diagnostic info.
- It now renders a distinct `optional, not found` note (not styled as an error, since kubelet mounts it empty rather than blocking the pod) and, like other volume problems, shows up without needing `--include-all-volumes`.
- Non-optional missing configMap/secret volumes are unaffected — still shown as a red `doesn't exist` error.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (457 tests, offline/golden suite)
- [x] Updated e2e fixture `pod-volume-configmap-secret-optional-missing.regex` and the corresponding `TestE2EParallel` subtest to drop `--include-all-volumes` and assert the new note (verified regex logic against synthetic samples matching the template's single-line/multi-line volume rendering)