### PR TITLE
Fetch StorageClass from PersistentVolume/PersistentVolumeClaim

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -194,6 +195,90 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/crossplane-xr-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("PersistentVolumeClaim fetches its StorageClass and surfaces a non-default binding mode and volume expansion", func(t *testing.T) {
+		// Issue #669: PersistentVolumeClaim.tmpl previously only printed the storage class name
+		// as a string, never fetching the object -- so provisioning-relevant fields like
+		// volumeBindingMode (which explains a claim staying Pending until a Pod is scheduled)
+		// were invisible. This exercises the live KubeGetFirst fetch, which --shallow/--local
+		// (and thus every offline artifact test) makes a no-op.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-storageclass"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, storageClasses.Items, "expected minikube's default storage-provisioner addon to have registered a StorageClass")
+		provisioner := storageClasses.Items[0].Provisioner
+
+		scName := "e2e-wait-for-first-consumer"
+		bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		allowExpansion := true
+		_, err = clientset.StorageV1().StorageClasses().Create(context.TODO(), &storagev1.StorageClass{
+			ObjectMeta:           metav1.ObjectMeta{Name: scName},
+			Provisioner:          provisioner,
+			VolumeBindingMode:    &bindingMode,
+			AllowVolumeExpansion: &allowExpansion,
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.StorageV1().StorageClasses().Delete(context.TODO(), scName, metav1.DeleteOptions{})
+		})
+
+		// WaitForFirstConsumer keeps the claim Pending with no consuming Pod -- exactly the
+		// "unbound/late-bound claim" case the issue asks for, and it needs no wait: the claim
+		// is Pending as soon as it's created.
+		pvcName := "e2e-wfc-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the fetched StorageClass in full -- offline artifact tests can't reach
+		// this branch either, since --shallow/--local (which every offline test uses) makes the
+		// KubeGetFirst behind it a no-op, so this is the only tier that verifies it renders.
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex",
+		}.assert(t, nil, opts...)
+
+		// A claim referencing a StorageClass that doesn't exist can't be told apart from one that
+		// simply wasn't fetched (--shallow/--local) by any offline artifact -- only a live fetch
+		// that comes back empty proves the "not found" warning path.
+		missingSCPVCName := "e2e-missing-sc-pvc"
+		missingSCName := "e2e-no-such-storageclass"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: missingSCPVCName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &missingSCName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pvc/" + missingSCPVCName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-missing.regex",
 		}.assert(t, nil, opts...)
 	})
 }

--- a/pkg/plugin/templates/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/PersistentVolume.tmpl
@@ -3,11 +3,13 @@
     {{- template "status_summary_line" . }}
     {{- template "kstatus_summary" . }}
     {{- template "finalizer_details_on_termination" . }}
+    {{- $provisionedByAnnotation := index .Annotations "pv.kubernetes.io/provisioned-by" }}
     {{- "PV" | nindent 2 }} is {{- with .Status.phase }} {{ . | colorKeyword }}{{ end }}
     {{- with .Status.lastPhaseTransitionTime }}, since {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with .Spec.storageClassName  }} managed by {{ $.Include "resource_ref" (dict "kind" "StorageClass" "name" .) }}{{ end }}
+    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with index .Annotations "kubernetes.io/createdby" }} created by {{ . | bold }}{{ end }}
-    {{- with index .Annotations "pv.kubernetes.io/provisioned-by" }} provisioned by {{ . | bold }}{{ end }}
+    {{- with $provisionedByAnnotation }} provisioned by {{ . | bold }}{{ end }}
     {{- with .Spec.accessModes }}{{- with index . 0 }} with {{ . | bold }} mode{{ end }}{{- end }}
     {{- with .Spec.persistentVolumeReclaimPolicy }}, reclaim: {{ . | cyan }}{{ end }}
     {{- with .Status.reason }}{{ "reason" | bold }}: {{ . }}{{ end }}

--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -5,13 +5,16 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "application_details" . }}
     {{- template "conditions_summary" . }}
+    {{- $storageProvisionerAnnotation := index .Annotations "volume.beta.kubernetes.io/storage-provisioner" }}
     {{- "PVC" | nindent 2 }}
     {{- with .Spec.volumeName }} uses {{ $.Include "resource_ref" (dict "kind" "PersistentVolume" "name" .) }}{{ end }}
+    {{- with .Spec.storageClassName }} via {{ $.Include "resource_ref" (dict "kind" "StorageClass" "name" .) }}{{ end }}
     {{- with .Spec.volumeMode }}, with {{ . | bold }} mode{{ end }}
     {{- with .Status.capacity.storage }}, asks for {{ . | bold }}{{ end }}
-    {{- with index .Annotations "volume.beta.kubernetes.io/storage-provisioner" }}, provisioned by {{ . | bold }}{{ end }}
+    {{- with $storageProvisionerAnnotation }}, provisioned by {{ . | bold }}{{ end }}
     {{- with index .Annotations "volume.kubernetes.io/selected-node" }}, attached on {{ $.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
     {{- if not .Spec.volumeName }}, {{ "Pending" | red | bold }}: no paired PV yet{{ end }}
+    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "volume.beta.kubernetes.io/storage-provisioner") "warnMissing" (not $.Spec.volumeName)) }}{{ end }}
     {{- /* Disk usage: find running pods that have this PVC mounted, collect usage stats from the first one */ -}}
     {{- $pvcName := $.Name }}
     {{- $volStats := dict }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -66,6 +66,40 @@
     {{- end }}
 {{- end -}}
 
+{{- define "storageclass_summary" }}
+    {{- /* Expects dict "ctx" (RenderableObject, used for KubeGetFirst/Include/Config) "name"
+           (the storageClassName from a PV or PVC spec) "provisionerShown" (optional bool -- true
+           when the caller already printed the provisioner from an annotation, so this doesn't
+           repeat it) "warnMissing" (optional bool -- true when the caller's state indicates
+           provisioning/binding actually depends on this class, e.g. a still-Pending PVC, so a
+           missing class is worth flagging rather than silently ignored; PV.tmpl leaves this
+           unset since a legacy PV can be valid without one). Fetches the StorageClass object to
+           surface the provisioner (when not already on screen) and volumeBindingMode/
+           allowVolumeExpansion, which explain stuck/delayed binding and scheduling-before-
+           binding behavior. Silent when unfetchable (--shallow/--local) or when everything it
+           would show is either unremarkable (Immediate binding, no expansion) or already on
+           screen. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $sc := $ctx.KubeGetFirst "" "StorageClass" .name }}
+    {{- if $sc.Object }}
+        {{- $bindingMode := $sc.Object.volumeBindingMode | default "Immediate" }}
+        {{- $expandable := $sc.Object.allowVolumeExpansion }}
+        {{- $showProvisioner := not .provisionerShown }}
+        {{- if or $showProvisioner (ne $bindingMode "Immediate") $expandable }}
+            {{- "StorageClass" | bold | nindent 2 }}:
+            {{- $needsComma := false }}
+            {{- if $showProvisioner }} {{ $sc.Object.provisioner | cyan }}{{ $needsComma = true }}{{ end }}
+            {{- if ne $bindingMode "Immediate" }}{{ if $needsComma }},{{ end }} volumeBindingMode: {{ $bindingMode | colorKeyword }}{{ $needsComma = true }}{{ end }}
+            {{- if $expandable }}{{ if $needsComma }},{{ end }} allows volume expansion{{ end }}
+        {{- end }}
+        {{- if $ctx.Config.GetBool "deep" }}
+            {{- $ctx.Include "StorageClass" $sc | nindent 4 }}
+        {{- end }}
+    {{- else if and .warnMissing (not $ctx.LiveQueriesDisabled) }}
+        {{- "" | nindent 2 }}{{ $ctx.Include "resource_ref" (dict "kind" "StorageClass" "name" .name) }} {{ "not found" | red | bold }}: binding/provisioning cannot proceed without it
+    {{- end }}
+{{- end -}}
+
 {{- define "certificate_validity_line" }}
     {{- /* Expects dict "cert" (a parsed-certificate entry from parseTLSSecretCertificate /
            certificatesInSecret / certificatesInConfigMap / certificateInCSR -- all of which set

--- a/tests/artifacts/pvc-bound.out
+++ b/tests/artifacts/pvc-bound.out
@@ -1,4 +1,4 @@
 
 PersistentVolumeClaim/data-web-0 -n default, created 1m ago Bound
   Current: PVC is Bound
-  PVC uses PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc1, with Filesystem mode, asks for 10Gi
+  PVC uses PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc1 via StorageClass/standard, with Filesystem mode, asks for 10Gi

--- a/tests/artifacts/pvc-pending.out
+++ b/tests/artifacts/pvc-pending.out
@@ -2,4 +2,4 @@
 PersistentVolumeClaim/pvc-pending -n pvc-test, created 1m ago Pending
   InProgress: PVC is not Bound. phase: Pending
     Reconciling: NotBound, PVC is not Bound. phase: Pending
-  PVC, with Filesystem mode, Pending: no paired PV yet
+  PVC via StorageClass/no-such-class, with Filesystem mode, Pending: no paired PV yet

--- a/tests/artifacts/pvc-resize-in-progress.out
+++ b/tests/artifacts/pvc-resize-in-progress.out
@@ -2,5 +2,5 @@
 PersistentVolumeClaim/data-web-0 -n default, created 1m ago Bound
   Current: PVC is Bound
   FileSystemResizePending FileSystemResizePending, Waiting for user to (re-)start a pod to finish file system resize of volume on node. for 1m
-  PVC uses PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc2, with Filesystem mode, asks for 10Gi
+  PVC uses PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc2 via StorageClass/standard, with Filesystem mode, asks for 10Gi
   Resize: storage 10Gi → 20Gi NodeExpansionRequired

--- a/tests/e2e-artifacts/pvc-storageclass-missing.regex
+++ b/tests/e2e-artifacts/pvc-storageclass-missing.regex
@@ -1,0 +1,7 @@
+\A
+PersistentVolumeClaim/e2e-missing-sc-pvc -n e2e-storageclass, created 1m ago Pending
+  InProgress: PVC is not Bound\. phase: Pending
+    Reconciling: NotBound, PVC is not Bound\. phase: Pending
+  PVC via StorageClass/e2e-no-such-storageclass, with Filesystem mode, Pending: no paired PV yet
+  StorageClass/e2e-no-such-storageclass not found: binding/provisioning cannot proceed without it
+\z

--- a/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex
+++ b/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex
@@ -1,0 +1,10 @@
+\A
+PersistentVolumeClaim/e2e-wfc-pvc -n e2e-storageclass, created 1m ago Pending
+  InProgress: PVC is not Bound\. phase: Pending
+    Reconciling: NotBound, PVC is not Bound\. phase: Pending
+  PVC via StorageClass/e2e-wait-for-first-consumer, with Filesystem mode, Pending: no paired PV yet
+  StorageClass: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+    StorageClass/e2e-wait-for-first-consumer, created 1m ago
+      Current: Resource is current
+      Provisioner: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+\z

--- a/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex
+++ b/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex
@@ -1,0 +1,7 @@
+\A
+PersistentVolumeClaim/e2e-wfc-pvc -n e2e-storageclass, created 1m ago Pending
+  InProgress: PVC is not Bound\. phase: Pending
+    Reconciling: NotBound, PVC is not Bound\. phase: Pending
+  PVC via StorageClass/e2e-wait-for-first-consumer, with Filesystem mode, Pending: no paired PV yet
+  StorageClass: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+\z


### PR DESCRIPTION
## Summary
- Part of #669 (storage/volume enhancements). This is the StorageClass-fetch slice, delivered independently per the issue's delivery-slices guidance.
- `PersistentVolume.tmpl`/`PersistentVolumeClaim.tmpl` previously only printed the storage class *name*; now they fetch the object and surface `provisioner` (when not already visible via annotation), non-default `volumeBindingMode`, and `allowVolumeExpansion` — the fields that actually explain stuck/delayed binding and scheduling-before-consumer behavior.
- A still-Pending PVC whose referenced StorageClass doesn't exist now gets an explicit "not found" warning instead of rendering nothing.
- `--deep` inlines the full fetched StorageClass.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] 3 static golden artifacts regenerated (`pvc-bound`, `pvc-pending`, `pvc-resize-in-progress`) via `make update-artifacts`
- [x] New live e2e subtest in `TestE2EDynamicManifests` covering default fetch, `--deep` inline, and the missing-StorageClass warning — the only tier that exercises `KubeGetFirst`, since `--shallow`/`--local` (used by all offline artifact tests) makes it a no-op
- [x] Ran against real minikube; verified passing
- [x] Full `make test-e2e` suite run — clean aside from 2 pre-existing, unrelated failures in a Cilium/Calico network-policy test (transient `metrics.k8s.io` unavailability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)