### PR TITLE
Fix PersistentVolume --deep rendering glued onto inlined StorageClass

### DIFF
--- a/pkg/plugin/templates/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/PersistentVolume.tmpl
@@ -7,13 +7,17 @@
     {{- "PV" | nindent 2 }} is {{- with .Status.phase }} {{ . | colorKeyword }}{{ end }}
     {{- with .Status.lastPhaseTransitionTime }}, since {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with .Spec.storageClassName  }} managed by {{ $.Include "resource_ref" (dict "kind" "StorageClass" "name" .) }}{{ end }}
-    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with index .Annotations "kubernetes.io/createdby" }} created by {{ . | bold }}{{ end }}
     {{- with $provisionedByAnnotation }} provisioned by {{ . | bold }}{{ end }}
     {{- with .Spec.accessModes }}{{- with index . 0 }} with {{ . | bold }} mode{{ end }}{{- end }}
     {{- with .Spec.persistentVolumeReclaimPolicy }}, reclaim: {{ . | cyan }}{{ end }}
     {{- with .Status.reason }}{{ "reason" | bold }}: {{ . }}{{ end }}
     {{- with .Status.message }}{{ "message" | red | bold | nindent 2 }}: {{ . }}{{- end }}{{/* Exists usually when there is problem */}}
+    {{- /* Placed after every same-line field above (not inline where the class is named) --
+           its --deep branch can inline a multi-line StorageClass block, and anything appended
+           on the same line after that would land glued onto its last line instead of the
+           original PV status line. */ -}}
+    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with .Spec.claimRef }}
         {{- "Created" | nindent 2 }} for {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace) }}
         {{- $pvc := $.KubeGetFirst .namespace .kind .name }}


### PR DESCRIPTION
## Summary
- Bugfix found while working on the VolumeAttachment slice of #669: `storageclass_summary`'s `--deep` branch (introduced in #731) can inline a multi-line `StorageClass` block. It was called mid-line in `PersistentVolume.tmpl`, between "managed by StorageClass/X" and later same-line fields (`provisioned by`, `reclaim:`), so under `--deep` those fields landed glued onto the inlined block's last line instead of continuing the original PV status line.
- Fix: move the `storageclass_summary` call to the end of that logical line, after every other same-line field, so nothing trails a potentially multi-line inline block.
- Split out from the VolumeAttachment work into its own PR per repo convention (small, independently reviewable fixes shouldn't ride along with feature PRs).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] `make update-artifacts` — no diff (bug only manifests under live `--deep`, which `--shallow`/`--local` used by all offline tests makes a no-op)
- [x] Verified live against minikube: before the fix, `kubectl status pv/<name> --deep` on a storage-classed PV showed `Provisioner: X provisioned by X with ReadWriteOnce mode, reclaim: Delete` glued onto one line inside the nested StorageClass block; after the fix, the PV's own status line and the nested StorageClass block render as separate, correctly indented blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)