### PR TITLE
Surface ReadWriteOncePod claim holder on PersistentVolumeClaim (#669)

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -281,6 +281,154 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-missing.regex",
 		}.assert(t, nil, opts...)
 	})
+	t.Run("PersistentVolumeClaim surfaces its ReadWriteOncePod holder and a scheduling conflict", func(t *testing.T) {
+		// Issue #669: a ReadWriteOncePod claim allows only one non-terminal Pod to use it at a
+		// time -- enforced by the kube-scheduler's built-in VolumeRestrictions plugin, no CSI
+		// driver involved, so this is fully deterministic on minikube's default scheduler.
+		// Before this, PersistentVolumeClaim.tmpl gave no indication of which Pod currently
+		// holds the claim, nor any explicit signal when a second Pod is stuck behind it.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-rwop"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		// No storageClassName -- picks up the cluster's default class (Immediate binding), so
+		// the claim binds to a real PV before any Pod exists.
+		pvcName := "e2e-rwop-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		podSpec := func(pvcName string) corev1.PodSpec {
+			return corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name: "data",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+					},
+				}},
+			}
+		}
+
+		holderName := "e2e-rwop-holder"
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: holderName},
+			Spec:       podSpec(pvcName),
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Pods(ns).Delete(context.TODO(), holderName, metav1.DeleteOptions{})
+		})
+		waitForInNamespace(t, "pod/"+holderName, "condition=Ready", ns)
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-rwop-holder.regex",
+		}.assert(t, nil, opts...)
+
+		// A second Pod referencing the same ReadWriteOncePod claim can't be scheduled while the
+		// first is non-terminal -- the scheduler's VolumeRestrictions plugin rejects it and
+		// records that in the Pod's own PodScheduled condition, which is what
+		// rwop_holder_diagnosis keys off to avoid guessing at the cause of an unrelated pending
+		// Pod.
+		conflictName := "e2e-rwop-conflict"
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: conflictName},
+			Spec:       podSpec(pvcName),
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Pods(ns).Delete(context.TODO(), conflictName, metav1.DeleteOptions{})
+		})
+		waitForInNamespace(t, "pod/"+conflictName,
+			`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}=False`, ns)
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-rwop-blocked.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("PersistentVolumeClaim renders an explicit conflict when two non-terminal Pods are scheduled against one ReadWriteOncePod claim", func(t *testing.T) {
+		// Issue #669: rwop_holder_diagnosis must never pick one Pod arbitrarily when more than
+		// one non-terminal Pod is scheduled against the same RWOP claim -- it has to render an
+		// explicit conflict instead. The kube-scheduler's VolumeRestrictions plugin normally
+		// prevents this from happening for real (see the subtest above), so to exercise the
+		// conflict branch deterministically we set spec.nodeName at Pod creation time, which
+		// skips the scheduler (and its RWOP check) entirely -- same "create it directly against
+		// the API" trick the VolumeAttachment subtest below uses to bypass needing a real CSI
+		// driver behind it. Pointed at a node name that doesn't exist rather than a real one: no
+		// kubelet ever claims the Pod, so phase stays Pending with no containerStatuses forever,
+		// instead of racing a real kubelet's admission/scheduling of the render against the
+		// test -- which flipped phase and readiness between runs when tried against a real node.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-rwop-conflict"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		const nodeName = "e2e-rwop-conflict-no-such-node"
+
+		pvcName := "e2e-rwop-conflict-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		for _, name := range []string{"e2e-rwop-conflict-a", "e2e-rwop-conflict-b"} {
+			_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+					Containers: []corev1.Container{{
+						Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+						},
+					}},
+				},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			podName := name
+			t.Cleanup(func() {
+				clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			})
+		}
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-rwop-conflict.regex",
+		}.assert(t, nil, opts...)
+	})
 	t.Run("PersistentVolume surfaces a VolumeAttachment attach error", func(t *testing.T) {
 		// Issue #669: VolumeAttachment has zero references anywhere in the templates today, so a
 		// PV/PVC pair can render fully Bound while the actual CSI attach/detach is stuck or

--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -70,6 +70,7 @@
             {{- $.Include "pod_health_summary" . | nindent 4 }}
         {{- end }}
     {{- end }}
+    {{- $.Include "rwop_holder_diagnosis" (dict "ctx" $ "pods" $usingPods "accessModes" (.Spec.accessModes | default list)) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -153,6 +153,55 @@
     {{- end }}
 {{- end -}}
 
+{{- define "rwop_holder_diagnosis" }}
+    {{- /* Expects dict "ctx" (RenderableObject, used for Include) "pods" ([]RenderableObject --
+           the Pods in the claim's namespace that mount it, already resolved by the caller since
+           PersistentVolumeClaim.tmpl needs that same Pod scan for its disk-usage stats and this
+           reuses it rather than running a second KubeGet pass) "accessModes" (the PVC's
+           spec.accessModes list). A no-op unless the claim uses the ReadWriteOncePod access
+           mode, which the apiserver/scheduler enforce as at most one non-terminal Pod using the
+           claim at a time. Silent when there's no non-terminal Pod yet (nothing to report) or
+           when a lone Pending Pod's own PodScheduled condition doesn't establish that RWOP is
+           what's blocking it -- guessing here would blame the wrong cause for an unscheduled
+           Pod. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if has "ReadWriteOncePod" .accessModes }}
+        {{- $scheduled := list }}
+        {{- $pending := list }}
+        {{- range .pods }}
+            {{- if not (has .Status.phase (list "Succeeded" "Failed")) }}
+                {{- if .Spec.nodeName }}
+                    {{- $scheduled = append $scheduled . }}
+                {{- else }}
+                    {{- $pending = append $pending . }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- if gt (len $scheduled) 1 }}
+            {{- "RWOP" | bold | nindent 2 }}: {{ "conflict" | red | bold }}: more than one non-terminal Pod is scheduled against this ReadWriteOncePod claim:
+            {{- range $scheduled }}
+                {{- $ctx.Include "pod_health_summary" . | nindent 4 }}
+                {{- with .Spec.nodeName }}, node {{ $ctx.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
+            {{- end }}
+        {{- else if eq (len $scheduled) 1 }}
+            {{- $holder := index $scheduled 0 }}
+            {{- "RWOP holder" | bold | nindent 2 }}: {{ $ctx.Include "pod_health_summary" $holder }}
+            {{- with $holder.Spec.nodeName }}, node {{ $ctx.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
+        {{- end }}
+        {{- /* Checked independently of the holder/conflict branches above: a Pod can be Pending
+               behind an already-scheduled holder, and that's the common real-world shape of this
+               (one Pod running, a second stuck waiting for it), not an either/or with it. */ -}}
+        {{- range $pending }}
+            {{- $pod := . }}
+            {{- with $pod.StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
+                {{- if and (eq .status "False") (contains "ReadWriteOncePod" (.message | default "")) }}
+                    {{- "RWOP" | bold | nindent 2 }}: {{ $ctx.Include "pod_health_summary" $pod }}, {{ "blocked" | red | bold }}: {{ .message }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
 {{- define "certificate_validity_line" }}
     {{- /* Expects dict "cert" (a parsed-certificate entry from parseTLSSecretCertificate /
            certificatesInSecret / certificatesInConfigMap / certificateInCSR -- all of which set

--- a/tests/e2e-artifacts/pvc-rwop-blocked.regex
+++ b/tests/e2e-artifacts/pvc-rwop-blocked.regex
@@ -1,0 +1,10 @@
+\A
+PersistentVolumeClaim/e2e-rwop-pvc -n e2e-rwop, created 1m ago Bound
+  Current: PVC is Bound
+  PVC uses PersistentVolume/\S+ via StorageClass/standard, with Filesystem mode, asks for 1Gi, provisioned by \S+
+  Pods:
+    Pod/e2e-rwop-holder, created 1m ago Running, 1/1 ready
+    Pod/e2e-rwop-conflict, created 1m ago Pending
+  RWOP holder: Pod/e2e-rwop-holder, created 1m ago Running, 1/1 ready, node Node/\S+
+  RWOP: Pod/e2e-rwop-conflict, created 1m ago Pending, blocked: 0/1 nodes are available: 1 node\(s\) unavailable due to PersistentVolumeClaim with ReadWriteOncePod access mode already in-use by another pod\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod\.
+\z

--- a/tests/e2e-artifacts/pvc-rwop-conflict.regex
+++ b/tests/e2e-artifacts/pvc-rwop-conflict.regex
@@ -1,0 +1,11 @@
+\A
+PersistentVolumeClaim/e2e-rwop-conflict-pvc -n e2e-rwop-conflict, created 1m ago Bound
+  Current: PVC is Bound
+  PVC uses PersistentVolume/\S+ via StorageClass/standard, with Filesystem mode, asks for 1Gi, provisioned by \S+
+  Pods:
+    Pod/e2e-rwop-conflict-a, created 1m ago Pending
+    Pod/e2e-rwop-conflict-b, created 1m ago Pending
+  RWOP: conflict: more than one non-terminal Pod is scheduled against this ReadWriteOncePod claim:
+    Pod/e2e-rwop-conflict-a, created 1m ago Pending, node Node/e2e-rwop-conflict-no-such-node
+    Pod/e2e-rwop-conflict-b, created 1m ago Pending, node Node/e2e-rwop-conflict-no-such-node
+\z

--- a/tests/e2e-artifacts/pvc-rwop-holder.regex
+++ b/tests/e2e-artifacts/pvc-rwop-holder.regex
@@ -1,0 +1,8 @@
+\A
+PersistentVolumeClaim/e2e-rwop-pvc -n e2e-rwop, created 1m ago Bound
+  Current: PVC is Bound
+  PVC uses PersistentVolume/\S+ via StorageClass/standard, with Filesystem mode, asks for 1Gi, provisioned by \S+
+  Pods:
+    Pod/e2e-rwop-holder, created 1m ago Running, 1/1 ready
+  RWOP holder: Pod/e2e-rwop-holder, created 1m ago Running, 1/1 ready, node Node/\S+
+\z


### PR DESCRIPTION
## Summary
- RWOP (`ReadWriteOncePod`) claims allow only one non-terminal Pod to use them at a time, but `PersistentVolumeClaim.tmpl` gave no indication of which Pod currently holds one, nor any signal when a second Pod is stuck behind it.
- Adds `rwop_holder_diagnosis`, reusing the Pod scan the template already runs for its disk-usage stats: a compact "holder" line (Pod + node + compact pod health) when exactly one non-terminal Pod is scheduled, an explicit "conflict" line rather than picking one arbitrarily when more than one is, and a "blocked" line for a Pending Pod only when its own `PodScheduled` condition actually names RWOP as the cause.
- Part of #669; this is the first of two remaining slices (RWOP here, VolumeSnapshot/VolumeSnapshotContent to follow in a separate PR).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` all clean
- [x] New `cmd/e2e_dynamic_test.go` subtests against a live minikube cluster, run repeatedly to confirm determinism:
  - holder: single Pod running → "RWOP holder" line with Pod/node
  - blocked: second Pod created behind it → scheduler's real `FailedScheduling`/`PodScheduled=False` message surfaces as "RWOP: ... blocked"
  - conflict: two Pods pinned to the same (nonexistent, for determinism) node bypass the scheduler entirely → explicit "RWOP: conflict" line instead of picking one arbitrarily
- [x] `--shallow`/`--local` naturally omit the whole section since it's driven entirely by the existing live Pod-scan loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)