### PR TITLE
Fetch and surface PriorityClass referenced by Pod

### DIFF
--- a/cmd/e2e_pod_scheduling_test.go
+++ b/cmd/e2e_pod_scheduling_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -204,6 +205,51 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		cmdTest{
 			args:            []string{"pod/pod-with-runtimeclass-overhead", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-with-runtimeclass-overhead.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("pod's priorityClassName resolves to the PriorityClass and surfaces value/globalDefault/preemptionPolicy", func(t *testing.T) {
+		t.Parallel()
+		opts := combineOpts(viperTestHackOpts())
+		ns := "e2e-pod-priorityclass"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		// A minikube cluster has no globalDefault PriorityClass out of the box, so setting it here
+		// is safe: it won't clash with any other PriorityClass in the (parallel) test pool.
+		never := corev1.PreemptNever
+		pc := &schedulingv1.PriorityClass{
+			ObjectMeta:       metav1.ObjectMeta{Name: "e2e-test-priority"},
+			Value:            1000000,
+			GlobalDefault:    true,
+			PreemptionPolicy: &never,
+		}
+		_, err = clientset.SchedulingV1().PriorityClasses().Create(context.TODO(), pc, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.SchedulingV1().PriorityClasses().Delete(context.TODO(), pc.Name, metav1.DeleteOptions{})
+		})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-priorityclass",
+				Namespace: ns,
+			},
+			Spec: corev1.PodSpec{
+				PriorityClassName: pc.Name,
+				Containers:        []corev1.Container{{Name: "app", Image: "busybox"}},
+			},
+		}
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.CoreV1().Pods(ns).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		cmdTest{
+			args:            []string{"pod/pod-with-priorityclass", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-with-priorityclass.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("workload's matching pod on a cordoned node surfaces a compact node-problem flag", func(t *testing.T) {

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -45,6 +45,7 @@
     {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" .Spec.serviceAccountName) }}
     {{- template "pod_init_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
+    {{- template "pod_priorityclass_summary" . }}
     {{- template "pod_runtimeclass_overhead" . }}
     {{- template "pod_ephemeral_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_volumes" . }}
@@ -174,6 +175,28 @@
             {{- else }}
                 {{- $pod.Include "container_status_summary" $containerStatusSummaryDict | nindent 4 }}
             {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "pod_priorityclass_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Resolves .spec.priorityClassName to its PriorityClass object and surfaces
+           value/globalDefault/preemptionPolicy -- these explain preemption/eviction order during
+           resource pressure but aren't fully visible on the Pod spec alone (spec.priority is just
+           the resolved numeric value, with no indication of default/preemption behavior). Silent
+           when there's no priorityClassName or no PriorityClass object. */ -}}
+    {{- with .Spec.priorityClassName }}
+        {{- $pc := $.KubeGetFirst "" "PriorityClass" . }}
+        {{- if $pc.Object }}
+            {{- $parts := list (printf "value: %s" ($pc.Object.value | toString | cyan)) }}
+            {{- if $pc.Object.globalDefault }}
+                {{- $parts = append $parts "global default" }}
+            {{- end }}
+            {{- if ne ($pc.Object.preemptionPolicy | default "PreemptLowerPriority") "PreemptLowerPriority" }}
+                {{- $parts = append $parts (printf "preemptionPolicy: %s" ($pc.Object.preemptionPolicy | colorKeyword)) }}
+            {{- end }}
+            {{- "Priority:" | bold | nindent 2 }} {{ template "resource_ref" (dict "kind" "PriorityClass" "name" .) }} ({{ join ", " $parts }})
         {{- end }}
     {{- end }}
 {{- end }}

--- a/tests/e2e-artifacts/pod-with-priorityclass.regex
+++ b/tests/e2e-artifacts/pod-with-priorityclass.regex
@@ -1,0 +1,1 @@
+Priority: PriorityClass/e2e-test-priority \(value: 1000000, global default, preemptionPolicy: Never\)


### PR DESCRIPTION
## Summary
- Resolve `.spec.priorityClassName` to its `PriorityClass` object and surface `value`/`globalDefault`/`preemptionPolicy` on `Pod.tmpl`, explaining preemption/eviction order during resource pressure that isn't otherwise visible from the Pod spec alone.
- Follows the existing `pod_runtimeclass_overhead` fetch-and-render pattern.

Closes #675

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./pkg/...` and `go test ./cmd/...` (non-e2e tier) pass
- [x] New live e2e subtest (`cmd/e2e_pod_scheduling_test.go`) against minikube: creates a real `PriorityClass` (value, globalDefault, non-default `preemptionPolicy`) and a Pod referencing it, asserts rendered output via `tests/e2e-artifacts/pod-with-priorityclass.regex` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)