### PR TITLE
Add generic Crossplane XR/Composition rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,20 @@ install-e2e-deps:
 	helm repo update cowboysysop
 	$(E2E_KUBECONFIG_ENV) helm upgrade --install vpa cowboysysop/vertical-pod-autoscaler --version 11.1.1 -n kube-system --wait --timeout 5m
 	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Available --timeout=120s deployment -l app.kubernetes.io/instance=vpa -n kube-system
+	# Crossplane: e2e scenarios exercise a real XR composing real children (a Composition
+	# Function renders them and derives readiness), not just kubectl-status reading static
+	# CRDs, so the Crossplane core plus the two Composition Functions it needs need to run
+	# for real -- same "controller must actually reconcile" reasoning as VPA above. No cloud
+	# provider is installed: the test Composition composes plain in-cluster Kubernetes
+	# resources (ConfigMap/Deployment), which Crossplane v2 supports natively.
+	helm repo add crossplane-stable https://charts.crossplane.io/stable
+	helm repo update crossplane-stable
+	$(E2E_KUBECONFIG_ENV) helm upgrade --install crossplane crossplane-stable/crossplane --version $(CROSSPLANE_VERSION) -n crossplane-system --create-namespace --wait --timeout 5m
+	# function-patch-and-transform renders the test Composition's child resources,
+	# function-auto-ready derives the XR's readiness from them. Versions pinned in the
+	# manifest itself (not hack/versions.env) since they're only used here.
+	$(E2E_KUBECONFIG_ENV) kubectl apply -f tests/e2e-artifacts/crossplane-functions.yaml
+	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Healthy --timeout=180s function.pkg.crossplane.io --all
 
 .PHONY: test-e2e
 ifeq ($(ASSUME_MINIKUBE_IS_CONFIGURED),true)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2055,6 +2055,93 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/vpa-standalone.regex",
 		}.assert(t, nil, opts...)
 	})
+	t.Run("Crossplane XR composes namespaced children and surfaces their health", func(t *testing.T) {
+		// Crossplane core plus the two Composition Functions it needs (installed cluster-wide by
+		// `make install-e2e-deps`) must actually reconcile to produce the XR's composed children,
+		// same "controller must actually run" reasoning as the VPA subtest above.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-crossplane-xr"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		applyManifest(t, "e2e-artifacts/crossplane-xstatusprobe.yaml")
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Established",
+			"xrd/xstatusprobes.tests.kubectl-status.io", "--timeout=60s").Run())
+		applyManifestInNamespace(t, "e2e-artifacts/crossplane-xr.yaml", ns)
+		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Synced", ns)
+		// The Deployment child is deliberately unschedulable (a nodeSelector no node can match),
+		// so the XR itself never reaches Ready -- wait on the field kubectl-status actually reads
+		// instead of a condition that will never flip.
+		waitForCrossplaneComposedRefs(t, ns, "probe-a", 2)
+		// Synced/resourceRefs land as soon as the render step runs, but the XR's own Responsive
+		// condition and the composed Deployment's Progressing/Available conditions populate
+		// slightly later via separate reconciles -- wait for all of them so the fixtures below
+		// pin a stable message instead of racing a transient "Replicas: 0/1" kstatus summary.
+		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Responsive", ns)
+		waitForInNamespace(t, "deployment/probe-a-blocked", "condition=Progressing", ns)
+		require.NoError(t, exec.Command("kubectl", "wait", "-n", ns,
+			"--for=condition=PodScheduled=false", "pod", "-l", "app=probe-a-blocked", "--timeout=2m").Run())
+		// kstatus (sigs.k8s.io/cli-utils/pkg/kstatus/status.ScheduleWindow) gives a Pod 15s from
+		// its creationTimestamp before reporting Unschedulable as Failed rather than InProgress --
+		// wait that out so the fixtures below pin the stable "Failed: Pod could not be scheduled"
+		// message instead of racing the transient one.
+		waitForPodScheduleWindow(t, ns, "app=probe-a-blocked")
+
+		// Only the live-query-dependent branches belong here: default mode's KubeGetFirst lookup
+		// (populating each composed child's compact health) and --deep's IncludeRenderableObject
+		// inline. Shallow rendering and Composition.tmpl make no live queries at all -- both are
+		// already covered by the offline artifacts (tests/artifacts/crossplane-*).
+		cmdTest{
+			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/crossplane-xr.regex",
+		}.assert(t, nil, opts...)
+		cmdTest{
+			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/crossplane-xr-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+}
+
+// waitForPodScheduleWindow blocks until at least 15s (kstatus's
+// sigs.k8s.io/cli-utils/pkg/kstatus/status.ScheduleWindow) have passed since the matching Pod's
+// creationTimestamp.
+func waitForPodScheduleWindow(t *testing.T, namespace, labelSelector string) {
+	t.Helper()
+	cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+		"-o", "jsonpath={.items[0].metadata.creationTimestamp}")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	created, err := time.Parse(time.RFC3339, strings.TrimSpace(string(output)))
+	require.NoError(t, err)
+	if remaining := time.Until(created.Add(16 * time.Second)); remaining > 0 {
+		time.Sleep(remaining)
+	}
+}
+
+// waitForCrossplaneComposedRefs polls until the XR's spec.crossplane.resourceRefs has at least
+// wantCount entries. Used instead of waiting on a Ready condition since the XR under test never
+// reaches Ready (one composed child is deliberately unschedulable).
+func waitForCrossplaneComposedRefs(t *testing.T, namespace, name string, wantCount int) {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", "xstatusprobe", name, "-n", namespace,
+			"-o", "jsonpath={.spec.crossplane.resourceRefs}")
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			var refs []interface{}
+			if json.Unmarshal(output, &refs) == nil && len(refs) >= wantCount {
+				t.Logf("xstatusprobe %s in namespace %s has %d composed resource refs", name, namespace, len(refs))
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for xstatusprobe %s in namespace %s to have %d composed resource refs", name, namespace, wantCount)
 }
 
 func applyManifest(t *testing.T, filepath string) {

--- a/hack/versions.env
+++ b/hack/versions.env
@@ -4,3 +4,4 @@
 # keep it to plain VAR=value lines only.
 GATEWAY_API_VERSION=v1.6.0
 CERT_MANAGER_VERSION=v1.21.0
+CROSSPLANE_VERSION=2.3.3

--- a/pkg/plugin/templates/Composition.tmpl
+++ b/pkg/plugin/templates/Composition.tmpl
@@ -1,0 +1,20 @@
+{{- define "Composition" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: apiextensions.crossplane.io/v1, Kind=Composition */ -}}
+    {{- template "status_summary_line" . }}
+    {{- with .Spec.compositeTypeRef }}
+        {{- "Composite type" | bold | nindent 2 }}: {{ .kind | cyan | bold }} ({{ .apiVersion | cyan }})
+    {{- end }}
+    {{- with .Spec.mode }}{{ if ne . "Pipeline" }}
+        {{- "Mode" | bold | nindent 2 }}: {{ . | yellow }}
+    {{- end }}{{ end }}
+    {{- with .Spec.pipeline }}
+        {{- "Pipeline" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- .step | cyan | nindent 4 }}: {{ .functionRef.name | cyan }}
+        {{- end }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+{{- end -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -7,6 +7,7 @@
     {{- template "application_details" . }}
     {{- template "replicas_status" . }}
     {{- template "suspended" . }}
+    {{- template "crossplane_composed_resources" . }}
     {{- template "conditions_summary" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
@@ -205,6 +206,37 @@
         {{- end }}{{ end }}{{ end }}
     {{- end }}
 {{- end -}}
+
+{{- define "crossplane_composed_resources" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* A Crossplane composite resource (XR) lists the resources it composes in
+           spec.crossplane.resourceRefs (v2, namespaced XRs) or spec.resourceRefs (v1, cluster-
+           scoped XRs). Presence of either is itself the marker that this object is an XR -- no
+           other Kubernetes object sets these paths -- so this is safe to invoke unconditionally
+           from DefaultResource. */ -}}
+    {{- $refs := .Spec.resourceRefs }}
+    {{- with .Spec.crossplane }}{{ with .resourceRefs }}{{ $refs = . }}{{ end }}{{ end }}
+    {{- with $refs }}
+        {{- "Composed resources" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- $ns := coalesce .namespace $.Namespace }}
+            {{- if $.Config.GetBool "deep" }}
+                {{- $obj := $.KubeGetFirst $ns .kind .name }}
+                {{- if $obj.Object }}
+                    {{- $.IncludeRenderableObject $obj | nindent 4 }}
+                {{- else }}
+                    {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $ns "callerNamespace" $.Namespace) | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- $obj := $.KubeGetFirst $ns .kind .name }}
+                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $ns "callerNamespace" $.Namespace) | nindent 4 }}
+                {{- if $obj.Object }}
+                    {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ with .Message }}: {{ . }}{{ end }}{{ end }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
 
 {{- define "owners" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject */ -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -213,10 +213,24 @@
            spec.crossplane.resourceRefs (v2, namespaced XRs) or spec.resourceRefs (v1, cluster-
            scoped XRs). Presence of either is itself the marker that this object is an XR -- no
            other Kubernetes object sets these paths -- so this is safe to invoke unconditionally
-           from DefaultResource. */ -}}
+           from DefaultResource. Since this now runs for every CRD kind that has no dedicated
+           template, a coincidentally-named but differently-shaped spec.resourceRefs/spec.crossplane
+           field (e.g. not a list of {kind,name} objects) must be ignored rather than treated as a
+           template error that would blank out that resource's whole render. */ -}}
     {{- $refs := .Spec.resourceRefs }}
-    {{- with .Spec.crossplane }}{{ with .resourceRefs }}{{ $refs = . }}{{ end }}{{ end }}
-    {{- with $refs }}
+    {{- $crossplane := .Spec.crossplane }}
+    {{- if kindIs "map" $crossplane }}
+        {{- with $crossplane.resourceRefs }}{{ $refs = . }}{{ end }}
+    {{- end }}
+    {{- $validRefs := list }}
+    {{- if kindIs "slice" $refs }}
+        {{- range $refs }}
+            {{- if and (kindIs "map" .) (kindIs "string" .kind) (kindIs "string" .name) }}
+                {{- $validRefs = append $validRefs . }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with $validRefs }}
         {{- "Composed resources" | bold | nindent 2 }}:
         {{- range . }}
             {{- $ns := coalesce .namespace $.Namespace }}

--- a/tests/artifacts/crossplane-composition.out
+++ b/tests/artifacts/crossplane-composition.out
@@ -1,0 +1,6 @@
+
+Composition/status-probe, created 1m ago, gen:1
+  Composite type: XStatusProbe (tests.kubectl-status.io/v1alpha1)
+  Pipeline:
+    render: function-patch-and-transform
+    readiness: function-auto-ready

--- a/tests/artifacts/crossplane-composition.yaml
+++ b/tests/artifacts/crossplane-composition.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"apiextensions.crossplane.io/v1","kind":"Composition","metadata":{"annotations":{},"name":"status-probe"},"spec":{"compositeTypeRef":{"apiVersion":"tests.kubectl-status.io/v1alpha1","kind":"XStatusProbe"},"mode":"Pipeline","pipeline":[{"functionRef":{"name":"function-patch-and-transform"},"input":{"apiVersion":"pt.fn.crossplane.io/v1beta1","kind":"Resources","resources":[{"base":{"apiVersion":"v1","data":{"state":"healthy"},"kind":"ConfigMap","metadata":{"name":"probe-a-config"}},"name":"config"},{"base":{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"probe-a-blocked"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"probe-a-blocked"}},"template":{"metadata":{"labels":{"app":"probe-a-blocked"}},"spec":{"containers":[{"image":"registry.k8s.io/pause:3.10","name":"pause","resources":{"requests":{"cpu":"1m","memory":"16Mi"}}}],"nodeSelector":{"kubectl-status.io/e2e-never-schedules":"true"}}}}},"name":"blocked-workload"}]},"step":"render"},{"functionRef":{"name":"function-auto-ready"},"step":"readiness"}]}}
+  creationTimestamp: "2026-07-19T20:11:10Z"
+  generation: 1
+  name: status-probe
+  resourceVersion: "1078"
+  uid: 53d706c1-ca80-4c75-832b-085a9bf6ffa8
+spec:
+  compositeTypeRef:
+    apiVersion: tests.kubectl-status.io/v1alpha1
+    kind: XStatusProbe
+  mode: Pipeline
+  pipeline:
+  - functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+      - base:
+          apiVersion: v1
+          data:
+            state: healthy
+          kind: ConfigMap
+          metadata:
+            name: probe-a-config
+        name: config
+      - base:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: probe-a-blocked
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: probe-a-blocked
+            template:
+              metadata:
+                labels:
+                  app: probe-a-blocked
+              spec:
+                containers:
+                - image: registry.k8s.io/pause:3.10
+                  name: pause
+                  resources:
+                    requests:
+                      cpu: 1m
+                      memory: 16Mi
+                nodeSelector:
+                  kubectl-status.io/e2e-never-schedules: "true"
+        name: blocked-workload
+    step: render
+  - functionRef:
+      name: function-auto-ready
+    step: readiness

--- a/tests/artifacts/crossplane-xr-composed.out
+++ b/tests/artifacts/crossplane-xr-composed.out
@@ -1,0 +1,10 @@
+
+XStatusProbe/probe-a -n crossplane-e2e, created 1m ago, gen:3
+  InProgress: Unready resources: blocked-workload, config
+    Reconciling: Creating, Unready resources: blocked-workload, config
+  Composed resources:
+    Deployment/probe-a-blocked
+    ConfigMap/probe-a-config
+  Synced ReconcileSuccess for 1m
+  Ready Creating, Unready resources: blocked-workload, config for 1m
+  Responsive WatchCircuitClosed for 1m

--- a/tests/artifacts/crossplane-xr-composed.yaml
+++ b/tests/artifacts/crossplane-xr-composed.yaml
@@ -1,0 +1,48 @@
+apiVersion: tests.kubectl-status.io/v1alpha1
+kind: XStatusProbe
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"tests.kubectl-status.io/v1alpha1","kind":"XStatusProbe","metadata":{"annotations":{},"name":"probe-a","namespace":"crossplane-e2e"},"spec":{"crossplane":{"compositionRef":{"name":"status-probe"}}}}
+  creationTimestamp: "2026-07-19T20:11:10Z"
+  finalizers:
+  - composite.apiextensions.crossplane.io
+  generation: 3
+  labels:
+    crossplane.io/composite: probe-a
+  name: probe-a
+  namespace: crossplane-e2e
+  resourceVersion: "1144"
+  uid: 137d2392-316b-4b78-a7b4-724cadf75a94
+spec:
+  crossplane:
+    compositionRef:
+      name: status-probe
+    compositionRevisionRef:
+      name: status-probe-56d8414
+    compositionUpdatePolicy: Automatic
+    resourceRefs:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: probe-a-blocked
+    - apiVersion: v1
+      kind: ConfigMap
+      name: probe-a-config
+status:
+  conditions:
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    observedGeneration: 3
+    reason: ReconcileSuccess
+    status: "True"
+    type: Synced
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    message: 'Unready resources: blocked-workload, config'
+    observedGeneration: 3
+    reason: Creating
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    observedGeneration: 3
+    reason: WatchCircuitClosed
+    status: "True"
+    type: Responsive

--- a/tests/e2e-artifacts/crossplane-functions.yaml
+++ b/tests/e2e-artifacts/crossplane-functions.yaml
@@ -1,0 +1,13 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-patch-and-transform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.9.0
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-auto-ready
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-auto-ready:v0.5.1

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -1,0 +1,60 @@
+\A
+XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
+  InProgress: Unready resources: blocked-workload, config
+    Reconciling: Creating, Unready resources: blocked-workload, config
+  Composed resources:
+    Deployment/probe-a-blocked -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a, gen:1 rev:1
+      InProgress: Available: 0/1
+        Reconciling: LessAvailable, Available: 0/1
+      desired:1, existing:1, ready:0, updated:1, available:0, unavailable:1
+      Selector: app=probe-a-blocked
+        Pod/probe-a-blocked-[a-z0-9]+-[a-z0-9]+ -n e2e-crossplane-xr, created 1m ago by ReplicaSet/probe-a-blocked-[a-z0-9]+, gen:1 Pending Burstable
+          Failed: Pod could not be scheduled
+            Stalled: PodUnschedulable, Pod could not be scheduled
+          Managed by probe-a-blocked application
+          Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+            PodScheduled Unschedulable, [^\n]*node\(s\) didn't match Pod's node affinity/selector[^\n]* for 1m
+          Volumes: kube-api-access-[a-z0-9]+ \(Projected\)
+          Owners:
+            ReplicaSet/probe-a-blocked-[a-z0-9]+ -n e2e-crossplane-xr, created 1m ago by Deployment/probe-a-blocked, gen:1
+              InProgress: Available: 0/1
+                Reconciling: LessAvailable, Available: 0/1
+              Managed by probe-a-blocked application
+              Selector: app=probe-a-blocked,pod-template-hash=[a-z0-9]+
+                Pod/probe-a-blocked-[a-z0-9]+-[a-z0-9]+\[e2e-crossplane-xr\] is already printed
+              Not matched by any Service
+              Outage: ReplicaSet has no Ready replicas\.
+              Owners:
+                Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
+      Not matched by any Service
+      Available MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
+      Progressing ReplicaSetUpdated, ReplicaSet "probe-a-blocked-[a-z0-9]+" is progressing\. for 1m
+      Ongoing Rollout: Waiting for deployment "probe-a-blocked" rollout to finish: 0 of 1 updated replicas are available\.\.\.
+      Outage: Deployment has no Ready replicas\.
+      Rollouts:
+        1m ago, managed by ReplicaSet/probe-a-blocked-[a-z0-9]+, has 1 replicas
+      Owners:
+        XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
+          InProgress: Unready resources: blocked-workload, config
+            Reconciling: Creating, Unready resources: blocked-workload, config
+          Composed resources:
+            Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
+            ConfigMap/probe-a-config -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a
+              Owners:
+                XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
+                  InProgress: Unready resources: blocked-workload, config
+                    Reconciling: Creating, Unready resources: blocked-workload, config
+                  Composed resources:
+                    Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
+                    ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
+                  Synced ReconcileSuccess for 1m
+                  Ready Creating, Unready resources: blocked-workload, config for 1m
+                  Responsive WatchCircuitClosed for 1m
+          Synced ReconcileSuccess for 1m
+          Ready Creating, Unready resources: blocked-workload, config for 1m
+          Responsive WatchCircuitClosed for 1m
+    ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
+  Synced ReconcileSuccess for 1m
+  Ready Creating, Unready resources: blocked-workload, config for 1m
+  Responsive WatchCircuitClosed for 1m
+\z

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -1,0 +1,11 @@
+\A
+XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
+  InProgress: Unready resources: blocked-workload, config
+    Reconciling: Creating, Unready resources: blocked-workload, config
+  Composed resources:
+    Deployment/probe-a-blocked, InProgress: Available: 0/1
+    ConfigMap/probe-a-config, Current: Resource is always ready
+  Synced ReconcileSuccess for 1m
+  Ready Creating, Unready resources: blocked-workload, config for 1m
+  Responsive WatchCircuitClosed for 1m
+\z

--- a/tests/e2e-artifacts/crossplane-xr.yaml
+++ b/tests/e2e-artifacts/crossplane-xr.yaml
@@ -1,0 +1,8 @@
+apiVersion: tests.kubectl-status.io/v1alpha1
+kind: XStatusProbe
+metadata:
+  name: probe-a
+spec:
+  crossplane:
+    compositionRef:
+      name: status-probe

--- a/tests/e2e-artifacts/crossplane-xstatusprobe.yaml
+++ b/tests/e2e-artifacts/crossplane-xstatusprobe.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xstatusprobes.tests.kubectl-status.io
+spec:
+  group: tests.kubectl-status.io
+  names:
+    kind: XStatusProbe
+    plural: xstatusprobes
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: status-probe
+spec:
+  compositeTypeRef:
+    apiVersion: tests.kubectl-status.io/v1alpha1
+    kind: XStatusProbe
+  mode: Pipeline
+  pipeline:
+    - step: render
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: config
+            base:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: probe-a-config
+              data:
+                state: healthy
+          - name: blocked-workload
+            base:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: probe-a-blocked
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    app: probe-a-blocked
+                template:
+                  metadata:
+                    labels:
+                      app: probe-a-blocked
+                  spec:
+                    nodeSelector:
+                      kubectl-status.io/e2e-never-schedules: "true"
+                    containers:
+                      - name: pause
+                        image: registry.k8s.io/pause:3.10
+                        resources:
+                          requests:
+                            cpu: 1m
+                            memory: 16Mi
+    - step: readiness
+      functionRef:
+        name: function-auto-ready


### PR DESCRIPTION
## Summary
- Adds `crossplane_composed_resources` to `DefaultResource` (`common.tmpl`), so any Crossplane composite resource (XR) — regardless of the arbitrary Kind its XRD defines — gets its composed children surfaced, shallow/default/deep-aware, alongside the existing `conditions_summary`/`kstatus_summary` (Ready/Synced). Detection is purely structural (`spec.crossplane.resourceRefs` for v2 namespaced XRs, `spec.resourceRefs` for v1 compat) — no XRD discovery, no kind-naming convention required.
- Adds `Composition.tmpl` showing `compositeTypeRef` and pipeline steps.
- Follows existing `resource_ref`/`IncludeRenderableObject` conventions (same pattern as `HTTPRoute.tmpl`'s `parentRefs`/`backendRefs`).

Closes #667.

## Test plan
- [x] Offline artifacts (`tests/artifacts/crossplane-xr-composed.*`, `crossplane-composition.*`) captured from a real reconciled Crossplane v2.3.3 cluster; `make update-artifacts` shows zero diffs on all pre-existing fixtures (DefaultResource is shared by every unrecognized CRD, so this was the key regression check).
- [x] Live e2e: `make install-e2e-deps` now installs Crossplane + `function-patch-and-transform` + `function-auto-ready` (composes plain in-cluster ConfigMap/Deployment, no cloud provider needed); new `TestE2EDynamicManifests` subtest covers only the genuinely dynamic branches (default-mode live `KubeGetFirst` fetch, `--deep` `IncludeRenderableObject` inline) since shallow/Composition rendering make no live calls and are already covered by Tier 1.
- [x] `make test` (vet, staticcheck, full offline suite) green.
- [x] Live e2e subtest passes reliably (accounts for kstatus's 15s pod-scheduling grace window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)