### PR TITLE
Fix nil namespace crash rendering cluster-scoped composed resources

### DIFF
--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -233,7 +233,8 @@
     {{- with $validRefs }}
         {{- "Composed resources" | bold | nindent 2 }}:
         {{- range . }}
-            {{- $ns := coalesce .namespace $.Namespace }}
+            {{- $ns := $.Namespace }}
+            {{- with .namespace }}{{ $ns = . }}{{ end }}
             {{- if $.Config.GetBool "deep" }}
                 {{- $obj := $.KubeGetFirst $ns .kind .name }}
                 {{- if $obj.Object }}

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
@@ -1,0 +1,10 @@
+
+XStatusProbe/probe-a, created 1m ago, gen:3
+  InProgress: Unready resources: blocked-workload, config
+    Reconciling: Creating, Unready resources: blocked-workload, config
+  Composed resources:
+    Deployment/probe-a-blocked
+    ConfigMap/probe-a-config
+  Synced ReconcileSuccess for 1m
+  Ready Creating, Unready resources: blocked-workload, config for 1m
+  Responsive WatchCircuitClosed for 1m

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.yaml
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.yaml
@@ -1,0 +1,42 @@
+apiVersion: tests.kubectl-status.io/v1alpha1
+kind: XStatusProbe
+metadata:
+  creationTimestamp: "2026-07-19T20:11:10Z"
+  finalizers:
+  - composite.apiextensions.crossplane.io
+  generation: 3
+  name: probe-a
+  resourceVersion: "1144"
+  uid: 137d2392-316b-4b78-a7b4-724cadf75a94
+spec:
+  crossplane:
+    compositionRef:
+      name: status-probe
+    compositionRevisionRef:
+      name: status-probe-56d8414
+    compositionUpdatePolicy: Automatic
+    resourceRefs:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: probe-a-blocked
+    - apiVersion: v1
+      kind: ConfigMap
+      name: probe-a-config
+status:
+  conditions:
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    observedGeneration: 3
+    reason: ReconcileSuccess
+    status: "True"
+    type: Synced
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    message: 'Unready resources: blocked-workload, config'
+    observedGeneration: 3
+    reason: Creating
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2026-07-19T20:11:32Z"
+    observedGeneration: 3
+    reason: WatchCircuitClosed
+    status: "True"
+    type: Responsive


### PR DESCRIPTION
## Summary
- `crossplane_composed_resources` used `coalesce .namespace $.Namespace` to
  pick the namespace for a composed resource lookup. Sprig's `coalesce`
  returns `nil` when every argument is empty, which happens for a
  cluster-scoped composite whose resourceRefs also carry no `.namespace` —
  crashing the render with "expected string" instead of showing the
  composed resources.
- Replaced it with an explicit fallback so the namespace is always a
  string, and added a fixture covering the cluster-scoped case.

## Test plan
- [x] `go test ./...`
- [x] Verified the new fixture fails with the old code and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)