### PR TITLE
crossplane: surface composition refs, management fields, and init/provider metadata

### DIFF
--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -7,8 +7,10 @@
     {{- template "application_details" . }}
     {{- template "replicas_status" . }}
     {{- template "suspended" . }}
+    {{- template "crossplane_composition_ref" . }}
     {{- template "crossplane_composed_resources" . }}
     {{- template "crossplane_managed_resource_drift" . }}
+    {{- template "crossplane_managed_resource_details" . }}
     {{- template "conditions_summary" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
@@ -208,6 +210,33 @@
     {{- end }}
 {{- end -}}
 
+{{- define "crossplane_composition_ref" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* A Crossplane composite resource (XR) or claim records which Composition it's bound to
+           in spec.compositionRef (v1, cluster-scoped XRs and their claims) or
+           spec.crossplane.compositionRef (v2, namespaced XRs). Neither path is set by any other
+           kind of object, so this is safe to invoke unconditionally from DefaultResource. */ -}}
+    {{- $ref := .Spec.compositionRef }}
+    {{- $revisionRef := .Spec.compositionRevisionRef }}
+    {{- $updatePolicy := .Spec.compositionUpdatePolicy }}
+    {{- $crossplane := .Spec.crossplane }}
+    {{- if kindIs "map" $crossplane }}
+        {{- with $crossplane.compositionRef }}{{ $ref = . }}{{ end }}
+        {{- with $crossplane.compositionRevisionRef }}{{ $revisionRef = . }}{{ end }}
+        {{- with $crossplane.compositionUpdatePolicy }}{{ $updatePolicy = . }}{{ end }}
+    {{- end }}
+    {{- $refIsValid := and (kindIs "map" $ref) (kindIs "string" $ref.name) }}
+    {{- $revisionRefIsValid := and (kindIs "map" $revisionRef) (kindIs "string" $revisionRef.name) }}
+    {{- if or $refIsValid $revisionRefIsValid $updatePolicy }}
+        {{- "Composition" | bold | nindent 2 }}:
+        {{- if $refIsValid }} {{ $ref.name | cyan }}{{ end }}
+        {{- if $revisionRefIsValid }}, revision {{ $revisionRef.name | cyan }}{{ end }}
+        {{- with $updatePolicy }}, update policy {{ . | redBoldIf (eq . "Manual") }}
+            {{- if eq . "Manual" }} (pinned; won't move to newer Composition revisions automatically){{ end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- define "crossplane_composed_resources" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* A Crossplane composite resource (XR) lists the resources it composes in
@@ -288,6 +317,50 @@
                         {{- printf "Observed-only fields: %d (hidden; provider defaults/computed state)" . | nindent 4 }}
                     {{- end }}
                 {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "crossplane_managed_resource_details" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Eligibility mirrors crossplane_managed_resource_drift: a non-empty spec.forProvider is
+           the signal that this is a Crossplane managed resource. Surfaces the operationally
+           high-signal external-name/composition-resource-name/external-create annotations and the
+           providerConfigRef/managementPolicies/initProvider spec fields, all only when present so
+           non-Crossplane resources and vanilla managed resources without these fields set stay
+           quiet. */ -}}
+    {{- $forProvider := .Spec.forProvider }}
+    {{- if and (kindIs "map" $forProvider) $forProvider }}
+        {{- $annotations := .Annotations }}
+        {{- with get $annotations "crossplane.io/external-name" }}
+            {{- "External name" | bold | nindent 2 }}: {{ . | cyan }}
+        {{- end }}
+        {{- with get $annotations "crossplane.io/composition-resource-name" }}
+            {{- "Composition resource name" | bold | nindent 2 }}: {{ . | cyan }}
+        {{- end }}
+        {{- $pending := get $annotations "crossplane.io/external-create-pending" }}
+        {{- $succeeded := get $annotations "crossplane.io/external-create-succeeded" }}
+        {{- if $pending }}
+            {{- if not $succeeded }}
+                {{- "External create" | red | bold | nindent 2 }}: pending since {{ $pending | colorAgo }}{{ agoSuffix }}, {{ "external-create-succeeded not set yet" | yellow }}
+            {{- else }}
+                {{- $pendingAt := $pending | toDate "2006-01-02T15:04:05Z" }}
+                {{- $succeededAt := $succeeded | toDate "2006-01-02T15:04:05Z" }}
+                {{- "External create" | bold | nindent 2 }}: succeeded, took {{ ($succeededAt.Sub $pendingAt) | colorDuration }}
+            {{- end }}
+        {{- end }}
+        {{- with .Spec.providerConfigRef }}
+            {{- "ProviderConfig" | bold | nindent 2 }}: {{ .kind | default "ProviderConfig" | cyan }}/{{ .name | cyan }}
+        {{- end }}
+        {{- $policies := .Spec.managementPolicies }}
+        {{- if kindIs "slice" $policies }}
+            {{- $isFullControl := and (eq (len $policies) 1) (eq (index $policies 0) "*") }}
+            {{- "Management policies" | bold | nindent 2 }}: {{ if $isFullControl }}{{ "* (full control)" | cyan }}{{ else }}{{ $policies | join ", " | yellow }}{{ end }}
+        {{- end }}
+        {{- with .Spec.initProvider }}
+            {{- if kindIs "map" . }}
+                {{- "initProvider" | bold | nindent 2 }}: {{ keys . | sortAlpha | join ", " | cyan }} (applied only at creation time)
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -228,9 +228,10 @@
     {{- $refIsValid := and (kindIs "map" $ref) (kindIs "string" $ref.name) }}
     {{- $revisionRefIsValid := and (kindIs "map" $revisionRef) (kindIs "string" $revisionRef.name) }}
     {{- if or $refIsValid $revisionRefIsValid $updatePolicy }}
-        {{- "Composition" | bold | nindent 2 }}:
-        {{- if $refIsValid }} {{ $ref.name | cyan }}{{ end }}
-        {{- if $revisionRefIsValid }}, revision {{ $revisionRef.name | cyan }}{{ end }}
+        {{- if $refIsValid }}
+            {{- $.Include "resource_ref" (dict "kind" "Composition" "name" $ref.name) | nindent 2 }}
+        {{- end }}
+        {{- if $revisionRefIsValid }}, revision {{ $.Include "resource_ref" (dict "kind" "CompositionRevision" "name" $revisionRef.name) }}{{ end }}
         {{- with $updatePolicy }}, update policy {{ . | redBoldIf (eq . "Manual") }}
             {{- if eq . "Manual" }} (pinned; won't move to newer Composition revisions automatically){{ end }}
         {{- end }}
@@ -351,7 +352,7 @@
             {{- end }}
         {{- end }}
         {{- with .Spec.providerConfigRef }}
-            {{- "ProviderConfig" | bold | nindent 2 }}: {{ .kind | default "ProviderConfig" | cyan }}/{{ .name | cyan }}
+            {{- $.Include "resource_ref" (dict "kind" (.kind | default "ProviderConfig") "name" .name) | nindent 2 }}
         {{- end }}
         {{- $policies := .Spec.managementPolicies }}
         {{- if kindIs "slice" $policies }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -748,3 +748,172 @@ func renderManagedResourceDrift(t *testing.T, obj map[string]interface{}, v *vip
 	r := newRenderableObject(obj, e, repo)
 	return r.renderTemplate("crossplane_managed_resource_drift", r)
 }
+
+func renderCrossplaneTemplate(t *testing.T, templateName string, obj map[string]interface{}) (string, error) {
+	t.Helper()
+	v := viper.New()
+	cfg := NewRenderConfig(v)
+	tmpl, _ := getTemplate(cfg)
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f, cfg.Viper)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	r := newRenderableObject(obj, e, repo)
+	return r.renderTemplate(templateName, r)
+}
+
+func TestCompositionRefTemplate_V1ClaimOrClusterScopedXR(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "checkout-db"},
+		"spec": map[string]interface{}{
+			"compositionRef":          map[string]interface{}{"name": "postgres-xl"},
+			"compositionRevisionRef":  map[string]interface{}{"name": "postgres-xl-abc123"},
+			"compositionUpdatePolicy": "Manual",
+		},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_composition_ref", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	for _, want := range []string{"postgres-xl", "postgres-xl-abc123", "Manual"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("got = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestCompositionRefTemplate_V2Namespaced(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "checkout-db"},
+		"spec": map[string]interface{}{
+			"crossplane": map[string]interface{}{
+				"compositionRef":          map[string]interface{}{"name": "postgres-xl"},
+				"compositionUpdatePolicy": "Automatic",
+			},
+		},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_composition_ref", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "postgres-xl") {
+		t.Errorf("got = %q, want composition name", got)
+	}
+	if strings.Contains(got, "pinned") {
+		t.Errorf("got = %q, Automatic policy must not show the Manual warning", got)
+	}
+}
+
+func TestCompositionRefTemplate_AbsentWhenNoCrossplaneFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "some-deployment"},
+		"spec":     map[string]interface{}{"replicas": float64(1)},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_composition_ref", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected no output for a non-Crossplane object, got = %q", got)
+	}
+}
+
+func TestManagedResourceDetailsTemplate_AnnotationsAndSpecFields(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "checkout-network",
+			"annotations": map[string]interface{}{
+				"crossplane.io/external-name":             "vpc-0123456789abcdef0",
+				"crossplane.io/composition-resource-name": "network",
+				"crossplane.io/external-create-pending":   "2026-06-01T10:00:00Z",
+				"crossplane.io/external-create-succeeded": "2026-06-01T10:00:30Z",
+			},
+		},
+		"spec": map[string]interface{}{
+			"forProvider":        map[string]interface{}{"region": "eu-west-1"},
+			"providerConfigRef":  map[string]interface{}{"name": "aws-prod"},
+			"managementPolicies": []interface{}{"*"},
+			"initProvider": map[string]interface{}{
+				"tags": map[string]interface{}{"environment": "production"},
+			},
+		},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_managed_resource_details", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	for _, want := range []string{
+		"vpc-0123456789abcdef0",
+		"network",
+		"succeeded, took 30s",
+		"aws-prod",
+		"full control",
+		"tags",
+		"applied only at creation time",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("got = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestManagedResourceDetailsTemplate_ExternalCreatePendingWithoutSucceeded(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": "checkout-network",
+			"annotations": map[string]interface{}{
+				"crossplane.io/external-create-pending": "2026-06-01T10:00:00Z",
+			},
+		},
+		"spec": map[string]interface{}{
+			"forProvider": map[string]interface{}{"region": "eu-west-1"},
+		},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_managed_resource_details", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "External create") || !strings.Contains(got, "pending") {
+		t.Errorf("got = %q, want a pending-without-succeeded warning", got)
+	}
+	if strings.Contains(got, "took") {
+		t.Errorf("got = %q, must not compute a latency without a succeeded timestamp", got)
+	}
+}
+
+func TestManagedResourceDetailsTemplate_PartialManagementPolicies(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "checkout-network"},
+		"spec": map[string]interface{}{
+			"forProvider":        map[string]interface{}{"region": "eu-west-1"},
+			"managementPolicies": []interface{}{"Observe", "LateInitialize"},
+		},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_managed_resource_details", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Observe, LateInitialize") {
+		t.Errorf("got = %q, want the partial policy list displayed", got)
+	}
+	if strings.Contains(got, "full control") {
+		t.Errorf("got = %q, partial policies must not show the full-control label", got)
+	}
+}
+
+func TestManagedResourceDetailsTemplate_NotAManagedResource(t *testing.T) {
+	obj := map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "some-deployment"},
+		"spec":     map[string]interface{}{"replicas": float64(1)},
+	}
+	got, err := renderCrossplaneTemplate(t, "crossplane_managed_resource_details", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected no output for a non-managed-resource object, got = %q", got)
+	}
+}

--- a/tests/artifacts/crossplane-managed-resource-details.out
+++ b/tests/artifacts/crossplane-managed-resource-details.out
@@ -1,0 +1,12 @@
+
+Bucket/checkout-bucket, created 1m ago, gen:1
+  Current: Resource is Ready
+  Drift: none across 1 configured fields
+  External name: my-bucket-9f3a1c
+  Composition resource name: bucket
+  External create: succeeded, took 1m
+  ProviderConfig: ProviderConfig/aws-provider
+  Management policies: Observe, LateInitialize
+  initProvider: tags (applied only at creation time)
+  Synced ReconcileSuccess for 1m
+  Ready Available for 1m

--- a/tests/artifacts/crossplane-managed-resource-details.out
+++ b/tests/artifacts/crossplane-managed-resource-details.out
@@ -5,7 +5,7 @@ Bucket/checkout-bucket, created 1m ago, gen:1
   External name: my-bucket-9f3a1c
   Composition resource name: bucket
   External create: succeeded, took 1m
-  ProviderConfig: ProviderConfig/aws-provider
+  ProviderConfig/aws-provider
   Management policies: Observe, LateInitialize
   initProvider: tags (applied only at creation time)
   Synced ReconcileSuccess for 1m

--- a/tests/artifacts/crossplane-managed-resource-details.yaml
+++ b/tests/artifacts/crossplane-managed-resource-details.yaml
@@ -1,0 +1,40 @@
+apiVersion: s3.aws.upbound.io/v1beta1
+kind: Bucket
+metadata:
+  annotations:
+    crossplane.io/external-name: my-bucket-9f3a1c
+    crossplane.io/composition-resource-name: bucket
+    crossplane.io/external-create-pending: "2026-05-01T09:00:00Z"
+    crossplane.io/external-create-succeeded: "2026-05-01T09:02:15Z"
+  creationTimestamp: "2026-05-01T09:00:00Z"
+  finalizers:
+  - finalizer.managedresource.crossplane.io
+  generation: 1
+  name: checkout-bucket
+  resourceVersion: "882210"
+  uid: 3f6d9e2a-9d0e-4a1b-9d3f-8e6a1c2b4d5e
+spec:
+  forProvider:
+    region: us-east-1
+  providerConfigRef:
+    kind: ProviderConfig
+    name: aws-provider
+  managementPolicies:
+  - Observe
+  - LateInitialize
+  initProvider:
+    tags:
+      team: platform
+status:
+  observedGeneration: 1
+  conditions:
+  - lastTransitionTime: "2026-05-01T09:02:15Z"
+    reason: ReconcileSuccess
+    status: "True"
+    type: Synced
+  - lastTransitionTime: "2026-05-01T09:02:15Z"
+    reason: Available
+    status: "True"
+    type: Ready
+  atProvider:
+    region: us-east-1

--- a/tests/artifacts/crossplane-managed-resource-drift.out
+++ b/tests/artifacts/crossplane-managed-resource-drift.out
@@ -10,5 +10,6 @@ VPC/checkout-network, created 1m ago, gen:2
      tags:
     -  environment: production
     +  environment: staging
+  Management policies: * (full control)
   Synced ReconcileSuccess for 1m
   Ready Available for 1m

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
@@ -2,7 +2,7 @@
 XStatusProbe/probe-a, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
-  Composition: status-probe, revision status-probe-56d8414, update policy Automatic
+  Composition/status-probe, revision CompositionRevision/status-probe-56d8414, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
@@ -2,6 +2,7 @@
 XStatusProbe/probe-a, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
+  Composition: status-probe, revision status-probe-56d8414, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config

--- a/tests/artifacts/crossplane-xr-composed.out
+++ b/tests/artifacts/crossplane-xr-composed.out
@@ -2,6 +2,7 @@
 XStatusProbe/probe-a -n crossplane-e2e, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
+  Composition: status-probe, revision status-probe-56d8414, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config

--- a/tests/artifacts/crossplane-xr-composed.out
+++ b/tests/artifacts/crossplane-xr-composed.out
@@ -2,7 +2,7 @@
 XStatusProbe/probe-a -n crossplane-e2e, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
-  Composition: status-probe, revision status-probe-56d8414, update policy Automatic
+  Composition/status-probe, revision CompositionRevision/status-probe-56d8414, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -2,6 +2,7 @@
 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
+  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a, gen:1 rev:1
       InProgress: Available: 0/1
@@ -37,6 +38,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
         XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
           InProgress: Unready resources: blocked-workload, config
             Reconciling: Creating, Unready resources: blocked-workload, config
+          Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
           Composed resources:
             Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
             ConfigMap/probe-a-config -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a
@@ -44,6 +46,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                   InProgress: Unready resources: blocked-workload, config
                     Reconciling: Creating, Unready resources: blocked-workload, config
+                  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
                   Composed resources:
                     Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
                     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -2,7 +2,7 @@
 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
-  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
+  Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a, gen:1 rev:1
       InProgress: Available: 0/1
@@ -38,7 +38,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
         XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
           InProgress: Unready resources: blocked-workload, config
             Reconciling: Creating, Unready resources: blocked-workload, config
-          Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
+          Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
           Composed resources:
             Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
             ConfigMap/probe-a-config -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a
@@ -46,7 +46,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                   InProgress: Unready resources: blocked-workload, config
                     Reconciling: Creating, Unready resources: blocked-workload, config
-                  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
+                  Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
                   Composed resources:
                     Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
                     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -2,6 +2,7 @@
 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
+  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked, InProgress: Available: 0/1
     ConfigMap/probe-a-config, Current: Resource is always ready

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -2,7 +2,7 @@
 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   InProgress: Unready resources: blocked-workload, config
     Reconciling: Creating, Unready resources: blocked-workload, config
-  Composition: status-probe, revision status-probe-[a-z0-9]+, update policy Automatic
+  Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
     Deployment/probe-a-blocked, InProgress: Available: 0/1
     ConfigMap/probe-a-config, Current: Resource is always ready


### PR DESCRIPTION
## Summary
- Show `compositionRef`/`compositionRevisionRef`/`compositionUpdatePolicy` for Claims and XRs (both v1 top-level and v2 `spec.crossplane.*` shapes), flagging `Manual` update policy as pinned.
- Show `crossplane.io/external-name` and `composition-resource-name` annotations on managed resources, warn when `external-create-pending` is set without `external-create-succeeded`, and compute create latency when both are present.
- Show managed-resource `providerConfigRef`, `managementPolicies` (`*` rendered as "full control"), and `initProvider` key presence (create-only fields).
- All fields only render when present, so non-Crossplane resources and MRs without these fields stay unaffected.

Closes #723.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests for both template blocks (`pkg/plugin/templates_common_test.go`)
- [x] New golden fixture `tests/artifacts/crossplane-managed-resource-details.{yaml,out}` exercising all new managed-resource fields together
- [x] Updated existing golden `.out`/`.regex` files affected by the new composition-ref line

🤖 Generated with [Claude Code](https://claude.com/claude-code)