### PR TITLE
Pod: render hard node-selection constraints for unscheduled Pods

### DIFF
--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -125,6 +125,8 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"untilClause":                     cfg.untilClause,
 		"labelSelector":                   labelSelector,
 		"taintsNotToleratedByPod":         taintsNotToleratedByPod,
+		"formatNodeSelector":              formatNodeSelector,
+		"formatNodeSelectorTerms":         formatNodeSelectorTerms,
 		"networkPolicyPolicyTypes":        networkPolicyPolicyTypes,
 		"calicoPolicyTypes":               calicoPolicyTypes,
 		"ciliumPolicyDirections":          ciliumPolicyDirectionsForTemplate,
@@ -847,6 +849,200 @@ func taintsNotToleratedByPod(nodeTaints, tolerations []interface{}) (result []in
 		}
 	}
 	return result
+}
+
+// formatNodeSelector renders spec.nodeSelector, a flat key/value map, as "k=v,k2=v2" -- the same
+// comma-joined "k=v" convention used elsewhere for rendered label selectors, keys sorted for
+// stable output.
+func formatNodeSelector(nodeSelector map[string]interface{}) string {
+	keys := make([]string, 0, len(nodeSelector))
+	for k := range nodeSelector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v, _ := nodeSelector[k].(string)
+		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(parts, ",")
+}
+
+// toInterfaceMapSlice converts an unstructured field (expected to be a []interface{} of
+// map[string]interface{} elements, e.g. matchExpressions/matchFields) into []map[string]interface{},
+// tolerating (by skipping) any element that isn't shaped like one -- unstructured content from the
+// API server is never guaranteed to match the expected shape.
+func toInterfaceMapSlice(field interface{}) []map[string]interface{} {
+	items, _ := field.([]interface{})
+	result := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// toStringSlice converts an unstructured []interface{} of strings (e.g. a NodeSelectorRequirement
+// "values" field) into a []string, skipping any non-string element.
+func toStringSlice(values interface{}) []string {
+	items, _ := values.([]interface{})
+	result := make([]string, 0, len(items))
+	for _, v := range items {
+		if s, ok := v.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// formatNodeSelectorRequirement renders a single matchExpressions/matchFields entry from
+// spec.affinity.nodeAffinity, mirroring the compact style of
+// k8s.io/apimachinery/pkg/labels.Requirement.String() ("key in (a,b)", "!key", "key>5") but
+// extended with Gt/Lt, which LabelSelectorRequirement doesn't support -- this is deliberately not
+// routed through the labelSelector pipe function, since NodeSelectorRequirement isn't
+// metav1.LabelSelector-shaped and silently dropping Gt/Lt would misrepresent the constraint.
+func formatNodeSelectorRequirement(expr map[string]interface{}) string {
+	key, _ := expr["key"].(string)
+	operator, _ := expr["operator"].(string)
+	values := toStringSlice(expr["values"])
+	joined := strings.Join(values, ",")
+	switch operator {
+	case "Exists":
+		return key
+	case "DoesNotExist":
+		return "!" + key
+	case "In":
+		return fmt.Sprintf("%s in (%s)", key, joined)
+	case "NotIn":
+		return fmt.Sprintf("%s notin (%s)", key, joined)
+	case "Gt":
+		return fmt.Sprintf("%s>%s", key, joined)
+	case "Lt":
+		return fmt.Sprintf("%s<%s", key, joined)
+	default:
+		return fmt.Sprintf("%s %s (%s)", key, operator, joined)
+	}
+}
+
+// formatNodeSelectorTerm renders one nodeSelectorTerm as the AND of its matchExpressions and
+// matchFields requirements.
+func formatNodeSelectorTerm(term map[string]interface{}) string {
+	var parts []string
+	for _, e := range toInterfaceMapSlice(term["matchExpressions"]) {
+		parts = append(parts, formatNodeSelectorRequirement(e))
+	}
+	for _, e := range toInterfaceMapSlice(term["matchFields"]) {
+		parts = append(parts, formatNodeSelectorRequirement(e))
+	}
+	return strings.Join(parts, ",")
+}
+
+// formatNodeSelectorTerms renders
+// spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms as
+// the OR of its terms, each an AND of its requirements. Multiple terms are parenthesized so the
+// OR/AND nesting stays unambiguous.
+func formatNodeSelectorTerms(terms []interface{}) string {
+	rendered := make([]string, 0, len(terms))
+	for _, t := range terms {
+		term, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if r := formatNodeSelectorTerm(term); r != "" {
+			rendered = append(rendered, r)
+		}
+	}
+	if len(rendered) > 1 {
+		for i, r := range rendered {
+			rendered[i] = fmt.Sprintf("(%s)", r)
+		}
+	}
+	return strings.Join(rendered, " or ")
+}
+
+// nodeSelectorRequirementMatches reports whether values (nodeLabels or nodeFields) satisfies a
+// single matchExpressions/matchFields requirement, mirroring
+// k8s.io/apimachinery/pkg/labels.Requirement.Matches: NotIn and DoesNotExist are satisfied when
+// the key is absent; In, Exists, Gt and Lt all require the key to be present.
+func nodeSelectorRequirementMatches(expr map[string]interface{}, values map[string]string) bool {
+	key, _ := expr["key"].(string)
+	operator, _ := expr["operator"].(string)
+	val, exists := values[key]
+	reqValues := toStringSlice(expr["values"])
+	switch operator {
+	case "In":
+		return exists && stringSliceContains(reqValues, val)
+	case "NotIn":
+		return !exists || !stringSliceContains(reqValues, val)
+	case "Exists":
+		return exists
+	case "DoesNotExist":
+		return !exists
+	case "Gt":
+		return exists && len(reqValues) == 1 && numericLess(reqValues[0], val)
+	case "Lt":
+		return exists && len(reqValues) == 1 && numericLess(val, reqValues[0])
+	default:
+		return false
+	}
+}
+
+// stringSliceContains reports whether s is present in values.
+func stringSliceContains(values []string, s string) bool {
+	for _, v := range values {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// numericLess reports whether a < b, treating both as base-10 integers. A non-integer operand
+// (malformed input) never satisfies the comparison, matching Requirement.Matches' behavior of
+// treating unparsable Gt/Lt values as non-matching rather than erroring.
+func numericLess(a, b string) bool {
+	aInt, aErr := strconv.ParseInt(a, 10, 64)
+	bInt, bErr := strconv.ParseInt(b, 10, 64)
+	return aErr == nil && bErr == nil && aInt < bInt
+}
+
+// nodeSelectorTermMatches reports whether nodeLabels/nodeFields satisfy a single nodeSelectorTerm:
+// AND across its matchExpressions (checked against nodeLabels) and matchFields (checked against
+// nodeFields).
+func nodeSelectorTermMatches(term map[string]interface{}, nodeLabels, nodeFields map[string]string) bool {
+	for _, e := range toInterfaceMapSlice(term["matchExpressions"]) {
+		if !nodeSelectorRequirementMatches(e, nodeLabels) {
+			return false
+		}
+	}
+	for _, e := range toInterfaceMapSlice(term["matchFields"]) {
+		if !nodeSelectorRequirementMatches(e, nodeFields) {
+			return false
+		}
+	}
+	return true
+}
+
+// nodeSelectorTermsMatch reports whether nodeLabels/nodeFields satisfy at least one of terms (OR
+// across terms), implementing required-during-scheduling node affinity semantics. An empty terms
+// list is unconstrained and matches everything -- mirroring
+// k8s.io/component-helpers/scheduling/corev1/nodeaffinity's treatment of an absent
+// nodeAffinity/nodeSelector as "no constraint" rather than "matches nothing".
+func nodeSelectorTermsMatch(terms []interface{}, nodeLabels, nodeFields map[string]string) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	for _, t := range terms {
+		term, ok := t.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if nodeSelectorTermMatches(term, nodeLabels, nodeFields) {
+			return true
+		}
+	}
+	return false
 }
 
 // networkPolicySelectsPod reports whether a NetworkPolicy's spec.podSelector matches podLabels.

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -334,6 +334,278 @@ func TestTaintsNotToleratedByPod(t *testing.T) {
 	}
 }
 
+func TestFormatNodeSelector(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeSelector map[string]interface{}
+		want         string
+	}{
+		{
+			name:         "empty",
+			nodeSelector: map[string]interface{}{},
+			want:         "",
+		},
+		{
+			name:         "single key",
+			nodeSelector: map[string]interface{}{"disktype": "ssd"},
+			want:         "disktype=ssd",
+		},
+		{
+			name:         "multiple keys are sorted",
+			nodeSelector: map[string]interface{}{"zone": "us-east-1a", "disktype": "ssd"},
+			want:         "disktype=ssd,zone=us-east-1a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatNodeSelector(tt.nodeSelector); got != tt.want {
+				t.Errorf("formatNodeSelector() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatNodeSelectorTerms(t *testing.T) {
+	tests := []struct {
+		name  string
+		terms []interface{}
+		want  string
+	}{
+		{
+			name:  "no terms",
+			terms: nil,
+			want:  "",
+		},
+		{
+			name: "single term, single expression",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "disktype", "operator": "In", "values": []interface{}{"ssd"}},
+				}},
+			},
+			want: "disktype in (ssd)",
+		},
+		{
+			name: "single term, multiple AND'd expressions and fields",
+			terms: []interface{}{
+				map[string]interface{}{
+					"matchExpressions": []interface{}{
+						map[string]interface{}{"key": "zone", "operator": "In", "values": []interface{}{"a", "b"}},
+						map[string]interface{}{"key": "gpu", "operator": "DoesNotExist"},
+					},
+					"matchFields": []interface{}{
+						map[string]interface{}{"key": "metadata.name", "operator": "NotIn", "values": []interface{}{"node-1"}},
+					},
+				},
+			},
+			want: "zone in (a,b),!gpu,metadata.name notin (node-1)",
+		},
+		{
+			name: "multiple OR'd terms are parenthesized",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "zone", "operator": "In", "values": []interface{}{"a"}},
+				}},
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "zone", "operator": "In", "values": []interface{}{"b"}},
+				}},
+			},
+			want: "(zone in (a)) or (zone in (b))",
+		},
+		{
+			name: "Gt and Lt operators",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "cores", "operator": "Gt", "values": []interface{}{"4"}},
+					map[string]interface{}{"key": "cores", "operator": "Lt", "values": []interface{}{"32"}},
+				}},
+			},
+			want: "cores>4,cores<32",
+		},
+		{
+			name: "Exists operator",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "gpu", "operator": "Exists"},
+				}},
+			},
+			want: "gpu",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatNodeSelectorTerms(tt.terms); got != tt.want {
+				t.Errorf("formatNodeSelectorTerms() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeSelectorTermsMatch(t *testing.T) {
+	inTerm := func(key string, values ...string) map[string]interface{} {
+		vs := make([]interface{}, len(values))
+		for i, v := range values {
+			vs[i] = v
+		}
+		return map[string]interface{}{"key": key, "operator": "In", "values": vs}
+	}
+
+	tests := []struct {
+		name       string
+		terms      []interface{}
+		nodeLabels map[string]string
+		nodeFields map[string]string
+		want       bool
+	}{
+		{
+			name:       "empty selector matches everything",
+			terms:      nil,
+			nodeLabels: map[string]string{},
+			want:       true,
+		},
+		{
+			name: "single term matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{inTerm("zone", "a")}},
+			},
+			nodeLabels: map[string]string{"zone": "a"},
+			want:       true,
+		},
+		{
+			name: "single term does not match",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{inTerm("zone", "a")}},
+			},
+			nodeLabels: map[string]string{"zone": "b"},
+			want:       false,
+		},
+		{
+			name: "multiple OR'd terms, second matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{inTerm("zone", "a")}},
+				map[string]interface{}{"matchExpressions": []interface{}{inTerm("zone", "b")}},
+			},
+			nodeLabels: map[string]string{"zone": "b"},
+			want:       true,
+		},
+		{
+			name: "multiple AND'd expressions within a term, one fails",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					inTerm("zone", "a"),
+					map[string]interface{}{"key": "gpu", "operator": "Exists"},
+				}},
+			},
+			nodeLabels: map[string]string{"zone": "a"},
+			want:       false,
+		},
+		{
+			name: "matchFields checked against nodeFields, not nodeLabels",
+			terms: []interface{}{
+				map[string]interface{}{"matchFields": []interface{}{inTerm("metadata.name", "node-1")}},
+			},
+			nodeFields: map[string]string{"metadata.name": "node-1"},
+			want:       true,
+		},
+		{
+			name: "In: key absent does not match",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{inTerm("zone", "a")}},
+			},
+			nodeLabels: map[string]string{},
+			want:       false,
+		},
+		{
+			name: "NotIn: key absent matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "zone", "operator": "NotIn", "values": []interface{}{"a"}},
+				}},
+			},
+			nodeLabels: map[string]string{},
+			want:       true,
+		},
+		{
+			name: "NotIn: key present with excluded value matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "zone", "operator": "NotIn", "values": []interface{}{"a"}},
+				}},
+			},
+			nodeLabels: map[string]string{"zone": "b"},
+			want:       true,
+		},
+		{
+			name: "NotIn: key present with excluded value list member does not match",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "zone", "operator": "NotIn", "values": []interface{}{"a"}},
+				}},
+			},
+			nodeLabels: map[string]string{"zone": "a"},
+			want:       false,
+		},
+		{
+			name: "Exists: key present matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "gpu", "operator": "Exists"},
+				}},
+			},
+			nodeLabels: map[string]string{"gpu": ""},
+			want:       true,
+		},
+		{
+			name: "DoesNotExist: key absent matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "gpu", "operator": "DoesNotExist"},
+				}},
+			},
+			nodeLabels: map[string]string{},
+			want:       true,
+		},
+		{
+			name: "Gt: value greater matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "cores", "operator": "Gt", "values": []interface{}{"4"}},
+				}},
+			},
+			nodeLabels: map[string]string{"cores": "8"},
+			want:       true,
+		},
+		{
+			name: "Gt: value not greater does not match",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "cores", "operator": "Gt", "values": []interface{}{"4"}},
+				}},
+			},
+			nodeLabels: map[string]string{"cores": "2"},
+			want:       false,
+		},
+		{
+			name: "Lt: value less matches",
+			terms: []interface{}{
+				map[string]interface{}{"matchExpressions": []interface{}{
+					map[string]interface{}{"key": "cores", "operator": "Lt", "values": []interface{}{"4"}},
+				}},
+			},
+			nodeLabels: map[string]string{"cores": "2"},
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeSelectorTermsMatch(tt.terms, tt.nodeLabels, tt.nodeFields)
+			if got != tt.want {
+				t.Errorf("nodeSelectorTermsMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNetworkPolicySelectsPod(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -5,6 +5,7 @@
     {{- template "finalizer_details_on_termination" . }}
     {{- template "application_details" . }}
     {{- .Include "pod_conditions_summary" . | nindent 2 }}
+    {{- template "pod_placement_constraints" . }}
     {{- template "pod_node_problems" . }}
     {{- $secCtx := .Spec.securityContext | default dict }}
     {{- $seccomp := index $secCtx "seccompProfile" | default dict }}
@@ -65,6 +66,31 @@
     {{- with .Status.qosClass }} {{ if ($.Object | default dict).inline }}{{ . }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}
     {{- with .Status.message }}, message: {{ . }}{{ end }}
 {{- end -}}
+
+{{- define "pod_placement_constraints" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Renders the hard placement constraints (nodeSelector, required nodeAffinity) that
+           restrict which Nodes this Pod can land on, gated on PodScheduled=False. The scheduler's
+           own message (already shown by pod_conditions_summary) stays the causal anchor -- this
+           states "restricts placement to..." as a declared fact, not "this is why it's
+           unschedulable", since multiple predicates can be failing simultaneously. Preferred
+           nodeAffinity is a scoring hint, not a blocker, and is deliberately never rendered here.
+           Spec-only: no live Node fetch, so this renders identically in --shallow/--local/--deep. */ -}}
+    {{- $podScheduledCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
+    {{- if not (isStatusConditionHealthy $podScheduledCondition) }}
+        {{- $nodeSelector := .Spec.nodeSelector | default dict }}
+        {{- $affinity := .Spec.affinity | default dict }}
+        {{- $nodeAffinity := $affinity.nodeAffinity | default dict }}
+        {{- $required := $nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution | default dict }}
+        {{- $terms := $required.nodeSelectorTerms | default list }}
+        {{- if $nodeSelector }}
+            {{- "node selector:" | bold | nindent 2 }} {{ formatNodeSelector $nodeSelector | cyan }}
+        {{- end }}
+        {{- if $terms }}
+            {{- "required node affinity:" | bold | nindent 2 }} {{ formatNodeSelectorTerms $terms | cyan }}
+        {{- end }}
+    {{- end }}
+{{- end }}
 
 {{- define "pod_node_problems" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}

--- a/tests/artifacts/pod-pending-nodeselector.out
+++ b/tests/artifacts/pod-pending-nodeselector.out
@@ -1,0 +1,8 @@
+
+Pod/pod-pending-nodeselector -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  node selector: disktype=ssd,kubernetes.io/arch=arm64
+  Standalone POD.

--- a/tests/artifacts/pod-pending-nodeselector.yaml
+++ b/tests/artifacts/pod-pending-nodeselector.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  name: pod-pending-nodeselector
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe11
+spec:
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeSelector:
+    disktype: ssd
+    kubernetes.io/arch: arm64
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: '0/3 nodes are available: 3 node(s) didn''t match Pod''s node affinity/selector.'
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/artifacts/pod-pending-preferred-nodeaffinity-only.out
+++ b/tests/artifacts/pod-pending-preferred-nodeaffinity-only.out
@@ -1,0 +1,7 @@
+
+Pod/pod-pending-preferred-nodeaffinity-only -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  Standalone POD.

--- a/tests/artifacts/pod-pending-preferred-nodeaffinity-only.yaml
+++ b/tests/artifacts/pod-pending-preferred-nodeaffinity-only.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  name: pod-pending-preferred-nodeaffinity-only
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe13
+spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - us-east-1a
+        weight: 50
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: '0/3 nodes are available: 3 node(s) didn''t match Pod''s node affinity/selector.'
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/artifacts/pod-pending-required-nodeaffinity.out
+++ b/tests/artifacts/pod-pending-required-nodeaffinity.out
@@ -1,0 +1,8 @@
+
+Pod/pod-pending-required-nodeaffinity -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  required node affinity: (topology.kubernetes.io/zone in (us-east-1a,us-east-1b)) or (node.kubernetes.io/instance-type in (m5.large),karpenter.sh/capacity-type notin (spot))
+  Standalone POD.

--- a/tests/artifacts/pod-pending-required-nodeaffinity.yaml
+++ b/tests/artifacts/pod-pending-required-nodeaffinity.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  name: pod-pending-required-nodeaffinity
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe12
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - us-east-1a
+            - us-east-1b
+        - matchExpressions:
+          - key: node.kubernetes.io/instance-type
+            operator: In
+            values:
+            - m5.large
+          - key: karpenter.sh/capacity-type
+            operator: NotIn
+            values:
+            - spot
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: '0/3 nodes are available: 3 node(s) didn''t match Pod''s node affinity/selector.'
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -15,6 +15,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
           Managed by probe-a-blocked application
           Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
             PodScheduled Unschedulable, [^\n]*node\(s\) didn't match Pod's node affinity/selector[^\n]* for 1m
+          node selector: kubectl-status\.io/e2e-never-schedules=true
           Volumes: kube-api-access-[a-z0-9]+ \(Projected\)
           Owners:
             ReplicaSet/probe-a-blocked-[a-z0-9]+ -n e2e-crossplane-xr, created 1m ago by Deployment/probe-a-blocked, gen:1


### PR DESCRIPTION
## Summary
- Render `spec.nodeSelector` and required `nodeAffinity.nodeSelectorTerms` under `PodScheduled=False`, so the operator sees what restricts placement without reading the raw Pod spec (`pod_placement_constraints` in `Pod.tmpl`, placed right after `pod_conditions_summary`).
- Preferred nodeAffinity is a scoring hint, not a blocker — deliberately never rendered.
- Adds reusable Go helpers (`formatNodeSelector`, `formatNodeSelectorTerms`, `nodeSelectorTermsMatch`, ...) mirroring the existing `taintsNotToleratedByPod` style. The matcher functions are fully unit-tested but not yet called from any template — they're built for the follow-up PVC/PV locality and Karpenter NodePool compatibility issues in this series to consume.
- Spec-only, zero additional API calls, so output is identical across `--shallow`/`--local`/`--deep`.

Closes #737

## Test plan
- [x] `make test` (vet, staticcheck, unit + artifact tests) passes
- [x] New Go unit tests cover the matcher: single term, multiple OR'd terms, `In`/`NotIn`/`Exists`/`DoesNotExist`/`Gt`/`Lt`, empty selector matches everything
- [x] New offline artifacts: `pod-pending-nodeselector`, `pod-pending-required-nodeaffinity` (multiple OR'd terms), `pod-pending-preferred-nodeaffinity-only` (proves silence)
- [x] Manually verified a healthy (`PodScheduled=True`) Pod with a `nodeSelector` renders nothing from this feature (AC#1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)