### PR TITLE
Warn about node-memory eviction/OOM risk for non-Guaranteed pods

### DIFF
--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -219,8 +219,8 @@
         mem {{ .usageBytes | float64 | humanizeSI "B" -}}
         , workingSet {{ .workingSetBytes | float64 | humanizeSI "B" -}}
         , rss {{ .rssBytes | float64 | humanizeSI "B" -}}
-        {{- if .available -}}
-        , available {{ .available | float64 | humanizeSI "B" -}}
+        {{- if .availableBytes -}}
+        , available {{ .availableBytes | float64 | humanizeSI "B" -}}
         {{- end -}}
         , pageFaults/major {{ .pageFaults | float64 | humanizeSI "" }}/{{ .majorPageFaults | float64 | humanizeSI "" }}
     {{- end }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -81,9 +81,13 @@
                 {{- .IncludeRenderableObject $node | nindent 4 }}
             {{- else }}
                 {{- $unhealthy := list }}
+                {{- $memoryPressure := false }}
                 {{- range $node.StatusConditions }}
                     {{- if not (isStatusConditionHealthy .) }}
                         {{- $unhealthy = append $unhealthy . }}
+                        {{- if and (eq .type "MemoryPressure") (eq .status "True") }}
+                            {{- $memoryPressure = true }}
+                        {{- end }}
                     {{- end }}
                 {{- end }}
                 {{- $blockingTaints := taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}
@@ -98,6 +102,54 @@
                         {{- $val := "" }}{{ with .value }}{{ $val = printf "=%s" . }}{{ end }}
                         {{- printf "taint %s%s:%s (not tolerated)" .key $val .effect | red | bold | nindent 4 }}
                     {{- end }}
+                {{- end }}
+                {{- template "pod_memory_eviction_risk" (dict "pod" . "node" $node "memoryPressure" $memoryPressure) }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "pod_memory_eviction_risk" }}
+    {{- /* Expects a dict "pod" (Pod RenderableObject) "node" (Node RenderableObject) "memoryPressure"
+           (bool, node's MemoryPressure condition is True). Warns BestEffort/Burstable Pods: these
+           QoS classes are kubelet's first node-pressure-eviction candidates and get little to no
+           kernel OOM-killer protection (oom_score_adj 1000 / 2-999 vs Guaranteed's -997). Pod
+           Priority only affects kubelet eviction *order* within a QoS tier, it is not OOM
+           protection, so it never suppresses this warning. Guaranteed and system-node-critical
+           Pods stay silent: they're evicted last, if at all. Deliberately keyed off the node's
+           MemoryPressure condition (kubelet's own memory.available-crossed-threshold signal)
+           rather than a raw utilization percentage, per https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/. */ -}}
+    {{- $pod := .pod }}
+    {{- if and .memoryPressure (ne ($pod.Spec.priorityClassName | default "") "system-node-critical") }}
+        {{- with $pod.Status.qosClass }}
+            {{- $qos := . }}
+            {{- if eq $qos "BestEffort" }}
+                {{- "OOM / eviction risk" | red | bold | nindent 2 }}: Node {{ $.node.Name | cyan }} has {{ "MemoryPressure" | red | bold }}. Pod is {{ $qos | colorKeyword }}, the first kubelet eviction candidate under node memory pressure and has essentially no kernel-OOM protection. Pod Priority affects eviction order, not OOM protection.
+            {{- else if eq $qos "Burstable" }}
+                {{- $reqMem := 0.0 }}
+                {{- range $pod.Spec.containers }}
+                    {{- with .resources.requests.memory }}
+                        {{- $reqMem = $reqMem | addFloat64 (. | quantityToFloat64) }}
+                    {{- end }}
+                {{- end }}
+                {{- $podMetrics := $pod.KubeGetPodMetrics $pod.Namespace $pod.Name }}
+                {{- $usedMem := 0.0 }}
+                {{- $haveMetrics := false }}
+                {{- if ($podMetrics.Object | default dict).containers }}
+                    {{- $haveMetrics = true }}
+                    {{- range $podMetrics.Object.containers }}
+                        {{- with .usage.memory }}
+                            {{- $usedMem = $usedMem | addFloat64 (. | quantityToFloat64) }}
+                        {{- end }}
+                    {{- end }}
+                {{- end }}
+                {{- if and $haveMetrics (le $reqMem 0.0) }}
+                    {{- "OOM / eviction risk" | red | bold | nindent 2 }}: Node {{ $.node.Name | cyan }} has {{ "MemoryPressure" | red | bold }}. Pod is {{ $qos | colorKeyword }} with no memory request, using {{ $usedMem | humanizeSI "B" }}, a kubelet eviction candidate. Pod Priority affects eviction order, not OOM protection.
+                {{- else if and $haveMetrics (gt $usedMem $reqMem) }}
+                    {{- $percent := percent $usedMem $reqMem }}
+                    {{- "OOM / eviction risk" | red | bold | nindent 2 }}: Node {{ $.node.Name | cyan }} has {{ "MemoryPressure" | red | bold }}. Pod is {{ $qos | colorKeyword }}, using {{ $usedMem | humanizeSI "B" }} of its {{ $reqMem | humanizeSI "B" }} request ({{ $percent | colorPercent "%.0f%%" }}), a kubelet eviction candidate. Pod Priority affects eviction order, not OOM protection.
+                {{- else if not $haveMetrics }}
+                    {{- "Elevated memory-pressure risk" | yellow | nindent 2 }}: Node {{ $.node.Name | cyan }} has {{ "MemoryPressure" | red | bold }} and Pod is {{ $qos | colorKeyword }}. Usage vs its memory request is unknown (no metrics); eviction is governed by usage relative to request, not by this note alone.
                 {{- end }}
             {{- end }}
         {{- end }}

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -19,11 +19,11 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
     eviction-hard: nodefs.available<\d+% nodefs.inodesFree<\d+% imagefs.available<\d+%
     container log rotation: [\d.]+[A-Za-z]+ cap, \d+ files, \d+ worker, \S+ monitor
   kubelet-api/stats/summary:
-    node overall: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+, processes \S+/\S+ \(rlimit\)
+    node overall: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+, processes \S+/\S+ \(rlimit\)
       network: rx/tx [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, rx/tx errors \d+/\d+
       rootfs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free; \S+/\S+ inode, \S+ inode still free
       imagefs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free; \S+/\S+ inode, \S+ inode still free
-    (?:pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
-    kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+|kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+
-    pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+, pageFaults/major \S+/\S+)
+    (?:pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+
+    kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+|kubelet: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+
+    pods: cpu [\d.]+core/sec, mem [\d.]+[A-Za-z]+, workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+)
 \z

--- a/tests/e2e-artifacts/pod-on-bad-node.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node.regex
@@ -2,3 +2,4 @@ Node/kubectl-status-test-bad-node-[a-z0-9]+ cordoned \(unschedulable\)
 .*Ready KubeletNotReady, kubelet is not ready.*
 .*MemoryPressure KubeletHasInsufficientMemory, kubelet has insufficient memory available.*
 .*taint dedicated=gpu:NoSchedule \(not tolerated\)
+.*OOM / eviction risk.*Node kubectl-status-test-bad-node-[a-z0-9]+ has MemoryPressure.*Pod is BestEffort.*


### PR DESCRIPTION
## Summary

Closes #171. BestEffort and Burstable pods are kubelet's first node-pressure eviction candidates and get little to no kernel OOM-killer protection, but that risk was invisible on the Pod's own render. This adds a warning that:

- Triggers off the Node's `MemoryPressure` condition (kubelet's own `memory.available`-threshold signal), not a raw utilization percentage, per the issue's guidance.
- Factors in QoS and request-overage:
  - **BestEffort**: always flagged — first eviction candidate, no kernel-OOM protection.
  - **Burstable**: flagged when usage exceeds its memory request (or it has no request at all), with the usage/request ratio shown; a softer note when usage can't be determined (no metrics).
  - **Guaranteed**: no new warning — the pre-existing `MemoryPressure` condition line on the Node already surfaces the problem regardless of QoS.
  - `system-node-critical` pods are skipped.
- Never implies Pod Priority protects against the kernel OOM killer — wording says it only affects kubelet eviction *order*.

Also fixes a pre-existing dead-code bug in `Node.tmpl` where kubelet `stats/summary` memory.available was read from the wrong JSON key (`.available` instead of `.availableBytes`), so it silently rendered nothing.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] Offline golden-file tests (296) pass — these only confirm the template parses and there's no regression, since `--shallow` no-ops the Node lookup this feature depends on
- [x] Updated `tests/e2e-artifacts/pod-on-bad-node.regex` to expect the new warning (that fixture's Node already has `MemoryPressure=True`); needs a live cluster to actually execute — not available in this environment, will run in CI
- [ ] Manual verification against a live cluster with a real `MemoryPressure` node (not done — no cluster available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)