### PR TITLE
Move install-e2e-deps' per-scenario dependencies into their topical test groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,13 @@ e2e-minikube-down:
 
 .PHONY: install-e2e-deps
 install-e2e-deps:
-	# metrics-server is needed by e2e scenarios exercising pod/node metrics rendering.
+	# metrics-server is the one cluster dependency that stays here as a global, upfront install
+	# rather than moving into its topical e2e test group (see cmd/e2e_helpers_test.go's
+	# ensure*(t) functions for cert-manager, Gateway API CRDs, Cilium/Calico CRDs, VPA, and
+	# Crossplane -- #720): pdb-empty-selector-conflict, not itself a metrics test, can render a
+	# spurious "metrics-server is not available" line if the metrics API isn't queryable yet
+	# when TestE2EParallel's parallel pool starts, so metrics availability is an invariant for
+	# the whole pool, not a per-group concern.
 	$(E2E_KUBECONFIG_ENV) minikube addons enable metrics-server $(E2E_PROFILE_FLAG)
 	$(E2E_KUBECONFIG_ENV) kubectl -n kube-system rollout status deployment/metrics-server --timeout=120s
 	# The Deployment/Pod going Ready above can still briefly precede the Service's EndpointSlice
@@ -131,56 +137,6 @@ install-e2e-deps:
 	# pdb-empty-selector-conflict) can otherwise race that gap and render a spurious
 	# "metrics-server is not available" line. Poll the actual data path instead of the rollout.
 	$(E2E_KUBECONFIG_ENV) bash -c 'for ((i=1; i<=60; i++)); do kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes >/dev/null 2>&1 && exit 0; sleep 2; done; echo "metrics.k8s.io never became queryable" >&2; exit 1'
-	# cert-manager and Gateway API CRDs are needed by e2e TLS-validation test scenarios.
-	# Versions are pinned in hack/versions.env (shared with hack/generate-screenshots.sh);
-	# bump them there periodically.
-	$(E2E_KUBECONFIG_ENV) kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Available --timeout=300s deployment --all -n cert-manager
-	# CRDs only (no controller needed): e2e tests only exercise kubectl-status's own
-	# read-only rendering of these objects, they don't need a controller reconciling them.
-	# Experimental channel is a superset of standard and adds TCPRoute/UDPRoute/
-	# BackendTLSPolicy/ListenerSet, which some e2e scenarios also render.
-	# --server-side: the experimental bundle's CRDs (e.g. HTTPRoute) are large enough that
-	# client-side apply's kubectl.kubernetes.io/last-applied-configuration annotation trips
-	# the 262144-byte annotation limit; server-side apply doesn't need that annotation.
-	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml
-	# CiliumNetworkPolicy/CiliumClusterwideNetworkPolicy and Calico NetworkPolicy/
-	# GlobalNetworkPolicy CRDs: kubectl-status only reads and matches these objects
-	# client-side (selector-vs-Pod-labels), it never relies on Cilium/Calico actually
-	# enforcing traffic, so the CRDs alone (no Cilium/Calico installed as CNI) are enough
-	# to exercise the e2e scenarios -- same "CRDs only" reasoning as cert-manager/Gateway
-	# API above. Calico's own NetworkPolicy/GlobalNetworkPolicy are served under
-	# crd.projectcalico.org/v1 (the Kubernetes-datastore storage CRDs), not the
-	# projectcalico.org/v3 API calicoctl/the Calico API server present -- that's the group
-	# kubectl-status's KubeGetCalico*MatchingPod helpers query.
-	# --server-side: these CRDs' embedded OpenAPI schemas are large enough to trip the same
-	# client-side last-applied-configuration annotation limit as HTTPRoute above.
-	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
-	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
-	$(E2E_KUBECONFIG_ENV) kubectl apply --server-side -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/crds.yaml
-	# VerticalPodAutoscaler: unlike the CRD-only entries above, e2e scenarios exercise it
-	# actually acting (the updater evicting/recreating a Pod to apply a recommendation), so its
-	# controllers (recommender/updater/admission-controller) need to run for real, not just the
-	# CRDs. The upstream project has no plain `kubectl apply` release bundle (its install script
-	# generates webhook certs locally), so this uses the cowboysysop community Helm chart instead.
-	helm repo add cowboysysop https://cowboysysop.github.io/charts/
-	helm repo update cowboysysop
-	$(E2E_KUBECONFIG_ENV) helm upgrade --install vpa cowboysysop/vertical-pod-autoscaler --version 11.1.1 -n kube-system --wait --timeout 5m
-	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Available --timeout=120s deployment -l app.kubernetes.io/instance=vpa -n kube-system
-	# Crossplane: e2e scenarios exercise a real XR composing real children (a Composition
-	# Function renders them and derives readiness), not just kubectl-status reading static
-	# CRDs, so the Crossplane core plus the two Composition Functions it needs need to run
-	# for real -- same "controller must actually reconcile" reasoning as VPA above. No cloud
-	# provider is installed: the test Composition composes plain in-cluster Kubernetes
-	# resources (ConfigMap/Deployment), which Crossplane v2 supports natively.
-	helm repo add crossplane-stable https://charts.crossplane.io/stable
-	helm repo update crossplane-stable
-	$(E2E_KUBECONFIG_ENV) helm upgrade --install crossplane crossplane-stable/crossplane --version $(CROSSPLANE_VERSION) -n crossplane-system --create-namespace --wait --timeout 5m
-	# function-patch-and-transform renders the test Composition's child resources,
-	# function-auto-ready derives the XR's readiness from them. Versions pinned in the
-	# manifest itself (not hack/versions.env) since they're only used here.
-	$(E2E_KUBECONFIG_ENV) kubectl apply -f tests/e2e-artifacts/crossplane-functions.yaml
-	$(E2E_KUBECONFIG_ENV) kubectl wait --for=condition=Healthy --timeout=180s function.pkg.crossplane.io --all
 
 .PHONY: test-e2e
 ifeq ($(ASSUME_MINIKUBE_IS_CONFIGURED),true)

--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -59,6 +59,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// alongside the other concurrent subtests -- causing unrelated renders elsewhere to
 		// intermittently report "metrics-server is not available". Running it serially, alongside
 		// the other genuinely cluster-wide-affecting subtest above, avoids that.
+		ensureVPA(t)
 		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-vpa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
@@ -146,9 +147,10 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("Crossplane XR composes namespaced children and surfaces their health", func(t *testing.T) {
-		// Crossplane core plus the two Composition Functions it needs (installed cluster-wide by
-		// `make install-e2e-deps`) must actually reconcile to produce the XR's composed children,
-		// same "controller must actually run" reasoning as the VPA subtest above.
+		// Crossplane core plus the two Composition Functions it needs must actually reconcile
+		// to produce the XR's composed children, same "controller must actually run" reasoning
+		// as the VPA subtest above.
+		ensureCrossplane(t)
 		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-crossplane-xr"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -556,4 +557,232 @@ func waitForPodRecreated(t *testing.T, namespace, labelSelector, originalPodName
 	}
 	t.Fatalf("timed out waiting for pod matching %s in namespace %s to be recreated (still %s)",
 		labelSelector, namespace, originalPodName)
+}
+
+// ---------------------------------------------------------------------------
+// Per-scenario cluster dependency installs (see #720).
+//
+// Each topical group installs whatever cluster prerequisites *it* needs (cert-manager, Gateway
+// API CRDs, Cilium/Calico CRDs, VPA, Crossplane) instead of everything being installed
+// unconditionally by `make install-e2e-deps` before any test runs. metrics-server is the one
+// exception left as a Makefile step: it must be available before TestE2EParallel's pool starts
+// (see that function's doc comment), not merely before whichever group happens to use it.
+//
+// A dependency used by more than one topical group (Gateway API CRDs: service-routing and
+// tls-validation) needs to install exactly once across the whole run, not once per group -- each
+// onceInstaller below is a package-level singleton shared by every caller, guarded by
+// sync.Once. The error from that single install attempt is cached and replayed to every caller
+// (including ones after the first) rather than only failing the subtest that happened to trigger
+// the install: sync.Once.Do still marks itself done even if its function calls t.FailNow
+// (testify's require does, via runtime.Goexit), so the install closures below stay t-free and
+// return a plain error instead.
+// ---------------------------------------------------------------------------
+
+type onceInstaller struct {
+	once sync.Once
+	err  error
+}
+
+func (o *onceInstaller) ensure(t *testing.T, install func() error) {
+	t.Helper()
+	o.once.Do(func() {
+		o.err = install()
+	})
+	require.NoError(t, o.err)
+}
+
+var (
+	versionsEnvOnce sync.Once
+	versionsEnv     map[string]string
+	versionsEnvErr  error
+)
+
+// loadVersionsEnv parses hack/versions.env's plain VAR=value lines, the same file
+// hack/generate-screenshots.sh sources, so both stay pinned to the same versions.
+func loadVersionsEnv() (map[string]string, error) {
+	versionsEnvOnce.Do(func() {
+		data, err := os.ReadFile(path.Join("..", "hack", "versions.env"))
+		if err != nil {
+			versionsEnvErr = err
+			return
+		}
+		vals := map[string]string{}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if k, v, ok := strings.Cut(line, "="); ok {
+				vals[k] = v
+			}
+		}
+		versionsEnv = vals
+	})
+	return versionsEnv, versionsEnvErr
+}
+
+func versionsEnvValue(key string) (string, error) {
+	vals, err := loadVersionsEnv()
+	if err != nil {
+		return "", err
+	}
+	v, ok := vals[key]
+	if !ok {
+		return "", fmt.Errorf("missing %s in hack/versions.env", key)
+	}
+	return v, nil
+}
+
+var gatewayAPICRDsInstaller onceInstaller
+
+// ensureGatewayAPICRDs installs the Gateway API CRDs (experimental channel), needed by both
+// runServiceRoutingSubtests and runTLSValidationSubtests. CRDs only: kubectl-status only reads/
+// matches these objects client-side, it never relies on a real Gateway controller reconciling
+// them. Experimental channel is a superset of standard and adds TCPRoute/UDPRoute/
+// BackendTLSPolicy/ListenerSet, which some e2e scenarios also render. --server-side: the
+// experimental bundle's CRDs (e.g. HTTPRoute) are large enough that client-side apply's
+// kubectl.kubernetes.io/last-applied-configuration annotation trips the 262144-byte annotation
+// limit; server-side apply doesn't need that annotation.
+func ensureGatewayAPICRDs(t *testing.T) {
+	t.Helper()
+	gatewayAPICRDsInstaller.ensure(t, func() error {
+		version, err := versionsEnvValue("GATEWAY_API_VERSION")
+		if err != nil {
+			return err
+		}
+		url := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/experimental-install.yaml", version)
+		output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("kubectl apply gateway-api CRDs: %w: %s", err, output)
+		}
+		return nil
+	})
+}
+
+var certManagerInstaller onceInstaller
+
+// ensureCertManager installs cert-manager, needed by runTLSValidationSubtests. Versions are
+// pinned in hack/versions.env (shared with hack/generate-screenshots.sh); bump them there
+// periodically.
+func ensureCertManager(t *testing.T) {
+	t.Helper()
+	certManagerInstaller.ensure(t, func() error {
+		version, err := versionsEnvValue("CERT_MANAGER_VERSION")
+		if err != nil {
+			return err
+		}
+		url := fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", version)
+		if output, err := exec.Command("kubectl", "apply", "-f", url).CombinedOutput(); err != nil {
+			return fmt.Errorf("kubectl apply cert-manager.yaml: %w: %s", err, output)
+		}
+		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=300s",
+			"deployment", "--all", "-n", "cert-manager").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("kubectl wait cert-manager deployments: %w: %s", err, output)
+		}
+		return nil
+	})
+}
+
+var ciliumCalicoCRDsInstaller onceInstaller
+
+// ensureCiliumCalicoCRDs installs the CiliumNetworkPolicy/CiliumClusterwideNetworkPolicy and
+// Calico NetworkPolicy/GlobalNetworkPolicy CRDs, needed by runNetworkPolicySubtests.
+// kubectl-status only reads and matches these objects client-side (selector-vs-Pod-labels), it
+// never relies on Cilium/Calico actually enforcing traffic, so the CRDs alone (no Cilium/Calico
+// installed as CNI) are enough to exercise the e2e scenarios -- same "CRDs only" reasoning as
+// cert-manager/Gateway API above. Calico's own NetworkPolicy/GlobalNetworkPolicy are served
+// under crd.projectcalico.org/v1 (the Kubernetes-datastore storage CRDs), not the
+// projectcalico.org/v3 API calicoctl/the Calico API server present -- that's the group
+// kubectl-status's KubeGetCalico*MatchingPod helpers query. --server-side: these CRDs' embedded
+// OpenAPI schemas are large enough to trip the same client-side last-applied-configuration
+// annotation limit as HTTPRoute above.
+func ensureCiliumCalicoCRDs(t *testing.T) {
+	t.Helper()
+	ciliumCalicoCRDsInstaller.ensure(t, func() error {
+		urls := []string{
+			"https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml",
+			"https://raw.githubusercontent.com/cilium/cilium/v1.19.5/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml",
+			"https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/crds.yaml",
+		}
+		for _, url := range urls {
+			output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("kubectl apply %s: %w: %s", url, err, output)
+			}
+		}
+		return nil
+	})
+}
+
+var vpaInstaller onceInstaller
+
+// ensureVPA installs VerticalPodAutoscaler, needed by TestE2EDynamicManifests' VPA subtest.
+// Unlike the CRD-only installers above, that scenario exercises it actually acting (the updater
+// evicting/recreating a Pod to apply a recommendation), so its controllers (recommender/updater/
+// admission-controller) need to run for real, not just the CRDs. The upstream project has no
+// plain `kubectl apply` release bundle (its install script generates webhook certs locally), so
+// this uses the cowboysysop community Helm chart instead.
+func ensureVPA(t *testing.T) {
+	t.Helper()
+	vpaInstaller.ensure(t, func() error {
+		if output, err := exec.Command("helm", "repo", "add", "cowboysysop", "https://cowboysysop.github.io/charts/").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm repo add cowboysysop: %w: %s", err, output)
+		}
+		if output, err := exec.Command("helm", "repo", "update", "cowboysysop").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm repo update cowboysysop: %w: %s", err, output)
+		}
+		if output, err := exec.Command("helm", "upgrade", "--install", "vpa", "cowboysysop/vertical-pod-autoscaler",
+			"--version", "11.1.1", "-n", "kube-system", "--wait", "--timeout", "5m").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm upgrade vpa: %w: %s", err, output)
+		}
+		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=120s",
+			"deployment", "-l", "app.kubernetes.io/instance=vpa", "-n", "kube-system").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("kubectl wait vpa deployments: %w: %s", err, output)
+		}
+		return nil
+	})
+}
+
+var crossplaneInstaller onceInstaller
+
+// ensureCrossplane installs Crossplane core plus the two Composition Functions the e2e test
+// Composition needs, required by TestE2EDynamicManifests' Crossplane subtest. That scenario
+// exercises a real XR composing real children (a Composition Function renders them and derives
+// readiness), not just kubectl-status reading static CRDs, so Crossplane needs to actually
+// reconcile -- same "controller must actually run" reasoning as VPA above. No cloud provider is
+// installed: the test Composition composes plain in-cluster Kubernetes resources (ConfigMap/
+// Deployment), which Crossplane v2 supports natively. function-patch-and-transform renders the
+// test Composition's child resources, function-auto-ready derives the XR's readiness from them.
+// Their versions are pinned in the manifest itself (not hack/versions.env) since they're only
+// used here.
+func ensureCrossplane(t *testing.T) {
+	t.Helper()
+	crossplaneInstaller.ensure(t, func() error {
+		version, err := versionsEnvValue("CROSSPLANE_VERSION")
+		if err != nil {
+			return err
+		}
+		if output, err := exec.Command("helm", "repo", "add", "crossplane-stable", "https://charts.crossplane.io/stable").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm repo add crossplane-stable: %w: %s", err, output)
+		}
+		if output, err := exec.Command("helm", "repo", "update", "crossplane-stable").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm repo update crossplane-stable: %w: %s", err, output)
+		}
+		if output, err := exec.Command("helm", "upgrade", "--install", "crossplane", "crossplane-stable/crossplane",
+			"--version", version, "-n", "crossplane-system", "--create-namespace", "--wait", "--timeout", "5m").CombinedOutput(); err != nil {
+			return fmt.Errorf("helm upgrade crossplane: %w: %s", err, output)
+		}
+		functionsManifest := path.Join("..", "tests", "e2e-artifacts", "crossplane-functions.yaml")
+		if output, err := exec.Command("kubectl", "apply", "-f", functionsManifest).CombinedOutput(); err != nil {
+			return fmt.Errorf("kubectl apply %s: %w: %s", functionsManifest, err, output)
+		}
+		output, err := exec.Command("kubectl", "wait", "--for=condition=Healthy", "--timeout=180s",
+			"function.pkg.crossplane.io", "--all").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("kubectl wait crossplane functions: %w: %s", err, output)
+		}
+		return nil
+	})
 }

--- a/cmd/e2e_networkpolicy_test.go
+++ b/cmd/e2e_networkpolicy_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset, dynamicClient dynamic.Interface) {
+	ensureCiliumCalicoCRDs(t)
 	t.Run("pod selected by a NetworkPolicy surfaces the compact isolation signal", func(t *testing.T) {
 		t.Parallel()
 		// A dedicated namespace keeps this test in control of exactly which NetworkPolicy

--- a/cmd/e2e_service_routing_test.go
+++ b/cmd/e2e_service_routing_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
+	ensureGatewayAPICRDs(t)
 	t.Run("sts-with-ingress", func(t *testing.T) {
 		t.Parallel()
 		opts := combineOpts(hackOpts, viperTestHackOpts())

--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
+	ensureCertManager(t)
+	ensureGatewayAPICRDs(t)
 	t.Run("tls-validation", func(t *testing.T) {
 		t.Parallel()
 		// Builds a real cert-manager CA chain (self-signed root -> ca-type Issuer -> leaf


### PR DESCRIPTION
## Summary
- cert-manager, Gateway API CRDs, Cilium/Calico CRDs, VPA, and Crossplane no longer install unconditionally via `make install-e2e-deps` -- each now installs lazily, exactly once, from whichever topical e2e test group(s) actually need it (`sync.Once`-guarded `ensure*(t)` functions in `cmd/e2e_helpers_test.go`), deduped for Gateway API CRDs which both service-routing and tls-validation depend on.
- metrics-server stays a global `install-e2e-deps` step: its availability is an invariant for `TestE2EParallel`'s whole pool (a `pdb-empty-selector-conflict` subtest can otherwise render a spurious "metrics-server is not available" line), not a per-group concern.
- Versions (cert-manager, Gateway API, Crossplane) are parsed from `hack/versions.env` at test time instead of via Make variable substitution.

Fixes #720

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `make test-e2e` passed cleanly end-to-end against a fresh isolated minikube cluster (confirming each topical group's `ensure*` install actually fires and installs only what that group needs)
- [x] Rebased cleanly onto latest master
- Note: two subsequent pre-push `make test-e2e` re-runs hit unrelated infra flakiness on this host (disk I/O contention causing transient minikube apiserver connection blips, and a known metrics-server-scrape-timing flake tracked separately in #724) -- not failures in this change's logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)