### PR TITLE
Pod/PV/StorageClass: cross-check bound/unbound PVC zone locality against Pod placement

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -225,6 +225,17 @@ func TestE2EDynamicManifests(t *testing.T) {
 			Provisioner:          provisioner,
 			VolumeBindingMode:    &bindingMode,
 			AllowVolumeExpansion: &allowExpansion,
+			// Issue #738: this is the only e2e path that renders storageclass_summary (used by
+			// PersistentVolumeClaim.tmpl below) against a live class, so allowedTopologies is
+			// added here rather than to a separate StorageClass -- a dedicated fixture would only
+			// exercise the already-covered standalone StorageClass.tmpl render, not this compact
+			// partial's new branch.
+			AllowedTopologies: []corev1.TopologySelectorTerm{{
+				MatchLabelExpressions: []corev1.TopologySelectorLabelRequirement{{
+					Key:    "topology.kubernetes.io/zone",
+					Values: []string{"e2e-zone-a", "e2e-zone-b"},
+				}},
+			}},
 		}, metav1.CreateOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -643,6 +654,194 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"volumesnapshotcontent/" + vscName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/volumesnapshotcontent-bound-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("Pod surfaces a bound PV's zone-restricting nodeAffinity when it can't be scheduled", func(t *testing.T) {
+		// Issue #738: pod_storage_locality resolves a Pod's PVC-backed volume to its bound PV and
+		// surfaces the PV's spec.nodeAffinity when the Pod itself can't be scheduled -- a fact
+		// PersistentVolume.tmpl, StorageClass.tmpl, and Pod.tmpl never connected before. There's
+		// no live cluster mechanism that reliably produces a real zone-restricted CSI PV on
+		// minikube (its hostpath storage-provisioner isn't zone-aware), so -- same "create
+		// directly against the API" trick the VolumeAttachment/RWOP-conflict subtests above use
+		// -- we hand-craft a PV with a nodeAffinity requirement no real minikube Node label
+		// satisfies, and a PVC statically bound to it via spec.volumeName (bypassing dynamic
+		// provisioning). The kube-scheduler's VolumeBinding plugin still evaluates a bound PVC's
+		// PV nodeAffinity against candidate Nodes for real, so the consuming Pod below stays
+		// genuinely Pending -- not a simulated state.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-pv-zone"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		pvName := "e2e-pv-zone-restricted"
+		_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: pvName},
+			Spec: corev1.PersistentVolumeSpec{
+				Capacity:                      corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/e2e-pv-zone-restricted"},
+				},
+				NodeAffinity: &corev1.VolumeNodeAffinity{
+					Required: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+							MatchExpressions: []corev1.NodeSelectorRequirement{{
+								Key:      "topology.kubernetes.io/zone",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"e2e-no-such-zone"},
+							}},
+						}},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().PersistentVolumes().Delete(context.TODO(), pvName, metav1.DeleteOptions{})
+		})
+
+		// An explicit "" (not nil) opts this PVC out of the default-StorageClass admission
+		// controller, which would otherwise stamp the cluster's default class onto it and make
+		// static binding to our classless PV fail on a class mismatch.
+		noClass := ""
+		pvcName := "e2e-pvc-zone-restricted"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+				VolumeName:       pvName,
+				StorageClassName: &noClass,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		podName := "e2e-pod-zone-restricted"
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Labels: map[string]string{"app": podName}},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name:         "data",
+					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName}},
+				}},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		})
+		waitForInNamespace(t, "pod/"+podName,
+			`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}=False`, ns)
+		// Fixture pins kstatus's own summary line, which only reports Unschedulable as Failed
+		// once the Pod is past its 15s ScheduleWindow -- same wait the Crossplane XR subtest
+		// above uses for the same reason.
+		waitForPodScheduleWindow(t, ns, "app="+podName)
+
+		cmdTest{
+			args:            []string{"pod/" + podName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-pv-zone-restricted.regex",
+		}.assert(t, nil, opts...)
+
+		cmdTest{
+			args:            []string{"pv/" + pvName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pv-zone-restricted-standalone.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("Pod hedges on an unbound WaitForFirstConsumer PVC's allowedTopologies", func(t *testing.T) {
+		// Issue #738: an unbound claim against a WaitForFirstConsumer class with
+		// allowedTopologies has no PV yet to cross-check, so pod_storage_locality must hedge
+		// ("isn't zone-pinned yet ... may still constrain") instead of asserting a zone. Reuses
+		// the same custom StorageClass pattern as the "PersistentVolumeClaim fetches its
+		// StorageClass" subtest above, adding allowedTopologies to it.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-pv-zone-wfc"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, storageClasses.Items, "expected minikube's default storage-provisioner addon to have registered a StorageClass")
+		provisioner := storageClasses.Items[0].Provisioner
+
+		scName := "e2e-wfc-topologies"
+		bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		_, err = clientset.StorageV1().StorageClasses().Create(context.TODO(), &storagev1.StorageClass{
+			ObjectMeta:        metav1.ObjectMeta{Name: scName},
+			Provisioner:       provisioner,
+			VolumeBindingMode: &bindingMode,
+			AllowedTopologies: []corev1.TopologySelectorTerm{{
+				MatchLabelExpressions: []corev1.TopologySelectorLabelRequirement{{
+					Key:    "topology.kubernetes.io/zone",
+					Values: []string{"e2e-zone-a", "e2e-zone-b"},
+				}},
+			}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.StorageV1().StorageClasses().Delete(context.TODO(), scName, metav1.DeleteOptions{})
+		})
+
+		pvcName := "e2e-wfc-topologies-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		podName := "e2e-pod-wfc-topologies"
+		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Labels: map[string]string{"app": podName}},
+			Spec: corev1.PodSpec{
+				// An unsatisfiable nodeSelector unrelated to storage guarantees this Pod's own
+				// PodScheduled=False deterministically, without racing whether minikube's
+				// topology-unaware hostpath provisioner would otherwise happily bind the
+				// WaitForFirstConsumer claim once the scheduler picks a node for it -- the
+				// node-selector filter rejects every Node before scheduling ever reaches volume
+				// binding, so the claim also stays reliably unbound.
+				NodeSelector: map[string]string{"e2e-no-such-label": "true"},
+				Containers: []corev1.Container{{
+					Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+				}},
+				Volumes: []corev1.Volume{{
+					Name:         "data",
+					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName}},
+				}},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		})
+		waitForInNamespace(t, "pod/"+podName,
+			`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}=False`, ns)
+		waitForPodScheduleWindow(t, ns, "app="+podName)
+
+		cmdTest{
+			args:            []string{"pod/" + podName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pod-wfc-topologies-unbound.regex",
 		}.assert(t, nil, opts...)
 	})
 }

--- a/pkg/plugin/templates/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/PersistentVolume.tmpl
@@ -13,6 +13,11 @@
     {{- with .Spec.persistentVolumeReclaimPolicy }}, reclaim: {{ . | cyan }}{{ end }}
     {{- with .Status.reason }}{{ "reason" | bold }}: {{ . }}{{ end }}
     {{- with .Status.message }}{{ "message" | red | bold | nindent 2 }}: {{ . }}{{- end }}{{/* Exists usually when there is problem */}}
+    {{- $nodeAffinity := .Spec.nodeAffinity | default dict }}
+    {{- $requiredTerms := ($nodeAffinity.required | default dict).nodeSelectorTerms | default list }}
+    {{- if $requiredTerms }}
+        {{- "Node affinity:" | bold | nindent 2 }} restricts placement to {{ formatNodeSelectorTerms $requiredTerms | cyan }}
+    {{- end }}
     {{- /* Placed after every same-line field above (not inline where the class is named) --
            its --deep branch can inline a multi-line StorageClass block, and anything appended
            on the same line after that would land glued onto its last line instead of the

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -50,6 +50,7 @@
     {{- template "pod_runtimeclass_overhead" . }}
     {{- template "pod_ephemeral_containers" (dict "pod" . "podPullSecretsBroken" $podPullSecretsBroken) }}
     {{- template "pod_volumes" . }}
+    {{- template "pod_storage_locality" . }}
     {{- template "matching_services" (dict "ctx" . "namespace" .Namespace "svcs" (.KubeGetServicesMatchingPod .Namespace .Name)) }}
     {{- template "matching_pdbs" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
     {{- template "matching_network_policies" (dict "ctx" . "namespace" .Namespace "labels" .Labels) }}
@@ -485,6 +486,55 @@
         {{- else }}
             {{- "Volumes:" | nindent 2 }}
             {{- range $entries }}{{ . | nindent 4 }}{{ end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "pod_storage_locality" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* For each persistentVolumeClaim volume, resolves PVC -> (if bound) PV -> its
+           nodeAffinity, and the PVC's storageClassName -> StorageClass volumeBindingMode/
+           allowedTopologies -- cross-checking zone/node locality the PV or its class may impose
+           against this Pod's own placement. Renders facts side by side, same restraint already
+           used by rwop_holder_diagnosis/volumeattachment_diagnosis: this never asserts a
+           conflict with the Pod's own constraints (shown by pod_placement_constraints) or claims
+           the scheduler's PodScheduled message (shown by pod_conditions_summary) is explained by
+           it -- multiple predicates can be failing at once. An unbound claim against a
+           WaitForFirstConsumer class with allowedTopologies is worded as "not yet zone-pinned",
+           never as an unconditional zone claim, since dynamic provisioning hasn't run yet. Gated
+           on PodScheduled=False only, mirroring pod_placement_constraints -- a healthy/scheduled
+           Pod's --deep render already gets the same PV/StorageClass facts inline via
+           pod_volumes's deep branch and storageclass_summary's own deep inline, so repeating them
+           here would just duplicate that. Needs live PVC/PV/StorageClass fetches, so
+           --shallow/--local render nothing here. */ -}}
+    {{- $podScheduledCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
+    {{- if not (isStatusConditionHealthy $podScheduledCondition) }}
+        {{- range $.Spec.volumes }}
+            {{- if hasKey . "persistentVolumeClaim" }}
+                {{- $claimName := .persistentVolumeClaim.claimName }}
+                {{- $pvc := $.KubeGetFirst $.Namespace "PersistentVolumeClaim" $claimName }}
+                {{- if $pvc.Object }}
+                    {{- $pvcSpec := $pvc.Spec | default dict }}
+                    {{- if $pvcSpec.volumeName }}
+                        {{- $pv := $.KubeGetFirst "" "PersistentVolume" $pvcSpec.volumeName }}
+                        {{- if $pv.Object }}
+                            {{- $nodeAffinity := $pv.Spec.nodeAffinity | default dict }}
+                            {{- $terms := ($nodeAffinity.required | default dict).nodeSelectorTerms | default list }}
+                            {{- if $terms }}
+                                {{- "PV node affinity:" | bold | nindent 2 }} {{ $.Include "resource_ref" (dict "kind" "PersistentVolume" "name" $pv.Name) }} (backing {{ $.Include "resource_ref" (dict "kind" "PersistentVolumeClaim" "name" $claimName "namespace" $.Namespace "callerNamespace" $.Namespace) }}) restricts placement to {{ formatNodeSelectorTerms $terms | cyan }}
+                            {{- end }}
+                        {{- end }}
+                    {{- else if $pvcSpec.storageClassName }}
+                        {{- $sc := $.KubeGetFirst "" "StorageClass" $pvcSpec.storageClassName }}
+                        {{- if $sc.Object }}
+                            {{- $bindingMode := $sc.Object.volumeBindingMode | default "Immediate" }}
+                            {{- if and (eq $bindingMode "WaitForFirstConsumer") $sc.Object.allowedTopologies }}
+                                {{- "PV locality:" | yellow | nindent 2 }} {{ $.Include "resource_ref" (dict "kind" "PersistentVolumeClaim" "name" $claimName "namespace" $.Namespace "callerNamespace" $.Namespace) }} isn't zone-pinned yet ({{ "WaitForFirstConsumer" | colorKeyword }} via {{ $.Include "resource_ref" (dict "kind" "StorageClass" "name" $pvcSpec.storageClassName) }}), but its provisioning topology may still constrain candidate nodes
+                            {{- end }}
+                        {{- end }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -74,23 +74,33 @@
            provisioning/binding actually depends on this class, e.g. a still-Pending PVC, so a
            missing class is worth flagging rather than silently ignored; PV.tmpl leaves this
            unset since a legacy PV can be valid without one). Fetches the StorageClass object to
-           surface the provisioner (when not already on screen) and volumeBindingMode/
+           surface the provisioner (when not already on screen), volumeBindingMode/
            allowVolumeExpansion, which explain stuck/delayed binding and scheduling-before-
-           binding behavior. Silent when unfetchable (--shallow/--local) or when everything it
-           would show is either unremarkable (Immediate binding, no expansion) or already on
-           screen. */ -}}
+           binding behavior, and allowedTopologies, which explains where WaitForFirstConsumer
+           dynamic provisioning is permitted to place the volume. Silent when unfetchable
+           (--shallow/--local) or when everything it would show is either unremarkable (Immediate
+           binding, no expansion, no allowedTopologies) or already on screen. */ -}}
     {{- $ctx := .ctx }}
     {{- $sc := $ctx.KubeGetFirst "" "StorageClass" .name }}
     {{- if $sc.Object }}
         {{- $bindingMode := $sc.Object.volumeBindingMode | default "Immediate" }}
         {{- $expandable := $sc.Object.allowVolumeExpansion }}
+        {{- $topologies := $sc.Object.allowedTopologies }}
         {{- $showProvisioner := not .provisionerShown }}
-        {{- if or $showProvisioner (ne $bindingMode "Immediate") $expandable }}
+        {{- if or $showProvisioner (ne $bindingMode "Immediate") $expandable $topologies }}
             {{- "StorageClass" | bold | nindent 2 }}:
             {{- $needsComma := false }}
             {{- if $showProvisioner }} {{ $sc.Object.provisioner | cyan }}{{ $needsComma = true }}{{ end }}
             {{- if ne $bindingMode "Immediate" }}{{ if $needsComma }},{{ end }} volumeBindingMode: {{ $bindingMode | colorKeyword }}{{ $needsComma = true }}{{ end }}
             {{- if $expandable }}{{ if $needsComma }},{{ end }} allows volume expansion{{ end }}
+        {{- end }}
+        {{- with $topologies }}
+            {{- "Allowed topologies" | bold | nindent 4 }}
+            {{- range . }}
+                {{- range .matchLabelExpressions }}
+                    {{- "" | nindent 6 }}{{ .key }} in [{{ .values | join ", " }}]
+                {{- end }}
+            {{- end }}
         {{- end }}
         {{- if $ctx.Config.GetBool "deep" }}
             {{- $ctx.Include "StorageClass" $sc | nindent 4 }}

--- a/tests/artifacts/pv-nodeaffinity-zone.out
+++ b/tests/artifacts/pv-nodeaffinity-zone.out
@@ -1,0 +1,5 @@
+
+PersistentVolume/pv-nodeaffinity-zone, created 1m ago Available
+  Current: Resource is current
+  PV is Available managed by StorageClass/fast-ebs with ReadWriteOnce mode, reclaim: Delete
+  Node affinity: restricts placement to topology.kubernetes.io/zone in (us-east-1a,us-east-1b)

--- a/tests/artifacts/pv-nodeaffinity-zone.yaml
+++ b/tests/artifacts/pv-nodeaffinity-zone.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: pv-nodeaffinity-zone
+  resourceVersion: "317052"
+  uid: c3d4e5f6-a7b8-9012-cdef-123456789012
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  csi:
+    driver: ebs.csi.aws.com
+    volumeHandle: vol-0123456789abcdef0
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values:
+          - us-east-1a
+          - us-east-1b
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: fast-ebs
+  volumeMode: Filesystem
+status:
+  phase: Available

--- a/tests/artifacts/storageclass-allowed-topologies.out
+++ b/tests/artifacts/storageclass-allowed-topologies.out
@@ -1,0 +1,6 @@
+
+StorageClass/zonal-ebs, created 1m ago
+  Current: Resource is current
+  Provisioner: ebs.csi.aws.com, volumeBindingMode: WaitForFirstConsumer
+  Allowed topologies
+    topology.kubernetes.io/zone in [us-east-1a, us-east-1b]

--- a/tests/artifacts/storageclass-allowed-topologies.yaml
+++ b/tests/artifacts/storageclass-allowed-topologies.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  creationTimestamp: "2026-07-10T14:52:59Z"
+  name: zonal-ebs
+  resourceVersion: "317053"
+  uid: d4e5f6a7-b8c9-0123-defa-234567890123
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.kubernetes.io/zone
+    values:
+    - us-east-1a
+    - us-east-1b

--- a/tests/e2e-artifacts/pod-pv-zone-restricted.regex
+++ b/tests/e2e-artifacts/pod-pv-zone-restricted.regex
@@ -1,0 +1,11 @@
+\A
+Pod/e2e-pod-zone-restricted -n e2e-pv-zone, created 1m ago, gen:1 Pending BestEffort
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Managed by e2e-pod-zone-restricted application
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match PersistentVolume's node affinity\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  Standalone POD\.
+  Volumes: data \(PersistentVolumeClaim/e2e-pvc-zone-restricted, asked 1Gi\)
+  PV node affinity: PersistentVolume/e2e-pv-zone-restricted \(backing PersistentVolumeClaim/e2e-pvc-zone-restricted\) restricts placement to topology\.kubernetes\.io/zone in \(e2e-no-such-zone\)
+\z

--- a/tests/e2e-artifacts/pod-wfc-topologies-unbound.regex
+++ b/tests/e2e-artifacts/pod-wfc-topologies-unbound.regex
@@ -1,0 +1,12 @@
+\A
+Pod/e2e-pod-wfc-topologies -n e2e-pv-zone-wfc, created 1m ago, gen:1 Pending BestEffort
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Managed by e2e-pod-wfc-topologies application
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  node selector: e2e-no-such-label=true
+  Standalone POD\.
+  Volumes: data \(PersistentVolumeClaim/e2e-wfc-topologies-pvc, asked 1Gi\)
+  PV locality: PersistentVolumeClaim/e2e-wfc-topologies-pvc isn't zone-pinned yet \(WaitForFirstConsumer via StorageClass/e2e-wfc-topologies\), but its provisioning topology may still constrain candidate nodes
+\z

--- a/tests/e2e-artifacts/pv-zone-restricted-standalone.regex
+++ b/tests/e2e-artifacts/pv-zone-restricted-standalone.regex
@@ -1,0 +1,7 @@
+\A
+PersistentVolume/e2e-pv-zone-restricted, created 1m ago Bound
+  Current: Resource is current
+  PV is Bound, since 1m ago with ReadWriteOnce mode, reclaim: Retain
+  Node affinity: restricts placement to topology\.kubernetes\.io/zone in \(e2e-no-such-zone\)
+  Created for PersistentVolumeClaim/e2e-pvc-zone-restricted -n e2e-pv-zone
+\z

--- a/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex
+++ b/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex
@@ -4,7 +4,11 @@ PersistentVolumeClaim/e2e-wfc-pvc -n e2e-storageclass, created 1m ago Pending
     Reconciling: NotBound, PVC is not Bound\. phase: Pending
   PVC via StorageClass/e2e-wait-for-first-consumer, with Filesystem mode, Pending: no paired PV yet
   StorageClass: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+    Allowed topologies
+      topology\.kubernetes\.io/zone in \[e2e-zone-a, e2e-zone-b\]
     StorageClass/e2e-wait-for-first-consumer, created 1m ago
       Current: Resource is current
       Provisioner: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+      Allowed topologies
+        topology\.kubernetes\.io/zone in \[e2e-zone-a, e2e-zone-b\]
 \z

--- a/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex
+++ b/tests/e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex
@@ -4,4 +4,6 @@ PersistentVolumeClaim/e2e-wfc-pvc -n e2e-storageclass, created 1m ago Pending
     Reconciling: NotBound, PVC is not Bound\. phase: Pending
   PVC via StorageClass/e2e-wait-for-first-consumer, with Filesystem mode, Pending: no paired PV yet
   StorageClass: \S+, volumeBindingMode: WaitForFirstConsumer, allows volume expansion
+    Allowed topologies
+      topology\.kubernetes\.io/zone in \[e2e-zone-a, e2e-zone-b\]
 \z


### PR DESCRIPTION
## Summary
- `PersistentVolume.tmpl` now renders `spec.nodeAffinity.required` (zone/node placement restrictions on the PV itself).
- `storageclass_summary` (the compact partial used by PV/PVC) now renders `allowedTopologies`, previously silent on it.
- New `pod_storage_locality` partial in `Pod.tmpl`, gated on `PodScheduled=False`: resolves each PVC-backed volume to its bound PV's `nodeAffinity`, or an unbound `WaitForFirstConsumer` claim's `allowedTopologies`, and renders the fact next to the scheduler's own message — never asserting a conflict, consistent with `rwop_holder_diagnosis`/`volumeattachment_diagnosis`.

Closes #738 (depends on/builds on #737's shared node-selector-term rendering helper).

## Test plan
- [x] Offline artifacts (`pv-nodeaffinity-zone`, `storageclass-allowed-topologies`) added, `TestAllArtifactsLocal` passes (219 cases).
- [x] Two new e2e subtests added and run live against minikube: a Pod bound to a zone-restricted PV (real scheduler `VolumeBinding` rejection), and a Pod against a `WaitForFirstConsumer` + `allowedTopologies` class (hedge-worded note).
- [x] Extended the existing `pvc-storageclass-wait-for-first-consumer` e2e subtest's StorageClass with `allowedTopologies` to close the one gap that wasn't otherwise covered (`storageclass_summary`'s new branch specifically), regenerated both its default/`--deep` fixtures live.
- [x] Full `TestE2EDynamicManifests` suite passes against a live minikube cluster (no regressions).
- [x] `go build`, `go vet`, full local test suite (620 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)