### PR TITLE
Fetch VolumeAttachment from PersistentVolume

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -281,4 +281,88 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-missing.regex",
 		}.assert(t, nil, opts...)
 	})
+	t.Run("PersistentVolume surfaces a VolumeAttachment attach error", func(t *testing.T) {
+		// Issue #669: VolumeAttachment has zero references anywhere in the templates today, so a
+		// PV/PVC pair can render fully Bound while the actual CSI attach/detach is stuck or
+		// erroring -- invisible from both the Pod and PVC/PV views. minikube's own
+		// storage-provisioner addon isn't a real CSI driver (hostpath needs no attacher), so it
+		// never creates VolumeAttachment objects itself -- there's nothing to wait on
+		// deterministically. Instead we create the VolumeAttachment object directly against the
+		// API (same trick as the StorageClass subtest above): the apiserver only validates the
+		// object's shape, not that a driver is actually behind it, so this is fully
+		// deterministic and not flaky.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		// Its own namespace, not the "e2e-storageclass" one the subtest above uses: reusing it
+		// raced against that subtest's own namespace deletion still being in flight ("unable to
+		// create new content ... because it is being terminated") when both ran in the same
+		// process.
+		ns := "e2e-volumeattachment"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, nodes.Items)
+		nodeName := nodes.Items[0].Name
+
+		// No storageClassName -- picks up the cluster's default class (Immediate binding), so
+		// this actually provisions and binds a real PV to attach the fake VolumeAttachment to.
+		pvcName := "e2e-attach-error-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		pvc, err := clientset.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		require.NoError(t, err)
+		pvName := pvc.Spec.VolumeName
+		require.NotEmpty(t, pvName)
+
+		vaName := "e2e-fake-attach-error"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{Name: vaName},
+			Spec: storagev1.VolumeAttachmentSpec{
+				Attacher: "fake.csi.kubectl-status.io",
+				NodeName: nodeName,
+				Source:   storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvName},
+			},
+		}
+		created, err := clientset.StorageV1().VolumeAttachments().Create(context.TODO(), va, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.StorageV1().VolumeAttachments().Delete(context.TODO(), vaName, metav1.DeleteOptions{})
+		})
+		created.Status = storagev1.VolumeAttachmentStatus{
+			Attached: false,
+			AttachError: &storagev1.VolumeError{
+				Time:    metav1.Now(),
+				Message: "rpc error: code = Internal desc = fake attach failure for e2e test",
+			},
+		}
+		_, err = clientset.StorageV1().VolumeAttachments().UpdateStatus(context.TODO(), created, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pv/" + pvName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the matching VolumeAttachment in full -- offline artifact tests can't
+		// reach this branch either, since --shallow/--local (used by every offline test) makes
+		// the KubeGet behind it a no-op.
+		cmdTest{
+			args:            []string{"pv/" + pvName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error-deep.regex",
+		}.assert(t, nil, opts...)
+	})
 }

--- a/pkg/plugin/templates/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/PersistentVolume.tmpl
@@ -7,13 +7,17 @@
     {{- "PV" | nindent 2 }} is {{- with .Status.phase }} {{ . | colorKeyword }}{{ end }}
     {{- with .Status.lastPhaseTransitionTime }}, since {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with .Spec.storageClassName  }} managed by {{ $.Include "resource_ref" (dict "kind" "StorageClass" "name" .) }}{{ end }}
-    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with index .Annotations "kubernetes.io/createdby" }} created by {{ . | bold }}{{ end }}
     {{- with $provisionedByAnnotation }} provisioned by {{ . | bold }}{{ end }}
     {{- with .Spec.accessModes }}{{- with index . 0 }} with {{ . | bold }} mode{{ end }}{{- end }}
     {{- with .Spec.persistentVolumeReclaimPolicy }}, reclaim: {{ . | cyan }}{{ end }}
     {{- with .Status.reason }}{{ "reason" | bold }}: {{ . }}{{ end }}
     {{- with .Status.message }}{{ "message" | red | bold | nindent 2 }}: {{ . }}{{- end }}{{/* Exists usually when there is problem */}}
+    {{- /* Placed after every same-line field above (not inline where the class is named) --
+           its --deep branch can inline a multi-line StorageClass block, and anything appended
+           on the same line after that would land glued onto its last line instead of the
+           original PV status line. */ -}}
+    {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" (hasKey $.Annotations "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with .Spec.claimRef }}
         {{- "Created" | nindent 2 }} for {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace) }}
         {{- $pvc := $.KubeGetFirst .namespace .kind .name }}

--- a/pkg/plugin/templates/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/PersistentVolume.tmpl
@@ -44,6 +44,7 @@
         {{- with .shareName }}, share name is {{ . | bold }}{{end}}
         {{- with .readOnly }}, in {{ "RO" | bold | yellow }} mode{{ end }}
     {{- end }}
+    {{- $.Include "volumeattachment_diagnosis" (dict "ctx" $ "pvName" $.Name) }}
     {{- template "application_details" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}

--- a/pkg/plugin/templates/VolumeAttachment.tmpl
+++ b/pkg/plugin/templates/VolumeAttachment.tmpl
@@ -1,0 +1,26 @@
+{{- define "VolumeAttachment" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: storage.k8s.io/v1, Kind=VolumeAttachment */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- "Attacher" | bold | nindent 2 }}: {{ .Spec.attacher | cyan }}
+    {{- with .Spec.source.persistentVolumeName }}, volume {{ $.Include "resource_ref" (dict "kind" "PersistentVolume" "name" .) }}{{ end }}
+    {{- with .Spec.nodeName }}, node {{ $.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
+    {{- if .Status.attached }}
+        {{- ", " }}{{ "attached" | green }}
+    {{- else }}
+        {{- ", " }}{{ "not attached" | red | bold }}
+    {{- end }}
+    {{- with .Status.attachError }}
+        {{- "Attach error" | red | bold | nindent 2 }}: {{ .message }}
+        {{- with .time }} ({{ . | colorAgo }}{{ agoSuffix }}){{ end }}
+    {{- end }}
+    {{- with .Status.detachError }}
+        {{- "Detach error" | red | bold | nindent 2 }}: {{ .message }}
+        {{- with .time }} ({{ . | colorAgo }}{{ agoSuffix }}){{ end }}
+    {{- end }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -100,6 +100,59 @@
     {{- end }}
 {{- end -}}
 
+{{- define "volumeattachment_diagnosis" }}
+    {{- /* Expects dict "ctx" (RenderableObject, used for KubeGet/Include/Config/
+           LiveQueriesDisabled) "pvName" (the PersistentVolume's own name -- VolumeAttachment is
+           cluster-scoped and keyed by spec.source.persistentVolumeName, not by claim, so this is
+           only callable with a PV name in hand; PersistentVolumeClaim.tmpl resolves its bound PV
+           first rather than duplicating this lookup). VolumeAttachment has zero references
+           anywhere else in the templates -- without this, a PVC/PV pair can show fully Bound
+           while the actual CSI attach/detach is stuck, erroring, or left over on a stale node,
+           and nothing on the Pod or PVC/PV views surfaces that. Silent when unfetchable
+           (--shallow/--local) or when every matching attachment looks healthy: a nominal
+           "attached: true" record is not worth a line by default. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $pvName := .pvName }}
+    {{- if not $ctx.LiveQueriesDisabled }}
+        {{- $matching := list }}
+        {{- range $ctx.KubeGet "" "VolumeAttachment" }}
+            {{- if eq (.Spec.source.persistentVolumeName | default "") $pvName }}
+                {{- $matching = append $matching . }}
+            {{- end }}
+        {{- end }}
+        {{- $attachedCount := 0 }}
+        {{- range $matching }}
+            {{- if and .Status.attached (not .Metadata.deletionTimestamp) }}{{ $attachedCount = add $attachedCount 1 }}{{ end }}
+        {{- end }}
+        {{- range $matching }}
+            {{- $va := . }}
+            {{- $hasProblem := or $va.Metadata.deletionTimestamp (not $va.Status.attached) $va.Status.attachError $va.Status.detachError (gt $attachedCount 1) }}
+            {{- if $hasProblem }}
+                {{- "VolumeAttachment" | bold | nindent 2 }}: {{ $ctx.Include "resource_ref" (dict "kind" "VolumeAttachment" "name" $va.Name) }}, node {{ $ctx.Include "resource_ref" (dict "kind" "Node" "name" $va.Spec.nodeName) }}
+                {{- if $va.Metadata.deletionTimestamp }}
+                    {{- ", " }}{{ "detaching" | yellow | bold }} (deletion in progress)
+                {{- else if $va.Status.attached }}
+                    {{- ", " }}{{ "attached" | green }}
+                {{- else }}
+                    {{- ", " }}{{ "not attached" | red | bold }}
+                {{- end }}
+                {{- if gt $attachedCount 1 }}
+                    {{- ", " }}{{ "conflict" | red | bold }}: volume is attached on more than one node at once
+                {{- end }}
+                {{- with $va.Status.attachError }}
+                    {{- "Attach error" | red | bold | nindent 4 }}: {{ .message }}
+                {{- end }}
+                {{- with $va.Status.detachError }}
+                    {{- "Detach error" | red | bold | nindent 4 }}: {{ .message }}
+                {{- end }}
+                {{- if $ctx.Config.GetBool "deep" }}
+                    {{- $ctx.Include "VolumeAttachment" $va | nindent 4 }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
 {{- define "certificate_validity_line" }}
     {{- /* Expects dict "cert" (a parsed-certificate entry from parseTLSSecretCertificate /
            certificatesInSecret / certificatesInConfigMap / certificateInCSR -- all of which set

--- a/tests/artifacts/volumeattachment-attach-error.out
+++ b/tests/artifacts/volumeattachment-attach-error.out
@@ -1,0 +1,5 @@
+
+VolumeAttachment/csi-9f8e7d6c5b4a3210, created 1m ago
+  Current: Resource is current
+  Attacher: ebs.csi.aws.com, volume PersistentVolume/pvc-fedcba98-7654-3210-fedc-ba9876543210, node Node/ip-10-0-0-2.ec2.internal, not attached
+  Attach error: rpc error: code = Internal desc = Could not attach volume "vol-0123456789abcdef0" to node "i-0123456789abcdef0": attachment limit exceeded (1m ago)

--- a/tests/artifacts/volumeattachment-attach-error.yaml
+++ b/tests/artifacts/volumeattachment-attach-error.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttachment
+metadata:
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: csi-9f8e7d6c5b4a3210
+  resourceVersion: "317052"
+  uid: c3d4e5f6-a7b8-9012-cdef-123456789012
+spec:
+  attacher: ebs.csi.aws.com
+  nodeName: ip-10-0-0-2.ec2.internal
+  source:
+    persistentVolumeName: pvc-fedcba98-7654-3210-fedc-ba9876543210
+status:
+  attached: false
+  attachError:
+    time: "2026-07-10T14:53:59Z"
+    message: "rpc error: code = Internal desc = Could not attach volume \"vol-0123456789abcdef0\" to node \"i-0123456789abcdef0\": attachment limit exceeded"

--- a/tests/artifacts/volumeattachment-attached.out
+++ b/tests/artifacts/volumeattachment-attached.out
@@ -1,0 +1,4 @@
+
+VolumeAttachment/csi-1a2b3c4d5e6f7890, created 1m ago
+  Current: Resource is current
+  Attacher: ebs.csi.aws.com, volume PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc1, node Node/ip-10-0-0-1.ec2.internal, attached

--- a/tests/artifacts/volumeattachment-attached.yaml
+++ b/tests/artifacts/volumeattachment-attached.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttachment
+metadata:
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: csi-1a2b3c4d5e6f7890
+  resourceVersion: "317051"
+  uid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+spec:
+  attacher: ebs.csi.aws.com
+  nodeName: ip-10-0-0-1.ec2.internal
+  source:
+    persistentVolumeName: pvc-23498768-c86b-4102-a660-139ed9044bc1
+status:
+  attached: true

--- a/tests/e2e-artifacts/pv-volumeattachment-error-deep.regex
+++ b/tests/e2e-artifacts/pv-volumeattachment-error-deep.regex
@@ -1,0 +1,16 @@
+\A
+PersistentVolume/\S+, created 1m ago Bound
+  Current: Resource is current
+  PV is Bound, since 1m ago managed by StorageClass/standard provisioned by \S+ with ReadWriteOnce mode, reclaim: Delete
+    StorageClass/standard, created 1m ago
+      Current: Resource is current
+      Default StorageClass
+      Provisioner: \S+
+  Created for PersistentVolumeClaim/e2e-attach-error-pvc -n e2e-volumeattachment
+  VolumeAttachment: VolumeAttachment/e2e-fake-attach-error, node Node/\S+, not attached
+    Attach error: rpc error: code = Internal desc = fake attach failure for e2e test
+    VolumeAttachment/e2e-fake-attach-error, created 1m ago
+      Current: Resource is current
+      Attacher: fake\.csi\.kubectl-status\.io, volume PersistentVolume/\S+, node Node/\S+, not attached
+      Attach error: rpc error: code = Internal desc = fake attach failure for e2e test \(1m ago\)
+\z

--- a/tests/e2e-artifacts/pv-volumeattachment-error.regex
+++ b/tests/e2e-artifacts/pv-volumeattachment-error.regex
@@ -1,0 +1,8 @@
+\A
+PersistentVolume/\S+, created 1m ago Bound
+  Current: Resource is current
+  PV is Bound, since 1m ago managed by StorageClass/standard provisioned by \S+ with ReadWriteOnce mode, reclaim: Delete
+  Created for PersistentVolumeClaim/e2e-attach-error-pvc -n e2e-volumeattachment
+  VolumeAttachment: VolumeAttachment/e2e-fake-attach-error, node Node/\S+, not attached
+    Attach error: rpc error: code = Internal desc = fake attach failure for e2e test
+\z


### PR DESCRIPTION
## Summary
- Part of #669 (storage/volume enhancements). This is the VolumeAttachment slice (P0, highest operational value per the issue's delivery-slices guidance), delivered independently.
- **Depends on #733** — this branch is stacked on top of it (includes its commit) so this PR's own e2e coverage isn't broken by the bug it fixes. The diff here will shrink to just the VolumeAttachment changes once #733 merges and this branch is rebased.
- `VolumeAttachment` previously had zero references anywhere in the templates. A PV/PVC pair could render fully `Bound` while the actual CSI attach/detach was stuck, erroring, or left over on a stale node — invisible from both the Pod and PVC/PV views.
- New `volumeattachment_diagnosis` partial (in `common.tmpl`), wired into `PersistentVolume.tmpl`: resolves matching `VolumeAttachment`s by `spec.source.persistentVolumeName` from the PV, and renders a compact diagnosis **only on failure/ambiguity** — deletion in progress, `attached: false`, an attach/detach error, or more than one attachment on the volume at once. A nominal `attached: true` record stays silent by design (per the issue: "a healthy attachment adds little signal").
- New standalone `VolumeAttachment.tmpl` so `kubectl status volumeattachment/x` renders properly on its own; `--deep` on the PV inlines the matching object in full.
- PVC-side lookup (PVC → its bound PV → VolumeAttachment) is intentionally deferred — implementing from PV first avoids turning `PersistentVolumeClaim.tmpl` into a multi-hop lookup engine, per the issue's own guidance. Noting this as the known follow-up.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] 2 new static golden artifacts (`volumeattachment-attached`, `volumeattachment-attach-error`) for the standalone template
- [x] Live e2e subtest in `TestE2EDynamicManifests`: minikube's own storage-provisioner addon isn't a real CSI driver (hostpath needs no attacher), so it never creates `VolumeAttachment` objects itself — nothing to wait on deterministically. Instead the test creates the `VolumeAttachment` object directly against the API (same approach as the StorageClass slice): the apiserver only validates the object's shape, not that a driver is behind it, so this is deterministic and not flaky.
- [x] Covers default-mode diagnosis and `--deep` full inline; verified passing against real minikube, including a full `TestE2EDynamicManifests` rerun alongside the other subtests (caught and fixed a namespace-collision race between subtests along the way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)