### PR TITLE
Add karpenter.sh/v1 NodePool and NodeClaim templates

### DIFF
--- a/pkg/plugin/templates/NodeClaim.tmpl
+++ b/pkg/plugin/templates/NodeClaim.tmpl
@@ -1,0 +1,31 @@
+{{- define "NodeClaim" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: karpenter.sh/v1, Kind=NodeClaim */ -}}
+    {{- /* The owning NodePool is already shown by status_summary_line's ownerReferences clause --
+           no need to re-render it here. */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- with .Spec.nodeClassRef }}
+        {{- "NodeClass" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" .kind "name" .name) }}
+    {{- end }}
+    {{- $labels := .Metadata.labels | default dict }}
+    {{- $instanceType := index $labels "node.kubernetes.io/instance-type" }}
+    {{- $zone := index $labels "topology.kubernetes.io/zone" }}
+    {{- $capacityType := index $labels "karpenter.sh/capacity-type" }}
+    {{- if or $instanceType $zone $capacityType }}
+        {{- "Capacity" | bold | nindent 2 }}:
+        {{- with $instanceType }} {{ . | cyan }}{{ end }}
+        {{- with $capacityType }} ({{ . | colorKeyword }}){{ end }}
+        {{- with $zone }} in {{ . | cyan }}{{ end }}
+    {{- end }}
+    {{- with (.Status | default dict).nodeName }}
+        {{- "Node" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Node" "name" .) }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}

--- a/pkg/plugin/templates/NodePool.tmpl
+++ b/pkg/plugin/templates/NodePool.tmpl
@@ -1,0 +1,65 @@
+{{- define "NodePool" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: karpenter.sh/v1, Kind=NodePool */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- with .Spec.template.spec.nodeClassRef }}
+        {{- "NodeClass" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" .kind "name" .name) }}
+    {{- end }}
+    {{- /* Only render requirements that constrain scheduling in ways operators typically care
+           about when debugging "why won't this pool provision compatible capacity" -- template
+           labels/annotations, taints and disruption settings are configuration, not capacity
+           envelope, so they're intentionally left out. */ -}}
+    {{- $relevantKeys := list "node.kubernetes.io/instance-type" "karpenter.k8s.aws/instance-category" "karpenter.k8s.aws/instance-family" "topology.kubernetes.io/zone" "kubernetes.io/arch" "kubernetes.io/os" "karpenter.sh/capacity-type" }}
+    {{- $requirements := list }}
+    {{- range .Spec.template.spec.requirements }}
+        {{- if has .key $relevantKeys }}{{ $requirements = append $requirements . }}{{ end }}
+    {{- end }}
+    {{- with $requirements }}
+        {{- "Requirements" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- $line := "" }}
+            {{- if eq .operator "Exists" }}
+                {{- $line = printf "%s exists" .key }}
+            {{- else if eq .operator "DoesNotExist" }}
+                {{- $line = printf "%s does not exist" .key }}
+            {{- else }}
+                {{- $line = printf "%s %s [%s]" .key .operator (.values | default list | join ", ") }}
+            {{- end }}
+            {{- with .minValues }}{{ $line = printf "%s (min %d values)" $line . }}{{ end }}
+            {{- $line | cyan | nindent 4 }}
+        {{- end }}
+    {{- end }}
+    {{- $spec := .Spec | default dict }}
+    {{- if hasKey $spec "replicas" }}
+        {{- "Replicas" | bold | nindent 2 }}: {{ $spec.replicas | toString | cyan }}
+    {{- else if hasKey (.Status | default dict) "nodes" }}
+        {{- "Nodes" | bold | nindent 2 }}: {{ .Status.nodes | toString | cyan }}
+    {{- end }}
+    {{- $limits := $spec.limits }}
+    {{- $resources := (.Status | default dict).resources }}
+    {{- if or (and (kindIs "map" $limits) $limits) (and (kindIs "map" $resources) $resources) }}
+        {{- $keys := list }}
+        {{- range keys ($limits | default dict) }}{{ if not (has . $keys) }}{{ $keys = append $keys . }}{{ end }}{{ end }}
+        {{- range keys ($resources | default dict) }}{{ if not (has . $keys) }}{{ $keys = append $keys . }}{{ end }}{{ end }}
+        {{- "Resources" | bold | nindent 2 }}: (current/limit)
+        {{- range ($keys | sortAlpha) }}
+            {{- $key := . }}
+            {{- $isBytes := or (hasSuffix "memory" $key) (hasSuffix "storage" $key) }}
+            {{- $usedRaw := index ($resources | default dict) $key }}
+            {{- $limitRaw := index ($limits | default dict) $key }}
+            {{- $usedStr := "n/a" }}
+            {{- with $usedRaw }}{{ $usedStr = . | toString }}{{ if $isBytes }}{{ $usedStr = $usedStr | quantityToFloat64 | humanizeSI "B" }}{{ end }}{{ end }}
+            {{- $limitStr := "unlimited" }}
+            {{- with $limitRaw }}{{ $limitStr = . | toString }}{{ if $isBytes }}{{ $limitStr = $limitStr | quantityToFloat64 | humanizeSI "B" }}{{ end }}{{ end }}
+            {{- printf "%s: %s/%s" $key $usedStr $limitStr | cyan | nindent 4 }}
+        {{- end }}
+    {{- end }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}

--- a/tests/artifacts/nodeclaim-healthy.out
+++ b/tests/artifacts/nodeclaim-healthy.out
@@ -1,0 +1,10 @@
+
+NodeClaim/default-abcde, created 1m ago by NodePool/default, gen:1
+  Current: Resource is Ready
+  NodeClass: EC2NodeClass/default
+  Capacity: m5.large (spot) in us-east-1a
+  Node: Node/ip-10-0-1-23.ec2.internal
+  Launched Launched for 1m
+  Registered Registered for 1m
+  Initialized Initialized for 1m
+  Ready Ready for 1m

--- a/tests/artifacts/nodeclaim-healthy.yaml
+++ b/tests/artifacts/nodeclaim-healthy.yaml
@@ -1,0 +1,65 @@
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: default-abcde
+  generation: 1
+  creationTimestamp: "2026-07-19T10:00:00Z"
+  uid: 44444444-4444-4444-4444-444444444444
+  resourceVersion: "900"
+  labels:
+    karpenter.sh/nodepool: default
+    node.kubernetes.io/instance-type: m5.large
+    topology.kubernetes.io/zone: us-east-1a
+    karpenter.sh/capacity-type: spot
+    kubernetes.io/arch: amd64
+  ownerReferences:
+    - apiVersion: karpenter.sh/v1
+      kind: NodePool
+      name: default
+      uid: 11111111-1111-1111-1111-111111111111
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  nodeClassRef:
+    group: karpenter.k8s.aws
+    kind: EC2NodeClass
+    name: default
+  requirements:
+    - key: node.kubernetes.io/instance-type
+      operator: In
+      values:
+        - m5.large
+  resources:
+    requests:
+      cpu: "2"
+      memory: 8Gi
+  expireAfter: 720h
+status:
+  nodeName: ip-10-0-1-23.ec2.internal
+  providerID: aws:///us-east-1a/i-0123456789abcdef0
+  imageID: ami-0123456789abcdef0
+  capacity:
+    cpu: "2"
+    memory: 8Gi
+    pods: "58"
+  allocatable:
+    cpu: "1930m"
+    memory: 7Gi
+    pods: "58"
+  conditions:
+    - type: Launched
+      status: "True"
+      reason: Launched
+      lastTransitionTime: "2026-07-19T10:00:05Z"
+    - type: Registered
+      status: "True"
+      reason: Registered
+      lastTransitionTime: "2026-07-19T10:00:20Z"
+    - type: Initialized
+      status: "True"
+      reason: Initialized
+      lastTransitionTime: "2026-07-19T10:01:00Z"
+    - type: Ready
+      status: "True"
+      reason: Ready
+      lastTransitionTime: "2026-07-19T10:01:00Z"

--- a/tests/artifacts/nodeclaim-launch-failed.out
+++ b/tests/artifacts/nodeclaim-launch-failed.out
@@ -1,0 +1,10 @@
+
+NodeClaim/default-fghij, created 1m ago by NodePool/default, gen:1
+  InProgress: NodeClaim is not initialized
+    Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
+  NodeClass: EC2NodeClass/default
+  Capacity: (spot)
+  Launched LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
+  Registered AwaitingLaunch for 1m
+  Initialized AwaitingRegistration for 1m
+  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m

--- a/tests/artifacts/nodeclaim-launch-failed.yaml
+++ b/tests/artifacts/nodeclaim-launch-failed.yaml
@@ -1,0 +1,48 @@
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: default-fghij
+  generation: 1
+  creationTimestamp: "2026-07-19T18:00:00Z"
+  uid: 55555555-5555-5555-5555-555555555555
+  resourceVersion: "950"
+  labels:
+    karpenter.sh/nodepool: default
+    karpenter.sh/capacity-type: spot
+  ownerReferences:
+    - apiVersion: karpenter.sh/v1
+      kind: NodePool
+      name: default
+      uid: 11111111-1111-1111-1111-111111111111
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  nodeClassRef:
+    group: karpenter.k8s.aws
+    kind: EC2NodeClass
+    name: default
+  requirements:
+    - key: node.kubernetes.io/instance-type
+      operator: In
+      values:
+        - m5.large
+status:
+  conditions:
+    - type: Launched
+      status: "False"
+      reason: LaunchFailed
+      message: "InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested"
+      lastTransitionTime: "2026-07-19T18:00:10Z"
+    - type: Registered
+      status: Unknown
+      reason: AwaitingLaunch
+      lastTransitionTime: "2026-07-19T18:00:00Z"
+    - type: Initialized
+      status: Unknown
+      reason: AwaitingRegistration
+      lastTransitionTime: "2026-07-19T18:00:00Z"
+    - type: Ready
+      status: "False"
+      reason: NodeClaimNotInitialized
+      message: "NodeClaim is not initialized"
+      lastTransitionTime: "2026-07-19T18:00:00Z"

--- a/tests/artifacts/nodeclaim-registration-failed.out
+++ b/tests/artifacts/nodeclaim-registration-failed.out
@@ -1,0 +1,10 @@
+
+NodeClaim/default-klmno, created 1m ago by NodePool/default, gen:1
+  InProgress: NodeClaim is not initialized
+    Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
+  NodeClass: EC2NodeClass/default
+  Capacity: m5.large (on-demand) in us-east-1b
+  Launched Launched for 1m
+  Registered NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m
+  Initialized AwaitingRegistration for 1m
+  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m

--- a/tests/artifacts/nodeclaim-registration-failed.yaml
+++ b/tests/artifacts/nodeclaim-registration-failed.yaml
@@ -1,0 +1,51 @@
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: default-klmno
+  generation: 1
+  creationTimestamp: "2026-07-19T19:00:00Z"
+  uid: 66666666-6666-6666-6666-666666666666
+  resourceVersion: "960"
+  labels:
+    karpenter.sh/nodepool: default
+    node.kubernetes.io/instance-type: m5.large
+    topology.kubernetes.io/zone: us-east-1b
+    karpenter.sh/capacity-type: on-demand
+  ownerReferences:
+    - apiVersion: karpenter.sh/v1
+      kind: NodePool
+      name: default
+      uid: 11111111-1111-1111-1111-111111111111
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  nodeClassRef:
+    group: karpenter.k8s.aws
+    kind: EC2NodeClass
+    name: default
+  requirements:
+    - key: node.kubernetes.io/instance-type
+      operator: In
+      values:
+        - m5.large
+status:
+  providerID: aws:///us-east-1b/i-0fedcba9876543210
+  conditions:
+    - type: Launched
+      status: "True"
+      reason: Launched
+      lastTransitionTime: "2026-07-19T19:00:05Z"
+    - type: Registered
+      status: "False"
+      reason: NodeNotFound
+      message: "node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s"
+      lastTransitionTime: "2026-07-19T19:00:05Z"
+    - type: Initialized
+      status: Unknown
+      reason: AwaitingRegistration
+      lastTransitionTime: "2026-07-19T19:00:05Z"
+    - type: Ready
+      status: "False"
+      reason: NodeClaimNotInitialized
+      message: "NodeClaim is not initialized"
+      lastTransitionTime: "2026-07-19T19:00:05Z"

--- a/tests/artifacts/nodeclaim-sparse.out
+++ b/tests/artifacts/nodeclaim-sparse.out
@@ -1,0 +1,4 @@
+
+NodeClaim/pending-abcde, created 1m ago, gen:1
+  Current: Resource is current
+  NodeClass: EC2NodeClass/default

--- a/tests/artifacts/nodeclaim-sparse.yaml
+++ b/tests/artifacts/nodeclaim-sparse.yaml
@@ -1,0 +1,13 @@
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: pending-abcde
+  generation: 1
+  creationTimestamp: "2026-07-19T20:00:00Z"
+  uid: 77777777-7777-7777-7777-777777777777
+  resourceVersion: "970"
+spec:
+  nodeClassRef:
+    group: karpenter.k8s.aws
+    kind: EC2NodeClass
+    name: default

--- a/tests/artifacts/nodepool-healthy.out
+++ b/tests/artifacts/nodepool-healthy.out
@@ -1,0 +1,19 @@
+
+NodePool/default, created 1m ago, gen:3
+  Current: Resource is Ready
+  NodeClass: EC2NodeClass/default
+  Requirements:
+    karpenter.sh/capacity-type In [spot, on-demand]
+    node.kubernetes.io/instance-type exists
+    karpenter.k8s.aws/instance-category In [c, m, r] (min 2 values)
+    topology.kubernetes.io/zone Gte [1]
+    kubernetes.io/arch In [amd64]
+    karpenter.k8s.aws/instance-family NotIn [t3, t3a]
+  Nodes: 4
+  Resources: (current/limit)
+    cpu: 48/1000
+    memory: 206.1GB/1TB
+    pods: 220/unlimited
+  Ready Ready for 1m
+  NodeClassReady NodeClassReady for 1m
+  ValidationSucceeded ValidationSucceeded for 1m

--- a/tests/artifacts/nodepool-healthy.yaml
+++ b/tests/artifacts/nodepool-healthy.yaml
@@ -1,0 +1,77 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+  generation: 3
+  creationTimestamp: "2026-07-01T10:00:00Z"
+  uid: 11111111-1111-1111-1111-111111111111
+  resourceVersion: "1000"
+spec:
+  weight: 10
+  template:
+    metadata:
+      labels:
+        team: platform
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+            - spot
+            - on-demand
+        - key: node.kubernetes.io/instance-type
+          operator: Exists
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values:
+            - c
+            - m
+            - r
+          minValues: 2
+        - key: topology.kubernetes.io/zone
+          operator: Gte
+          values:
+            - "1"
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+            - amd64
+        - key: karpenter.k8s.aws/instance-family
+          operator: NotIn
+          values:
+            - t3
+            - t3a
+      taints:
+        - key: dedicated
+          value: gpu
+          effect: NoSchedule
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s
+  limits:
+    cpu: "1000"
+    memory: 1000Gi
+status:
+  nodeClassObservedGeneration: 3
+  nodes: 4
+  resources:
+    cpu: "48"
+    memory: 192Gi
+    pods: "220"
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Ready
+      lastTransitionTime: "2026-07-19T10:00:00Z"
+    - type: NodeClassReady
+      status: "True"
+      reason: NodeClassReady
+      lastTransitionTime: "2026-07-19T10:00:00Z"
+    - type: ValidationSucceeded
+      status: "True"
+      reason: ValidationSucceeded
+      lastTransitionTime: "2026-07-19T10:00:00Z"

--- a/tests/artifacts/nodepool-sparse.out
+++ b/tests/artifacts/nodepool-sparse.out
@@ -1,0 +1,4 @@
+
+NodePool/minimal, created 1m ago, gen:1
+  Current: Resource is current
+  NodeClass: EC2NodeClass/minimal

--- a/tests/artifacts/nodepool-sparse.yaml
+++ b/tests/artifacts/nodepool-sparse.yaml
@@ -1,0 +1,15 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: minimal
+  generation: 1
+  creationTimestamp: "2026-07-19T10:00:00Z"
+  uid: 22222222-2222-2222-2222-222222222222
+  resourceVersion: "500"
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: minimal

--- a/tests/artifacts/nodepool-static-replicas.out
+++ b/tests/artifacts/nodepool-static-replicas.out
@@ -1,0 +1,11 @@
+
+NodePool/static-pool, created 1m ago, gen:1
+  InProgress: EC2NodeClass default is not ready
+    Reconciling: NodeClassNotReady, EC2NodeClass default is not ready
+  NodeClass: EC2NodeClass/default
+  Requirements:
+    kubernetes.io/os In [linux]
+  Replicas: 0
+  Resources: (current/limit)
+    nodes: n/a/5
+  Ready NodeClassNotReady, EC2NodeClass default is not ready for 1m

--- a/tests/artifacts/nodepool-static-replicas.yaml
+++ b/tests/artifacts/nodepool-static-replicas.yaml
@@ -1,0 +1,31 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: static-pool
+  generation: 1
+  creationTimestamp: "2026-07-10T10:00:00Z"
+  uid: 33333333-3333-3333-3333-333333333333
+  resourceVersion: "700"
+spec:
+  replicas: 0
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values:
+            - linux
+  limits:
+    nodes: "5"
+status:
+  nodes: 0
+  conditions:
+    - type: Ready
+      status: "False"
+      reason: NodeClassNotReady
+      message: "EC2NodeClass default is not ready"
+      lastTransitionTime: "2026-07-19T18:00:00Z"


### PR DESCRIPTION
## Summary

Closes #663. Adds dedicated `kubectl-status` templates for Karpenter's `karpenter.sh/v1` `NodePool` and `NodeClaim` (both cluster-scoped).

- **NodePool** ("can this pool provision compatible capacity, and what's the envelope?"): compact `NodeClassRef`, only the scheduling-relevant `spec.template.spec.requirements` entries (instance-type, instance-category, instance-family, zone, arch, os, capacity-type), each with operator/values/minValues preserved (`Exists`/`DoesNotExist` rendered as prose, `In`/`NotIn`/`Gt`/`Gte`/`Lt`/`Lte` as `key OP [values]`), static `replicas` when set else `status.nodes`, and a current-vs-limit `Resources` line only when `spec.limits`/`status.resources` are present. Template labels/annotations, full taints, and disruption config are intentionally omitted.
- **NodeClaim** ("what capacity was selected, which pool owns it, where did provisioning fail?"): `NodeClassRef`, selected instance type/zone/capacity-type read from `metadata.labels`, `status.nodeName`. The owning `NodePool` needs no special-cased code — `status_summary_line`'s existing owner-reference clause already renders it from `metadata.ownerReferences`. All lifecycle conditions (`Launched`/`Registered`/`Initialized`/`Ready`) go through the shared `conditions_summary`, so false/unknown reason+message are visible without custom formatting. Full `spec.requirements`, `status.capacity`/`allocatable`, `imageID`, and `providerID` are intentionally left out as noise for a diagnostic view.

Both templates make zero live-cluster calls (no `KubeGetFirst`/`IncludeRenderableObject`), so they need no extra API calls under `--shallow`/default/`--deep`.

## Sample output

Healthy NodePool (`tests/artifacts/nodepool-healthy.out`):
```
NodePool/default, created 1m ago, gen:3
  Current: Resource is Ready
  NodeClass: EC2NodeClass/default
  Requirements:
    karpenter.sh/capacity-type In [spot, on-demand]
    node.kubernetes.io/instance-type exists
    karpenter.k8s.aws/instance-category In [c, m, r] (min 2 values)
    topology.kubernetes.io/zone Gte [1]
    kubernetes.io/arch In [amd64]
    karpenter.k8s.aws/instance-family NotIn [t3, t3a]
  Nodes: 4
  Resources: (current/limit)
    cpu: 48/1000
    memory: 206.1GB/1TB
    pods: 220/unlimited
  Ready Ready for 1m
  NodeClassReady NodeClassReady for 1m
  ValidationSucceeded ValidationSucceeded for 1m
```

Failed NodeClaim, provider launch error (`tests/artifacts/nodeclaim-launch-failed.out`):
```
NodeClaim/default-fghij, created 1m ago by NodePool/default, gen:1
  InProgress: NodeClaim is not initialized
    Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
  NodeClass: EC2NodeClass/default
  Capacity: (spot)
  Launched LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
  Registered AwaitingLaunch for 1m
  Initialized AwaitingRegistration for 1m
  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m
```

Failed NodeClaim, later registration-stage error (`tests/artifacts/nodeclaim-registration-failed.out`):
```
NodeClaim/default-klmno, created 1m ago by NodePool/default, gen:1
  InProgress: NodeClaim is not initialized
    Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
  NodeClass: EC2NodeClass/default
  Capacity: m5.large (on-demand) in us-east-1b
  Launched Launched for 1m
  Registered NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m
  Initialized AwaitingRegistration for 1m
  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m
```

All fixture `.yaml`/`.out` pairs (healthy/failed/sparse/static-replicas for both kinds) are hand-authored against the upstream CRD schemas, not captured from a live cluster — I did not have a Karpenter-enabled cluster (AWS/kwok) available to validate against real objects. Every field path and label key exercised (`spec.template.spec.requirements`, `spec.replicas`, `status.nodes`, `status.resources`, and the three `metadata.labels`) matches the upstream `karpenter.sh_nodepools.yaml`/`karpenter.sh_nodeclaims.yaml` CRD schemas, but I'd appreciate a check against a real cluster before merge if anyone has one handy.

**Important limitation**: a `NodeClaim` that fails and gets garbage-collected/deleted before anyone observes it is not reconstructable from `NodeClaim` state — its conditions and labels are gone with the object. Debugging that case requires Karpenter controller events/logs, not `kubectl-status` on the (nonexistent) NodeClaim.

## Testing

- `make update-artifacts && make test` — all offline golden fixtures pass, including the pre-commit `make test` hook on this commit.
- No `TestE2EDynamicManifests` case added: per CONTRIBUTING.md that suite is only required when a template touches `$.KubeGetFirst`/`$.IncludeRenderableObject`/live-cluster interaction, and neither of these templates does (all rendering is offline, string-only). `TestAllArtifactsLocal` (runs `--shallow --local`) already covers 100% of the rendering logic.
- Did **not** run `make test-e2e` against a real Karpenter install (official Helm chart + kwok/cloud provider, per the issue's testing note) — no cluster available in this environment. Since the templates make no live calls, this should carry low risk, but it's untested against reality.

## Test plan

- [ ] `make test` (already passing, pre-commit-enforced)
- [ ] Optional: validate `kubectl status nodepool/nodeclaim` output against a real Karpenter install (Helm chart + kwok or a supported cloud provider) before merge