### PR TITLE
Add Crossplane managed-resource drift detection

### DIFF
--- a/pkg/plugin/crossplanedrift/crossplanedrift.go
+++ b/pkg/plugin/crossplanedrift/crossplanedrift.go
@@ -1,0 +1,314 @@
+// Package crossplanedrift computes a leaf-field comparison between a Crossplane managed
+// resource's desired configuration (spec.forProvider) and the provider-observed external state
+// (status.atProvider).
+//
+// status.atProvider is commonly a superset of spec.forProvider: it carries provider-observed
+// values including API-defaulted fields, and Crossplane may late-initialize desired fields back
+// into spec.forProvider. Observe-only imports also populate status.atProvider before a resource
+// is fully managed. Because of this, the comparison is deliberately one-directional and
+// conservative: it only walks the leaf paths configured in spec.forProvider and looks up the
+// matching path in status.atProvider, rather than performing a symmetric recursive equality
+// check that would flag every provider-defaulted field as spurious drift.
+package crossplanedrift
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Class classifies a single configured leaf path.
+type Class int
+
+const (
+	// InSync means the configured and observed values are equal after normalization.
+	InSync Class = iota
+	// Drift means the configured and observed values differ after normalization.
+	Drift
+	// NotObserved means the configured path has no corresponding entry in status.atProvider.
+	NotObserved
+)
+
+// Entry is a single compared leaf path from spec.forProvider.
+type Entry struct {
+	Path     string
+	Desired  interface{}
+	Observed interface{}
+	Class    Class
+	Redacted bool
+}
+
+// Result is the outcome of comparing spec.forProvider against status.atProvider.
+type Result struct {
+	// Eligible is true when both forProvider and atProvider are non-empty maps, i.e. this
+	// object looks like a Crossplane managed resource with at least one observation.
+	Eligible bool
+	// TotalConfigured is the number of leaf paths found under spec.forProvider.
+	TotalConfigured  int
+	InSyncCount      int
+	NotObservedCount int
+	// DriftEntries holds only the entries classified as Drift, sorted by path, redacted, and
+	// bounded to maxDriftEntries (with Truncated/MoreCount reporting what was cut).
+	DriftEntries []Entry
+	Truncated    bool
+	MoreCount    int
+	// ObservedOnlyCount is the number of leaf paths present under status.atProvider that have
+	// no corresponding leaf path under spec.forProvider (provider-defaulted/computed fields).
+	ObservedOnlyCount int
+}
+
+// maxDriftEntries bounds rendered drift entries so an object with a pathologically large
+// forProvider payload can't dump an unbounded amount of output.
+const maxDriftEntries = 20
+
+// sensitivePathComponents marks path components that must have their values redacted before
+// display. Matching is case-insensitive substring containment against each dot-separated path
+// component, e.g. "dbPassword" or "spec.forProvider.auth.password" both match "password".
+var sensitivePathComponents = []string{"password", "secret", "token", "privatekey", "accesskey", "credential"}
+
+// Diff compares spec.forProvider against status.atProvider and returns the classified leaf
+// paths. forProvider/atProvider are expected to be the raw unstructured map values (as decoded
+// by k8s.io/apimachinery/pkg/apis/meta/v1/unstructured), or nil if absent.
+func Diff(forProvider, atProvider map[string]interface{}) Result {
+	if len(forProvider) == 0 || len(atProvider) == 0 {
+		return Result{Eligible: false}
+	}
+
+	desiredLeaves := walkLeaves("", forProvider)
+	observedLeaves := walkLeaves("", atProvider)
+	observedByPath := make(map[string]interface{}, len(observedLeaves))
+	for _, l := range observedLeaves {
+		observedByPath[l.path] = l.value
+	}
+	desiredPaths := make(map[string]struct{}, len(desiredLeaves))
+	for _, l := range desiredLeaves {
+		desiredPaths[l.path] = struct{}{}
+	}
+
+	result := Result{Eligible: true, TotalConfigured: len(desiredLeaves)}
+
+	var driftEntries []Entry
+	for _, l := range desiredLeaves {
+		observed, found := observedByPath[l.path]
+		switch {
+		case !found:
+			result.NotObservedCount++
+		case valuesEqual(l.value, observed):
+			result.InSyncCount++
+		default:
+			driftEntries = append(driftEntries, redactEntry(Entry{
+				Path:     l.path,
+				Desired:  l.value,
+				Observed: observed,
+				Class:    Drift,
+			}))
+		}
+	}
+	sort.Slice(driftEntries, func(i, j int) bool { return driftEntries[i].Path < driftEntries[j].Path })
+
+	if len(driftEntries) > maxDriftEntries {
+		result.MoreCount = len(driftEntries) - maxDriftEntries
+		result.Truncated = true
+		driftEntries = driftEntries[:maxDriftEntries]
+	}
+	result.DriftEntries = driftEntries
+
+	for path := range observedByPath {
+		if _, ok := desiredPaths[path]; !ok {
+			result.ObservedOnlyCount++
+		}
+	}
+
+	return result
+}
+
+func redactEntry(e Entry) Entry {
+	if !pathIsSensitive(e.Path) {
+		return e
+	}
+	e.Desired = "REDACTED"
+	e.Observed = "REDACTED"
+	e.Redacted = true
+	return e
+}
+
+func pathIsSensitive(path string) bool {
+	for _, component := range strings.Split(path, ".") {
+		lower := strings.ToLower(component)
+		for _, marker := range sensitivePathComponents {
+			if strings.Contains(lower, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type leaf struct {
+	path  string
+	value interface{}
+}
+
+// walkLeaves recurses through non-empty nested maps, treating any non-map value (including
+// lists, scalars, and empty maps) as a leaf. Lists are intentionally not recursed into: list
+// equality is handled as a single comparison by valuesEqual, since providers commonly use
+// different orderings/schemas for lists of objects that generic key-based matching can't
+// reliably reconcile.
+func walkLeaves(prefix string, v interface{}) []leaf {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return []leaf{{path: prefix, value: v}}
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var leaves []leaf
+	for _, k := range keys {
+		childPath := k
+		if prefix != "" {
+			childPath = prefix + "." + k
+		}
+		leaves = append(leaves, walkLeaves(childPath, m[k])...)
+	}
+	return leaves
+}
+
+// valuesEqual implements the normalized comparison: numeric JSON representations are equal
+// regardless of int/float encoding, maps are compared unordered, and lists follow the
+// conservative rules documented on the package: scalar lists without duplicates compare as
+// sets, everything else (lists containing duplicates, or containing maps/lists) compares by
+// position. Type differences that are semantically meaningful, e.g. the string "1" versus the
+// number 1, are preserved as inequality.
+func valuesEqual(a, b interface{}) bool {
+	af, aIsNum := asFloat64(a)
+	bf, bIsNum := asFloat64(b)
+	if aIsNum || bIsNum {
+		return aIsNum && bIsNum && af == bf
+	}
+
+	am, aIsMap := a.(map[string]interface{})
+	bm, bIsMap := b.(map[string]interface{})
+	if aIsMap || bIsMap {
+		if !aIsMap || !bIsMap || len(am) != len(bm) {
+			return false
+		}
+		for k, av := range am {
+			bv, ok := bm[k]
+			if !ok || !valuesEqual(av, bv) {
+				return false
+			}
+		}
+		return true
+	}
+
+	as, aIsSlice := a.([]interface{})
+	bs, bIsSlice := b.([]interface{})
+	if aIsSlice || bIsSlice {
+		if !aIsSlice || !bIsSlice {
+			return false
+		}
+		return listsEqual(as, bs)
+	}
+
+	return a == b
+}
+
+func listsEqual(a, b []interface{}) bool {
+	if isScalarListNoDuplicates(a) && isScalarListNoDuplicates(b) {
+		return scalarSetsEqual(a, b)
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !valuesEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isScalarListNoDuplicates(list []interface{}) bool {
+	seen := make(map[string]struct{}, len(list))
+	for _, v := range list {
+		switch v.(type) {
+		case map[string]interface{}, []interface{}:
+			return false
+		}
+		key := scalarSetKey(v)
+		if _, ok := seen[key]; ok {
+			return false
+		}
+		seen[key] = struct{}{}
+	}
+	return true
+}
+
+// scalarSetKey builds a dedup/membership key that treats numeric values the same way valuesEqual
+// does (1 and 1.0 key the same regardless of int/float encoding), while keeping non-numeric types
+// distinguished by their Go type so e.g. the string "1" and the number 1 get different keys.
+func scalarSetKey(v interface{}) string {
+	if f, ok := asFloat64(v); ok {
+		return fmt.Sprintf("number:%v", f)
+	}
+	return fmt.Sprintf("%T:%v", v, v)
+}
+
+func scalarSetsEqual(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	bSet := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		bSet[scalarSetKey(v)] = struct{}{}
+	}
+	for _, v := range a {
+		if _, ok := bSet[scalarSetKey(v)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Label picks the operator-facing wording for a non-empty drift result: an Observe-only managed
+// resource reads as an expected "Observed difference" (Crossplane isn't reconciling it), a
+// Synced=False resource reads as the stronger "Drift" signal (a reconcile failure, not just a
+// provider-side observation lag), and anything else (typically Synced=True) reads as the
+// unsurprising "Observed difference" case where the provider may still reconcile it. annotation
+// is an optional parenthetical with more detail, empty when the plain label needs no elaboration.
+func Label(syncedStatus string, managementPolicies []interface{}) (label string, annotation string) {
+	if isObserveOnly(managementPolicies) {
+		return "Observed difference", "Observe-only; Crossplane will not correct them"
+	}
+	if syncedStatus == "False" {
+		return "Drift", "reconcile failure; inspect Synced condition"
+	}
+	return "Observed difference", ""
+}
+
+func isObserveOnly(managementPolicies []interface{}) bool {
+	if len(managementPolicies) != 1 {
+		return false
+	}
+	policy, _ := managementPolicies[0].(string)
+	return policy == "Observe"
+}
+
+func asFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/plugin/crossplanedrift/crossplanedrift_test.go
+++ b/pkg/plugin/crossplanedrift/crossplanedrift_test.go
@@ -1,0 +1,239 @@
+package crossplanedrift
+
+import (
+	"testing"
+)
+
+func driftPaths(entries []Entry) []string {
+	paths := make([]string, len(entries))
+	for i, e := range entries {
+		paths[i] = e.Path
+	}
+	return paths
+}
+
+func TestDiff_NotEligible(t *testing.T) {
+	tests := []struct {
+		name        string
+		forProvider map[string]interface{}
+		atProvider  map[string]interface{}
+	}{
+		{"both nil", nil, nil},
+		{"empty forProvider", map[string]interface{}{}, map[string]interface{}{"region": "eu-west-1"}},
+		{"empty atProvider", map[string]interface{}{"region": "eu-west-1"}, map[string]interface{}{}},
+		{"nil atProvider", map[string]interface{}{"region": "eu-west-1"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Diff(tt.forProvider, tt.atProvider)
+			if result.Eligible {
+				t.Errorf("Diff() Eligible = true, want false")
+			}
+		})
+	}
+}
+
+func TestDiff_EqualScalarAndNestedMap(t *testing.T) {
+	forProvider := map[string]interface{}{
+		"region": "eu-west-1",
+		"tags":   map[string]interface{}{"environment": "production"},
+	}
+	atProvider := map[string]interface{}{
+		"region": "eu-west-1",
+		"tags":   map[string]interface{}{"environment": "production"},
+		"arn":    "arn:aws:ec2:...", // extra observed-only field
+	}
+	result := Diff(forProvider, atProvider)
+	if !result.Eligible {
+		t.Fatalf("Diff() Eligible = false, want true")
+	}
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none", result.DriftEntries)
+	}
+	if result.InSyncCount != 2 {
+		t.Errorf("InSyncCount = %d, want 2", result.InSyncCount)
+	}
+}
+
+func TestDiff_DifferingScalar(t *testing.T) {
+	forProvider := map[string]interface{}{"region": "eu-west-1"}
+	atProvider := map[string]interface{}{"region": "us-east-1"}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 1 {
+		t.Fatalf("DriftEntries = %v, want 1 entry", result.DriftEntries)
+	}
+	e := result.DriftEntries[0]
+	if e.Path != "region" || e.Desired != "eu-west-1" || e.Observed != "us-east-1" {
+		t.Errorf("DriftEntries[0] = %+v, want region eu-west-1 -> us-east-1", e)
+	}
+}
+
+func TestDiff_ExtraObservedFieldsNoDrift(t *testing.T) {
+	forProvider := map[string]interface{}{"region": "eu-west-1"}
+	atProvider := map[string]interface{}{"region": "eu-west-1", "vpcId": "vpc-123", "createdAt": "2024-01-01"}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none", result.DriftEntries)
+	}
+	if result.ObservedOnlyCount != 2 {
+		t.Errorf("ObservedOnlyCount = %d, want 2", result.ObservedOnlyCount)
+	}
+}
+
+func TestDiff_ConfiguredFieldAbsentFromObserved(t *testing.T) {
+	forProvider := map[string]interface{}{"region": "eu-west-1", "cidrBlock": "10.0.0.0/16"}
+	atProvider := map[string]interface{}{"region": "eu-west-1"}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none (absent path is NotObserved, not Drift)", result.DriftEntries)
+	}
+	if result.NotObservedCount != 1 {
+		t.Errorf("NotObservedCount = %d, want 1", result.NotObservedCount)
+	}
+}
+
+func TestDiff_MapKeyOrderingDoesNotMatter(t *testing.T) {
+	forProvider := map[string]interface{}{
+		"tags": map[string]interface{}{"a": "1", "b": "2", "c": "3"},
+	}
+	atProvider := map[string]interface{}{
+		"tags": map[string]interface{}{"c": "3", "a": "1", "b": "2"},
+	}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none", result.DriftEntries)
+	}
+}
+
+func TestDiff_ScalarListOrderingIsSetCompared(t *testing.T) {
+	forProvider := map[string]interface{}{"zones": []interface{}{"a", "b", "c"}}
+	atProvider := map[string]interface{}{"zones": []interface{}{"c", "b", "a"}}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none (scalar list without duplicates compares as a set)", result.DriftEntries)
+	}
+}
+
+func TestDiff_ScalarListSetComparisonNormalizesNumbers(t *testing.T) {
+	forProvider := map[string]interface{}{"ports": []interface{}{int64(1), int64(2)}}
+	atProvider := map[string]interface{}{"ports": []interface{}{float64(2), float64(1)}}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none (int64/float64 encodings of the same numbers must match in set comparison)", result.DriftEntries)
+	}
+}
+
+func TestDiff_ScalarListWithDuplicatesComparesOrdered(t *testing.T) {
+	forProvider := map[string]interface{}{"zones": []interface{}{"a", "a", "b"}}
+	atProvider := map[string]interface{}{"zones": []interface{}{"a", "b", "a"}}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 1 {
+		t.Fatalf("DriftEntries = %v, want 1 entry (duplicates disable set semantics)", result.DriftEntries)
+	}
+}
+
+func TestDiff_ObjectListOrderingIsPositional(t *testing.T) {
+	forProvider := map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{"port": int64(80)},
+			map[string]interface{}{"port": int64(443)},
+		},
+	}
+	atProvider := map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{"port": int64(443)},
+			map[string]interface{}{"port": int64(80)},
+		},
+	}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 1 {
+		t.Fatalf("DriftEntries = %v, want 1 entry (object lists compare positionally, not by key matching)", result.DriftEntries)
+	}
+	if result.DriftEntries[0].Path != "rules" {
+		t.Errorf("DriftEntries[0].Path = %q, want %q", result.DriftEntries[0].Path, "rules")
+	}
+}
+
+func TestDiff_SensitivePathIsRedacted(t *testing.T) {
+	forProvider := map[string]interface{}{
+		"auth": map[string]interface{}{"password": "hunter2", "accessKey": "AKIA..."},
+	}
+	atProvider := map[string]interface{}{
+		"auth": map[string]interface{}{"password": "different", "accessKey": "AKIB..."},
+	}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 2 {
+		t.Fatalf("DriftEntries = %v, want 2 entries", result.DriftEntries)
+	}
+	for _, e := range result.DriftEntries {
+		if !e.Redacted || e.Desired != "REDACTED" || e.Observed != "REDACTED" {
+			t.Errorf("entry %q not redacted: %+v", e.Path, e)
+		}
+	}
+}
+
+func TestDiff_TruncatesToBoundDeterministically(t *testing.T) {
+	forProvider := map[string]interface{}{}
+	atProvider := map[string]interface{}{}
+	for i := 0; i < 25; i++ {
+		key := "field" + string(rune('a'+i))
+		forProvider[key] = "desired"
+		atProvider[key] = "observed"
+	}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != maxDriftEntries {
+		t.Fatalf("len(DriftEntries) = %d, want %d", len(result.DriftEntries), maxDriftEntries)
+	}
+	if !result.Truncated || result.MoreCount != 5 {
+		t.Errorf("Truncated = %v, MoreCount = %d, want true, 5", result.Truncated, result.MoreCount)
+	}
+	paths := driftPaths(result.DriftEntries)
+	for i := 1; i < len(paths); i++ {
+		if paths[i-1] >= paths[i] {
+			t.Errorf("DriftEntries not sorted at index %d: %v", i, paths)
+			break
+		}
+	}
+}
+
+func TestDiff_NumericNormalization(t *testing.T) {
+	forProvider := map[string]interface{}{"count": int64(1)}
+	atProvider := map[string]interface{}{"count": float64(1.0)}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 0 {
+		t.Errorf("DriftEntries = %v, want none (1 and 1.0 are equal after normalization)", result.DriftEntries)
+	}
+}
+
+func TestLabel(t *testing.T) {
+	tests := []struct {
+		name               string
+		syncedStatus       string
+		managementPolicies []interface{}
+		wantLabel          string
+		wantAnnotation     string
+	}{
+		{"synced true, full control", "True", nil, "Observed difference", ""},
+		{"synced false", "False", nil, "Drift", "reconcile failure; inspect Synced condition"},
+		{"observe-only", "True", []interface{}{"Observe"}, "Observed difference", "Observe-only; Crossplane will not correct them"},
+		{"observe-only takes priority over synced false", "False", []interface{}{"Observe"}, "Observed difference", "Observe-only; Crossplane will not correct them"},
+		{"multiple policies is not observe-only", "True", []interface{}{"Observe", "Create"}, "Observed difference", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			label, annotation := Label(tt.syncedStatus, tt.managementPolicies)
+			if label != tt.wantLabel || annotation != tt.wantAnnotation {
+				t.Errorf("Label() = (%q, %q), want (%q, %q)", label, annotation, tt.wantLabel, tt.wantAnnotation)
+			}
+		})
+	}
+}
+
+func TestDiff_TypeSensitiveStringVersusNumber(t *testing.T) {
+	forProvider := map[string]interface{}{"count": "1"}
+	atProvider := map[string]interface{}{"count": int64(1)}
+	result := Diff(forProvider, atProvider)
+	if len(result.DriftEntries) != 1 {
+		t.Errorf("DriftEntries = %v, want 1 entry (string \"1\" and number 1 must differ)", result.DriftEntries)
+	}
+}

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/bergerx/kubectl-status/pkg/plugin/calicoselector"
+	"github.com/bergerx/kubectl-status/pkg/plugin/crossplanedrift"
 )
 
 // RenderConfig carries the per-invocation configuration and time/duration hooks that template
@@ -138,6 +139,8 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"parseServiceAccountTokenSecret": parseServiceAccountTokenSecret,
 		"parseBootstrapTokenSecret":      cfg.parseBootstrapTokenSecret,
 		"secretDataKeys":                 secretDataKeys,
+		"crossplaneManagedResourceDrift": crossplaneManagedResourceDrift,
+		"crossplaneDriftLabel":           crossplaneDriftLabel,
 	}
 }
 
@@ -912,6 +915,28 @@ func calicoNamespaceSelectorMatches(spec map[string]interface{}, namespace strin
 	}
 	augmented["projectcalico.org/name"] = namespace
 	return sel.Evaluate(augmented)
+}
+
+// crossplaneManagedResourceDrift compares a Crossplane managed resource's desired
+// spec.forProvider configuration against its observed status.atProvider, see
+// pkg/plugin/crossplanedrift for the comparison semantics. forProvider/atProvider are expected
+// to be untyped map values as decoded off the unstructured object (nil/non-map is treated as
+// absent).
+func crossplaneManagedResourceDrift(forProvider, atProvider interface{}) crossplanedrift.Result {
+	fp, _ := forProvider.(map[string]interface{})
+	ap, _ := atProvider.(map[string]interface{})
+	return crossplanedrift.Diff(fp, ap)
+}
+
+// crossplaneDriftLabel picks the operator-facing label/annotation for a non-empty drift result;
+// see crossplanedrift.Label. syncedStatus is the managed resource's Synced condition ".status"
+// value ("True"/"False"/"" if the condition is absent); managementPolicies is the untyped
+// spec.managementPolicies list value (nil if absent, meaning full-control/default). Returns a
+// dict with "Label" and "Annotation" keys for easy template consumption.
+func crossplaneDriftLabel(syncedStatus string, managementPolicies interface{}) map[string]string {
+	policies, _ := managementPolicies.([]interface{})
+	label, annotation := crossplanedrift.Label(syncedStatus, policies)
+	return map[string]string{"Label": label, "Annotation": annotation}
 }
 
 func withCalicoNamespaceLabel(podLabels map[string]string, namespace string) map[string]string {

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -8,6 +8,7 @@
     {{- template "replicas_status" . }}
     {{- template "suspended" . }}
     {{- template "crossplane_composed_resources" . }}
+    {{- template "crossplane_managed_resource_drift" . }}
     {{- template "conditions_summary" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
@@ -248,6 +249,42 @@
                 {{- if $obj.Object }}
                     {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ with .Message }}: {{ . }}{{ end }}{{ end }}
                 {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "crossplane_managed_resource_drift" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Eligibility: a non-empty spec.forProvider is the signal that this is a Crossplane
+           managed resource (no other Kubernetes object populates that path). A missing/empty
+           status.atProvider then means the resource hasn't been observed yet, rather than that
+           it's ineligible. See pkg/plugin/crossplanedrift for the comparison semantics. */ -}}
+    {{- $forProvider := .Spec.forProvider }}
+    {{- if and (kindIs "map" $forProvider) $forProvider }}
+        {{- $atProvider := .Status.atProvider }}
+        {{- if not (and (kindIs "map" $atProvider) $atProvider) }}
+            {{- "Drift" | bold | nindent 2 }}: unavailable; {{ "status.atProvider" | cyan }} has not been observed yet
+        {{- else }}
+            {{- $result := crossplaneManagedResourceDrift $forProvider $atProvider }}
+            {{- $syncedStatus := "" }}
+            {{- with getMatchingItemInMapList (dict "type" "Synced") .StatusConditions }}{{ $syncedStatus = .status }}{{ end }}
+            {{- $labeled := crossplaneDriftLabel $syncedStatus .Spec.managementPolicies }}
+            {{- if eq (len $result.DriftEntries) 0 }}
+                {{- "Drift" | bold | nindent 2 }}: none across {{ $result.TotalConfigured }} configured fields
+            {{- else if $.Config.GetBool "deep" }}
+                {{- $labeled.Label | bold | nindent 2 }} (`spec.forProvider` -> `status.atProvider`){{ with $labeled.Annotation }}, {{ . | yellow }}{{ end }}:
+                {{- range $result.DriftEntries }}
+                    {{- printf "%s: %s -> %s" .Path (.Desired | toJson) (.Observed | toJson) | nindent 4 }}
+                {{- end }}
+                {{- with $result.MoreCount }}
+                    {{- printf "… %d more" . | nindent 4 }}
+                {{- end }}
+                {{- with $result.ObservedOnlyCount }}
+                    {{- printf "Observed-only fields: %d (hidden; provider defaults/computed state)" . | nindent 4 }}
+                {{- end }}
+            {{- else }}
+                {{- $labeled.Label | bold | nindent 2 }}: {{ printf "%d configured fields differ from observed state" (len $result.DriftEntries) | redBoldIf true }}{{ with $labeled.Annotation }} ({{ . | yellow }}){{ end }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -646,3 +646,105 @@ func renderConfigzSummary(t *testing.T, configz map[string]interface{}) string {
 	}
 	return got
 }
+
+func managedResourceObj(forProvider, atProvider map[string]interface{}) map[string]interface{} {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "checkout-network"},
+		"spec":     map[string]interface{}{},
+		"status":   map[string]interface{}{},
+	}
+	if forProvider != nil {
+		obj["spec"].(map[string]interface{})["forProvider"] = forProvider
+	}
+	if atProvider != nil {
+		obj["status"].(map[string]interface{})["atProvider"] = atProvider
+	}
+	return obj
+}
+
+func TestManagedResourceDriftTemplate_NotAManagedResource(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "some-deployment"},
+		"spec":     map[string]interface{}{"replicas": float64(1)},
+	}
+	got, err := renderManagedResourceDrift(t, obj, viper.New())
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected no drift output for a non-managed-resource object, got = %q", got)
+	}
+}
+
+func TestManagedResourceDriftTemplate_NotYetObserved(t *testing.T) {
+	obj := managedResourceObj(map[string]interface{}{"region": "eu-west-1"}, nil)
+	got, err := renderManagedResourceDrift(t, obj, viper.New())
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "has not been observed yet") {
+		t.Errorf("got = %q, want a not-yet-observed message", got)
+	}
+}
+
+func TestManagedResourceDriftTemplate_InSync(t *testing.T) {
+	obj := managedResourceObj(
+		map[string]interface{}{"region": "eu-west-1"},
+		map[string]interface{}{"region": "eu-west-1"},
+	)
+	got, err := renderManagedResourceDrift(t, obj, viper.New())
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Drift: none across 1 configured fields") {
+		t.Errorf("got = %q, want an in-sync summary", got)
+	}
+}
+
+func TestManagedResourceDriftTemplate_DefaultDepthSummary(t *testing.T) {
+	obj := managedResourceObj(
+		map[string]interface{}{"region": "eu-west-1"},
+		map[string]interface{}{"region": "us-east-1"},
+	)
+	got, err := renderManagedResourceDrift(t, obj, viper.New())
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Observed difference: 1 configured fields differ from observed state") {
+		t.Errorf("got = %q, want the compact drift count", got)
+	}
+	if strings.Contains(got, "eu-west-1") {
+		t.Errorf("got = %q, default depth must not print field-level values", got)
+	}
+}
+
+func TestManagedResourceDriftTemplate_DeepShowsFieldDiff(t *testing.T) {
+	v := viper.New()
+	v.Set("deep", true)
+	obj := managedResourceObj(
+		map[string]interface{}{"region": "eu-west-1"},
+		map[string]interface{}{"region": "us-east-1"},
+	)
+	got, err := renderManagedResourceDrift(t, obj, v)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, `region: "eu-west-1" -> "us-east-1"`) {
+		t.Errorf("got = %q, want the field-level diff line", got)
+	}
+}
+
+func renderManagedResourceDrift(t *testing.T, obj map[string]interface{}, v *viper.Viper) (string, error) {
+	t.Helper()
+	cfg := NewRenderConfig(v)
+	tmpl, _ := getTemplate(cfg)
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f, cfg.Viper)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	r := newRenderableObject(obj, e, repo)
+	return r.renderTemplate("crossplane_managed_resource_drift", r)
+}

--- a/tests/artifacts/crossplane-managed-resource-drift.out
+++ b/tests/artifacts/crossplane-managed-resource-drift.out
@@ -1,0 +1,6 @@
+
+VPC/checkout-network, created 1m ago, gen:2
+  Current: Resource is Ready
+  Observed difference: 2 configured fields differ from observed state
+  Synced ReconcileSuccess for 1m
+  Ready Available for 1m

--- a/tests/artifacts/crossplane-managed-resource-drift.yaml
+++ b/tests/artifacts/crossplane-managed-resource-drift.yaml
@@ -1,0 +1,36 @@
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  creationTimestamp: "2026-06-01T10:00:00Z"
+  finalizers:
+  - finalizer.managedresource.crossplane.io
+  generation: 2
+  name: checkout-network
+  resourceVersion: "1330976"
+  uid: be814fad-43ba-4d86-bc5a-f4fb471af6ae
+spec:
+  forProvider:
+    region: eu-west-1
+    cidrBlock: 10.0.0.0/16
+    tags:
+      environment: production
+  managementPolicies:
+  - "*"
+status:
+  observedGeneration: 2
+  conditions:
+  - lastTransitionTime: "2026-06-01T10:05:00Z"
+    reason: ReconcileSuccess
+    status: "True"
+    type: Synced
+  - lastTransitionTime: "2026-06-01T10:05:00Z"
+    reason: Available
+    status: "True"
+    type: Ready
+  atProvider:
+    arn: arn:aws:ec2:eu-west-1:123456789012:vpc/vpc-0123456789abcdef0
+    id: vpc-0123456789abcdef0
+    region: us-east-1
+    cidrBlock: 10.0.0.0/16
+    tags:
+      environment: staging


### PR DESCRIPTION
## Summary
- Compares a Crossplane managed resource's desired `spec.forProvider` against its provider-observed `status.atProvider`, walking configured leaf paths only (never treating provider-defaulted/computed extras in `status.atProvider` as drift).
- Compact summary by default (`Drift: N configured fields differ from observed state`), full field-level diff under `--deep` (`path: "desired" -> "observed"`), with secret-like paths redacted and output bounded/deterministically truncated.
- Drift line label switches between `Observed difference` (Synced=True, or Observe-only management policy) and `Drift` (Synced=False), per issue #721's severity table.
- Core comparison logic lives in a new standalone `pkg/plugin/crossplanedrift` package (pure functions, no `RenderableObject` dependency), mirroring the existing `calicoselector` package pattern.

Closes #721

## Test plan
- [x] `pkg/plugin/crossplanedrift`: 24 unit tests covering the comparison matrix from the issue (equal/differing scalars, nested maps, map-key ordering, scalar-list set semantics incl. numeric normalization, duplicate-list ordering, object-list positional comparison, redaction, truncation, numeric normalization, type-sensitive string-vs-number, and label/severity selection).
- [x] Template-level tests in `pkg/plugin/templates_common_test.go` covering non-eligible objects, not-yet-observed, in-sync, default-depth summary, and `--deep` field diff rendering.
- [x] New static fixture `tests/artifacts/crossplane-managed-resource-drift.yaml` + golden `.out`, covered by the existing offline `TestAllArtifactsLocal` harness.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [ ] Minikube e2e coverage for a managed-resource-shaped composed child was intentionally descoped for this PR (agreed with issue author) in favor of the static fixture + unit/template tests above.