### PR TITLE
Render Crossplane drift as a unified diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubectl v0.36.2
 	sigs.k8s.io/cli-utils v0.37.2
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -92,5 +93,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/plugin/crossplanedrift/crossplanedrift.go
+++ b/pkg/plugin/crossplanedrift/crossplanedrift.go
@@ -15,6 +15,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"sigs.k8s.io/yaml"
 )
 
 // Class classifies a single configured leaf path.
@@ -120,6 +123,80 @@ func Diff(forProvider, atProvider map[string]interface{}) Result {
 	}
 
 	return result
+}
+
+// UnifiedDiff renders a unified, git-style diff between the desired and observed values of
+// DriftEntries, as two minimal YAML documents built from just the drifted leaf paths (shared
+// parent keys act as diff context). Returns "" when there's no drift, or when every drifted path
+// is redacted (see below). It deliberately excludes in-sync/not-observed/observed-only paths that
+// would otherwise show up as diff noise.
+//
+// Redacted entries are left out of the diffed documents entirely: Diff sets both their Desired
+// and Observed to the same "REDACTED" placeholder, which would render as a no-op diff line
+// (identical text on both sides) rather than a leak, but that silently hides the fact that the
+// field drifted. Callers should list r.RedactedPaths separately when non-empty.
+func (r Result) UnifiedDiff() string {
+	desired := map[string]interface{}{}
+	observed := map[string]interface{}{}
+	for _, e := range r.DriftEntries {
+		if e.Redacted {
+			continue
+		}
+		setPath(desired, e.Path, e.Desired)
+		setPath(observed, e.Path, e.Observed)
+	}
+	if len(desired) == 0 {
+		return ""
+	}
+	desiredYAML, err := yaml.Marshal(desired)
+	if err != nil {
+		return ""
+	}
+	observedYAML, err := yaml.Marshal(observed)
+	if err != nil {
+		return ""
+	}
+	// yaml.Marshal always ends its output with a trailing newline; SplitLines would otherwise
+	// turn that into a spurious trailing empty line, rendered as a whitespace-only context line.
+	out, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(strings.TrimRight(string(desiredYAML), "\n")),
+		B:        difflib.SplitLines(strings.TrimRight(string(observedYAML), "\n")),
+		FromFile: "spec.forProvider",
+		ToFile:   "status.atProvider",
+		Context:  3,
+	})
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(out, "\n")
+}
+
+// RedactedPaths returns the sorted paths of DriftEntries whose values were redacted, i.e. the
+// drifted fields UnifiedDiff leaves out of its rendered diff.
+func (r Result) RedactedPaths() []string {
+	var paths []string
+	for _, e := range r.DriftEntries {
+		if e.Redacted {
+			paths = append(paths, e.Path)
+		}
+	}
+	return paths
+}
+
+// setPath sets value at the given dot-separated path within doc, creating intermediate maps as
+// needed.
+func setPath(doc map[string]interface{}, path string, value interface{}) {
+	parts := strings.Split(path, ".")
+	cur := doc
+	for _, p := range parts[:len(parts)-1] {
+		next, ok := cur[p].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			cur[p] = next
+		}
+		cur = next
+	}
+	cur[parts[len(parts)-1]] = value
 }
 
 func redactEntry(e Entry) Entry {

--- a/pkg/plugin/crossplanedrift/crossplanedrift_test.go
+++ b/pkg/plugin/crossplanedrift/crossplanedrift_test.go
@@ -1,6 +1,7 @@
 package crossplanedrift
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -65,6 +66,62 @@ func TestDiff_DifferingScalar(t *testing.T) {
 	e := result.DriftEntries[0]
 	if e.Path != "region" || e.Desired != "eu-west-1" || e.Observed != "us-east-1" {
 		t.Errorf("DriftEntries[0] = %+v, want region eu-west-1 -> us-east-1", e)
+	}
+}
+
+func TestUnifiedDiff_NoDrift(t *testing.T) {
+	result := Diff(map[string]interface{}{"region": "eu-west-1"}, map[string]interface{}{"region": "eu-west-1"})
+	if got := result.UnifiedDiff(); got != "" {
+		t.Errorf("UnifiedDiff() = %q, want empty for no drift", got)
+	}
+}
+
+func TestUnifiedDiff_NestedPathAndScalar(t *testing.T) {
+	forProvider := map[string]interface{}{
+		"region": "eu-west-1",
+		"tags":   map[string]interface{}{"environment": "production"},
+	}
+	atProvider := map[string]interface{}{
+		"region": "eu-west-1",
+		"tags":   map[string]interface{}{"environment": "staging"},
+	}
+	result := Diff(forProvider, atProvider)
+	got := result.UnifiedDiff()
+	for _, want := range []string{"--- spec.forProvider", "+++ status.atProvider", "-  environment: production", "+  environment: staging"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("UnifiedDiff() = %q, want it to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "region") {
+		t.Errorf("UnifiedDiff() = %q, want the in-sync region field left out of the diff", got)
+	}
+}
+
+func TestUnifiedDiff_ExcludesRedactedFields(t *testing.T) {
+	forProvider := map[string]interface{}{"dbPassword": "s3cr3t-old", "region": "eu-west-1"}
+	atProvider := map[string]interface{}{"dbPassword": "s3cr3t-new", "region": "us-east-1"}
+	result := Diff(forProvider, atProvider)
+	got := result.UnifiedDiff()
+	if strings.Contains(got, "s3cr3t") || strings.Contains(got, "REDACTED") {
+		t.Errorf("UnifiedDiff() = %q, must not leak or even mention redacted fields", got)
+	}
+	if !strings.Contains(got, "-region: eu-west-1") || !strings.Contains(got, "+region: us-east-1") {
+		t.Errorf("UnifiedDiff() = %q, want the non-redacted field's diff", got)
+	}
+	if got := result.RedactedPaths(); len(got) != 1 || got[0] != "dbPassword" {
+		t.Errorf("RedactedPaths() = %v, want [dbPassword]", got)
+	}
+}
+
+func TestUnifiedDiff_OnlyRedactedFieldsDriftedYieldsNoDiff(t *testing.T) {
+	forProvider := map[string]interface{}{"dbPassword": "s3cr3t-old"}
+	atProvider := map[string]interface{}{"dbPassword": "s3cr3t-new"}
+	result := Diff(forProvider, atProvider)
+	if got := result.UnifiedDiff(); got != "" {
+		t.Errorf("UnifiedDiff() = %q, want empty when every drifted field is redacted", got)
+	}
+	if got := result.RedactedPaths(); len(got) != 1 || got[0] != "dbPassword" {
+		t.Errorf("RedactedPaths() = %v, want [dbPassword]", got)
 	}
 }
 

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -272,19 +272,22 @@
             {{- $labeled := crossplaneDriftLabel $syncedStatus .Spec.managementPolicies }}
             {{- if eq (len $result.DriftEntries) 0 }}
                 {{- "Drift" | bold | nindent 2 }}: none across {{ $result.TotalConfigured }} configured fields
-            {{- else if $.Config.GetBool "deep" }}
+            {{- else }}
                 {{- $labeled.Label | bold | nindent 2 }} (`spec.forProvider` -> `status.atProvider`){{ with $labeled.Annotation }}, {{ . | yellow }}{{ end }}:
-                {{- range $result.DriftEntries }}
-                    {{- printf "%s: %s -> %s" .Path (.Desired | toJson) (.Observed | toJson) | nindent 4 }}
+                {{- with $result.UnifiedDiff }}
+                    {{- . | markRed "^-.*" | markGreen "^\\+.*" | nindent 4 }}
+                {{- end }}
+                {{- with $result.RedactedPaths }}
+                    {{- printf "Redacted fields differ: %s" (join ", " .) | nindent 4 }}
                 {{- end }}
                 {{- with $result.MoreCount }}
                     {{- printf "… %d more" . | nindent 4 }}
                 {{- end }}
-                {{- with $result.ObservedOnlyCount }}
-                    {{- printf "Observed-only fields: %d (hidden; provider defaults/computed state)" . | nindent 4 }}
+                {{- if $.Config.GetBool "deep" }}
+                    {{- with $result.ObservedOnlyCount }}
+                        {{- printf "Observed-only fields: %d (hidden; provider defaults/computed state)" . | nindent 4 }}
+                    {{- end }}
                 {{- end }}
-            {{- else }}
-                {{- $labeled.Label | bold | nindent 2 }}: {{ printf "%d configured fields differ from observed state" (len $result.DriftEntries) | redBoldIf true }}{{ with $labeled.Annotation }} ({{ . | yellow }}){{ end }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -701,7 +701,7 @@ func TestManagedResourceDriftTemplate_InSync(t *testing.T) {
 	}
 }
 
-func TestManagedResourceDriftTemplate_DefaultDepthSummary(t *testing.T) {
+func TestManagedResourceDriftTemplate_DefaultDepthShowsUnifiedDiff(t *testing.T) {
 	obj := managedResourceObj(
 		map[string]interface{}{"region": "eu-west-1"},
 		map[string]interface{}{"region": "us-east-1"},
@@ -710,27 +710,27 @@ func TestManagedResourceDriftTemplate_DefaultDepthSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderTemplate() error = %v", err)
 	}
-	if !strings.Contains(got, "Observed difference: 1 configured fields differ from observed state") {
-		t.Errorf("got = %q, want the compact drift count", got)
-	}
-	if strings.Contains(got, "eu-west-1") {
-		t.Errorf("got = %q, default depth must not print field-level values", got)
+	if !strings.Contains(got, "-region: eu-west-1") || !strings.Contains(got, "+region: us-east-1") {
+		t.Errorf("got = %q, want a unified diff of the drifted field", got)
 	}
 }
 
-func TestManagedResourceDriftTemplate_DeepShowsFieldDiff(t *testing.T) {
+func TestManagedResourceDriftTemplate_DeepAddsObservedOnlyCount(t *testing.T) {
 	v := viper.New()
 	v.Set("deep", true)
 	obj := managedResourceObj(
 		map[string]interface{}{"region": "eu-west-1"},
-		map[string]interface{}{"region": "us-east-1"},
+		map[string]interface{}{"region": "us-east-1", "arn": "arn:aws:ec2:eu-west-1:123456789012:vpc/vpc-1"},
 	)
 	got, err := renderManagedResourceDrift(t, obj, v)
 	if err != nil {
 		t.Fatalf("renderTemplate() error = %v", err)
 	}
-	if !strings.Contains(got, `region: "eu-west-1" -> "us-east-1"`) {
-		t.Errorf("got = %q, want the field-level diff line", got)
+	if !strings.Contains(got, "-region: eu-west-1") || !strings.Contains(got, "+region: us-east-1") {
+		t.Errorf("got = %q, want the unified diff of the drifted field", got)
+	}
+	if !strings.Contains(got, "Observed-only fields: 1") {
+		t.Errorf("got = %q, want the deep-only observed-only-fields count", got)
 	}
 }
 

--- a/tests/artifacts/crossplane-managed-resource-drift.out
+++ b/tests/artifacts/crossplane-managed-resource-drift.out
@@ -1,6 +1,14 @@
 
 VPC/checkout-network, created 1m ago, gen:2
   Current: Resource is Ready
-  Observed difference: 2 configured fields differ from observed state
+  Observed difference (`spec.forProvider` -> `status.atProvider`):
+    --- spec.forProvider
+    +++ status.atProvider
+    @@ -1,3 +1,3 @@
+    -region: eu-west-1
+    +region: us-east-1
+     tags:
+    -  environment: production
+    +  environment: staging
   Synced ReconcileSuccess for 1m
   Ready Available for 1m


### PR DESCRIPTION
## Summary
- Default (non-`--deep`) output for the Crossplane managed-resource drift feature now shows a unified, git-style diff of the drifted `spec.forProvider` fields against `status.atProvider`, instead of a bare "N configured fields differ from observed state" count.
- Reuses the same diff mechanism used for workload rollout diffs (`go-difflib`), built from just the drifted leaf paths so it stays free of provider-defaulted noise and never renders redacted secret values (redacted fields are excluded from the diff and listed separately via `Redacted fields differ: ...`).
- `--deep` now only adds the extra `Observed-only fields` count on top of the same diff.

Addresses review feedback on #726: https://github.com/bergerx/kubectl-status/pull/726#discussion_r3616668737

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./...` (including regenerated `tests/artifacts/crossplane-managed-resource-drift.out`)
- [x] New unit tests for `UnifiedDiff`/`RedactedPaths` in `pkg/plugin/crossplanedrift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)