### PR TITLE
Render Pod PVC volume refs via resource_ref template

### DIFF
--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -220,7 +220,19 @@
 {{- end }}
 
 {{- define "pod_volume_line" }}
-    {{- /* Renders a single volume spec entry. Expects dict "vol" (spec entry) "stats" (kubelet VolumeStats or nil) "pvcStorage" (optional PVC requested storage) "problem" (optional pre-styled string, existence/key validation failure or optional-missing note for a configMap/secret volume) */ -}}
+    {{- /* Renders the one-line display string for a single Pod volume: "name (source[, usage])"
+           plus any configMap/secret problem note. Expects dict:
+             "ctx"  Pod RenderableObject -- renders resource_ref and fetches the PVC for its size.
+             "vol"  the Pod.spec.volumes entry to render.
+             "podStatsSummary"  this Pod's kubelet stats summary. The caller already resolves it
+                    (it also needs it for ephemeral-storage and emptyDir gating); this looks up
+                    the volume's usage from it rather than re-deriving stats per volume.
+             "problem"  optional pre-styled configMap/secret existence/key note. The caller
+                    computes it once because it also decides whether a broken volume is shown at
+                    all; passing it here avoids a second live lookup.
+           "stats" and "pvcStorage" are deliberately NOT parameters -- both are derived here from
+           podStatsSummary/the PVC, so callers only pass data they already hold. */ -}}
+    {{- $stats := .podStatsSummary.volume | default list | getMatchingItemInMapList (dict "name" .vol.name) }}
     {{- .vol.name | bold }}
     {{- $inner := "" }}
     {{- $isPVC := false }}
@@ -232,20 +244,24 @@
         {{- $inner = printf "HostPath: %s" .vol.hostPath.path }}
         {{- with .vol.hostPath.type }}{{- $inner = printf "%s, type: %s" $inner . }}{{- end }}
     {{- else if hasKey .vol "configMap" }}
-        {{- $inner = .refRendered }}
+        {{- $inner = .ctx.Include "resource_ref" (dict "kind" "ConfigMap" "name" .vol.configMap.name) }}
     {{- else if hasKey .vol "secret" }}
-        {{- $inner = .refRendered }}
+        {{- $inner = .ctx.Include "resource_ref" (dict "kind" "Secret" "name" .vol.secret.secretName) }}
     {{- else if hasKey .vol "persistentVolumeClaim" }}
         {{- $isPVC = true }}
-        {{- $inner = printf "PVC: %s" .vol.persistentVolumeClaim.claimName }}
+        {{- $inner = .ctx.Include "resource_ref" (dict "kind" "PersistentVolumeClaim" "name" .vol.persistentVolumeClaim.claimName) }}
         {{- if .vol.persistentVolumeClaim.readOnly }}{{- $inner = printf "%s, readOnly" $inner }}{{- end }}
-        {{- with .pvcStorage }}{{- $inner = printf "%s, asked %s" $inner . }}{{- end }}
+        {{- $pvc := .ctx.KubeGetFirst .ctx.Namespace "PersistentVolumeClaim" .vol.persistentVolumeClaim.claimName }}
+        {{- if $pvc.Object }}
+            {{- $pvcRequests := (($pvc.Spec | default dict).resources | default dict).requests | default dict }}
+            {{- with index $pvcRequests "storage" }}{{- $inner = printf "%s, asked %s" $inner . }}{{- end }}
+        {{- end }}
     {{- else if hasKey .vol "downwardAPI" }}{{- $inner = "DownwardAPI" }}
     {{- else if hasKey .vol "projected" }}{{- $inner = "Projected" }}
     {{- else if hasKey .vol "csi" }}{{- $inner = printf "CSI: %s" .vol.csi.driver }}
     {{- else if hasKey .vol "nfs" }}{{- $inner = printf "NFS: %s:%s" .vol.nfs.server .vol.nfs.path }}
     {{- end }}
-    {{- with .stats }}
+    {{- with $stats }}
         {{- if and .usedBytes .capacityBytes }}
             {{- $pct := percent (.usedBytes | float64) (.capacityBytes | float64) }}
             {{- $statsStr := printf "%s/%s[%s]" (.usedBytes | float64 | humanizeSI "B") (.capacityBytes | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%") }}
@@ -343,69 +359,31 @@
     {{- end }}
     {{- $deep := $.Config.GetBool "deep" }}
     {{- $showEphemeral := and $ephemeralStorage (index $ephemeralStorage "usedBytes") (index $ephemeralStorage "capacityBytes") }}
-    {{- $totalCount := len $displayVols }}
-    {{- if $showEphemeral }}{{ $totalCount = add1 $totalCount }}{{ end }}
-    {{- if gt $totalCount 0 }}
-        {{- if eq $totalCount 1 }}
-            {{- /* single-line format */ -}}
-            {{- "Volumes:" | nindent 2 }}
-            {{- if $showEphemeral }}
-                {{- $pct := percent (index $ephemeralStorage "usedBytes" | float64) (index $ephemeralStorage "capacityBytes" | float64) }}
-                {{- printf " ephemeral-storage (%s/%s[%s])" (index $ephemeralStorage "usedBytes" | float64 | humanizeSI "B") (index $ephemeralStorage "capacityBytes" | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%") }}
-            {{- else }}
-                {{- $vol := index $displayVols 0 }}
-                {{- $stats := $podStatsSummary.volume | default list | getMatchingItemInMapList (dict "name" $vol.name) }}
-                {{- $pvc := dict }}
-                {{- $pvcStorage := "" }}
-                {{- $refRendered := "" }}
-                {{- if hasKey $vol "configMap" }}
-                    {{- $refRendered = $.Include "resource_ref" (dict "kind" "ConfigMap" "name" $vol.configMap.name) }}
-                {{- else if hasKey $vol "secret" }}
-                    {{- $refRendered = $.Include "resource_ref" (dict "kind" "Secret" "name" $vol.secret.secretName) }}
-                {{- else if hasKey $vol "persistentVolumeClaim" }}
-                    {{- $pvc = $.KubeGetFirst $.Namespace "PersistentVolumeClaim" $vol.persistentVolumeClaim.claimName }}
-                    {{- if $pvc.Object }}
-                        {{- $pvcSpec := $pvc.Spec | default dict }}
-                        {{- $pvcResources := $pvcSpec.resources | default dict }}
-                        {{- $pvcRequests := $pvcResources.requests | default dict }}
-                        {{- $pvcStorage = index $pvcRequests "storage" | default "" }}
-                    {{- end }}
-                {{- end }}
-                {{- " " }}{{ template "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage "problem" (index $volProblems $vol.name) "refRendered" $refRendered) }}
-                {{- if and $deep $pvc.Metadata }}
-                    {{- $.Include "PersistentVolumeClaim" $pvc | nindent 4 }}
-                {{- end }}
+    {{- /* Render every shown volume to a flat entry string first, then choose the layout: a lone
+           entry sits inline after "Volumes:", two or more go one-per-line underneath. This keeps
+           the per-volume rendering -- and the --deep full-PVC dump appended under it -- in a single
+           place rather than duplicated across the two layouts. */ -}}
+    {{- $entries := list }}
+    {{- if $showEphemeral }}
+        {{- $pct := percent (index $ephemeralStorage "usedBytes" | float64) (index $ephemeralStorage "capacityBytes" | float64) }}
+        {{- $entries = append $entries (printf "%s (%s/%s[%s])" ("ephemeral-storage" | bold) (index $ephemeralStorage "usedBytes" | float64 | humanizeSI "B") (index $ephemeralStorage "capacityBytes" | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%")) }}
+    {{- end }}
+    {{- range $displayVols }}
+        {{- $entry := $.Include "pod_volume_line" (dict "ctx" $ "vol" . "podStatsSummary" $podStatsSummary "problem" (index $volProblems .name)) }}
+        {{- if and $deep (hasKey . "persistentVolumeClaim") }}
+            {{- $pvc := $.KubeGetFirst $.Namespace "PersistentVolumeClaim" .persistentVolumeClaim.claimName }}
+            {{- if $pvc.Metadata }}
+                {{- $entry = printf "%s%s" $entry ($.Include "PersistentVolumeClaim" $pvc | nindent 2) }}
             {{- end }}
+        {{- end }}
+        {{- $entries = append $entries $entry }}
+    {{- end }}
+    {{- if $entries }}
+        {{- if eq (len $entries) 1 }}
+            {{- "Volumes:" | nindent 2 }} {{ index $entries 0 }}
         {{- else }}
             {{- "Volumes:" | nindent 2 }}
-            {{- if $showEphemeral }}
-                {{- $pct := percent (index $ephemeralStorage "usedBytes" | float64) (index $ephemeralStorage "capacityBytes" | float64) }}
-                {{- printf "%s (%s/%s[%s])" ("ephemeral-storage" | bold) (index $ephemeralStorage "usedBytes" | float64 | humanizeSI "B") (index $ephemeralStorage "capacityBytes" | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%") | nindent 4 }}
-            {{- end }}
-            {{- range $displayVols }}
-                {{- $vol := . }}
-                {{- $stats := $podStatsSummary.volume | default list | getMatchingItemInMapList (dict "name" $vol.name) }}
-                {{- $pvc := dict }}
-                {{- $pvcStorage := "" }}
-                {{- $refRendered := "" }}
-                {{- if hasKey $vol "configMap" }}
-                    {{- $refRendered = $.Include "resource_ref" (dict "kind" "ConfigMap" "name" $vol.configMap.name) }}
-                {{- else if hasKey $vol "secret" }}
-                    {{- $refRendered = $.Include "resource_ref" (dict "kind" "Secret" "name" $vol.secret.secretName) }}
-                {{- else if hasKey $vol "persistentVolumeClaim" }}
-                    {{- $pvc = $.KubeGetFirst $.Namespace "PersistentVolumeClaim" $vol.persistentVolumeClaim.claimName }}
-                    {{- if $pvc.Object }}
-                        {{- $pvcSpec := $pvc.Spec | default dict }}
-                        {{- $pvcResources := $pvcSpec.resources | default dict }}
-                        {{- $pvcRequests := $pvcResources.requests | default dict }}
-                        {{- $pvcStorage = index $pvcRequests "storage" | default "" }}
-                    {{- end }}
-                {{- end }}
-                {{- $.Include "pod_volume_line" (dict "vol" $vol "stats" $stats "pvcStorage" $pvcStorage "problem" (index $volProblems $vol.name) "refRendered" $refRendered) | nindent 4 }}
-                {{- if and $deep $pvc.Metadata }}
-                    {{- $.Include "PersistentVolumeClaim" $pvc | nindent 6 }}
-                {{- end }}
-            {{- end }}
+            {{- range $entries }}{{ . | nindent 4 }}{{ end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/tests/artifacts/pod-marked-for-deletion.out
+++ b/tests/artifacts/pod-marked-for-deletion.out
@@ -4,4 +4,4 @@ Pod/web-0 -n test1, created 1m ago by StatefulSet/web, started after 1m Running 
   PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
   Containers: nginx (k8s.gcr.io/nginx-slim:0.8) Running for 1m and Ready, restarted 2 times
   previously: Started 1m ago and Completed after 1m
-  Volumes: www (PVC: www-web-0)
+  Volumes: www (PersistentVolumeClaim/www-web-0)

--- a/tests/artifacts/pod-missing-pvc.include-all-volumes.out
+++ b/tests/artifacts/pod-missing-pvc.include-all-volumes.out
@@ -5,5 +5,5 @@ Pod/web-0 -n test1, created 1m ago by StatefulSet/web Pending BestEffort
   Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
     PodScheduled Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
   Volumes:
-    www (PVC: www-web-0)
+    www (PersistentVolumeClaim/www-web-0)
     default-token-xqj2x (Secret/default-token-xqj2x)

--- a/tests/artifacts/pod-missing-pvc.out
+++ b/tests/artifacts/pod-missing-pvc.out
@@ -4,4 +4,4 @@ Pod/web-0 -n test1, created 1m ago by StatefulSet/web Pending BestEffort
     Stalled: PodUnschedulable, Pod could not be scheduled
   Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
     PodScheduled Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
-  Volumes: www (PVC: www-web-0)
+  Volumes: www (PersistentVolumeClaim/www-web-0)


### PR DESCRIPTION
## What

PVC references in the Pod `Volumes:` section were hardcoded as `PVC: <name>` instead of following the `resource_ref` convention (`PersistentVolumeClaim/<name>`) used everywhere else — ConfigMap, Secret, owners, etc.

```
  Volumes:
    www (PVC: www-web-0)                    # before
    www (PersistentVolumeClaim/www-web-0)   # after
```

## Refactor

While fixing this, `pod_volumes` had its ~95%-duplicated single-line and multi-line layouts collapsed into one path: each shown volume is rendered to a flat entry string once, then the layout is chosen (inline after `Volumes:` for a lone entry, one-per-line otherwise).

`pod_volume_line` now derives its own `stats` and `pvcStorage` from the pod context instead of having the caller pre-chew and thread them in — its contract is just "one volume → display string". Net −22 lines, duplication gone.

## Cosmetic deltas (not visible in tests — output runs colorless)

- **ephemeral-storage label**: was plain in single-volume mode, bold in multi; unified to **bold** (consistent with volume names).
- **single-volume `--deep` PVC indent**: shifts 4→2 spaces (inherent to inlining the entry). Live/`--deep`-only; no golden covers it.

## Testing

All 511 tests pass; `go vet` clean. Golden artifacts updated for the new PVC format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
