### PR TITLE
Faster e2e dev loop: test-e2e-quick + one shared minikube cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,16 +214,28 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 ### Running e2e Tests Locally
 
 `make test-e2e` runs the `TestE2E*` suite against a real cluster (see `cmd/main_test.go`). It
-manages its own minikube cluster, named and isolated by an `E2E_PROFILE` the Makefile computes
-from your current git branch (plus, when running under Claude Code, `CLAUDE_CODE_SESSION_ID`) —
-so parallel worktrees/branches, and even multiple sessions working the same branch, never share a
-profile or step on each other's cluster. Run `make print-e2e-profile` to see the profile name and
-kubeconfig path (`.e2e/<profile>.kubeconfig`, gitignored) it'll use. `install-e2e-deps` (cert-manager,
-Gateway API CRDs) runs against that same cluster right after it's created, so deps always land on
-the cluster the tests actually use. The cluster is left running after the tests finish, for fast
-reruns; delete it explicitly with `make e2e-minikube-down` when you're done with the branch, or
-run `make install-hooks` once (installs a `reference-transaction` git hook, shared across all
-worktrees of the clone) to have it deleted automatically whenever you delete the local branch.
+manages one **shared** minikube cluster/profile (`kstat-e2e-shared`), reused across every
+worktree, branch, and session on your machine — not one per branch/session. Run
+`make print-e2e-profile` to see the profile name and kubeconfig path (`~/.kstat-e2e/shared.kubeconfig`)
+it uses. `install-e2e-deps` (cert-manager, Gateway API CRDs) runs against that same cluster right
+after it's created, so deps always land on the cluster the tests actually use. The cluster is left
+running after the tests finish, for fast reruns from any worktree/session; delete it explicitly
+with `make e2e-minikube-down` when you're sure no other worktree/session still needs it — this
+tears it down for everyone sharing it, not just you.
+
+Because the cluster is shared and the e2e suite uses fixed (not generated) scratch namespace
+names, two `test-e2e`/`test-e2e-quick` runs against it at the same time would collide with
+"already exists" errors. Both targets guard against that with `flock` on a host-global lockfile:
+a second invocation (from another worktree, another terminal, a background Claude Code task)
+simply waits for the first to finish rather than racing it or getting its own cluster. This trades
+some concurrency for a much smaller footprint — one 4 CPU/6 GB VM total instead of one per
+worktree/branch/session, which is what actually hogs the host if left unchecked. `flock` (from
+`util-linux`) is required; it's standard on Linux but not present on macOS by default.
+
+If a run is killed ungracefully (Ctrl+C, OOM) mid-subtest, its cleanup won't run and it can leave
+a stale namespace behind that collides with the next run's fixed name. Recover with
+`kubectl --kubeconfig ~/.kstat-e2e/shared.kubeconfig delete ns <name>`, or nuke and recreate the
+whole cluster with `make e2e-minikube-down e2e-minikube-up`.
 
 CI instead sets `ASSUME_MINIKUBE_IS_CONFIGURED=true`, which makes `make test-e2e` skip all of the
 above and use whatever cluster your current kubeconfig context already points at (that's what
@@ -238,8 +250,32 @@ stays in sync automatically.
 
 Note: `TestE2E*` functions invoked directly via `go test -run TestE2E...` (bypassing the
 Makefile) fall back to using the bare test function name as the minikube profile if `E2E_PROFILE`
-isn't set in the environment, so ad hoc runs across worktrees can still collide — export
-`E2E_PROFILE` yourself (e.g. from `make print-e2e-profile`) to isolate those too.
+isn't set in the environment, which starts (and leaks) a one-off cluster instead of using the
+shared one — export `E2E_PROFILE` yourself (e.g. from `make print-e2e-profile`) to land on the
+shared cluster too.
+
+#### Fast Iteration: `make test-e2e-quick`
+
+`make test-e2e` reruns `vet`/`staticcheck`/`install-e2e-deps` and the whole ~60-subtest `TestE2E*`
+pattern every time, which is wasteful while iterating on a single scenario. Once you have a cluster
+up (`make e2e-minikube-up install-e2e-deps`, one time — it's left running afterwards, see above),
+use `make test-e2e-quick RUN='<pattern>'` to rerun just the subtest(s) you're working on against
+that same cluster, skipping the lint steps and the deps install:
+
+```bash
+make e2e-minikube-up install-e2e-deps   # once per shared cluster
+make test-e2e-quick RUN='TestE2EParallel/podscheduling'
+```
+
+`TestE2EParallel`'s subtests are grouped topically by the `runXSubtests` functions in
+`cmd/e2e_*_test.go` (e.g. `runPodSchedulingSubtests`, `runNetworkPolicySubtests`) — match the
+`-run` pattern to whichever group (or specific subtest name within it) covers the template/package
+you touched, rather than rerunning the full pattern. This is also the right tool for Claude Code to
+verify an e2e-covered change before committing: run the narrowest `RUN` pattern that covers the
+touched scenario instead of the full suite, so a dev-loop check doesn't tie up the shared cluster
+or the machine's resources for longer than necessary. `make test-e2e` (the full suite) stays the
+pre-push/CI gate — the targeted `test-e2e-quick` checks above are what a dev-loop/commit-time
+check should use, not the full suite.
 
 When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.Include`,
 or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`

--- a/Makefile
+++ b/Makefile
@@ -46,29 +46,22 @@ test: vet staticcheck
 #--------------------------
 # E2E cluster identity
 #--------------------------
-# Local test-e2e runs get their own minikube profile/kubeconfig, isolated by git
-# branch (worktrees can't share a branch, so this covers parallel worktrees) and,
-# when running under Claude Code, by session id too (so two sessions working the
-# same branch/worktree don't step on each other's cluster either). The branch name
-# is kept as a readable prefix (cosmetic only, safe to truncate). Uniqueness comes
-# from two hashes: BRANCH_HASH is a function of the branch name alone, so the
-# reference-transaction hook -- which only ever sees a deleted branch name, never a
-# session id -- can recompute it and match *only* that branch's profiles, even when
-# several branches share a truncated slug (e.g. worktree-*-<ulid> branches all
-# collapse to the same 20-char prefix). SESSION_HASH additionally folds in the
-# session id so parallel sessions on the same branch still get separate clusters.
-E2E_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-ifeq ($(E2E_GIT_BRANCH),HEAD)
-E2E_GIT_BRANCH := $(shell git rev-parse --short HEAD 2>/dev/null)
-endif
-ifeq ($(E2E_GIT_BRANCH),)
-E2E_GIT_BRANCH := local
-endif
-E2E_BRANCH_SLUG := $(shell ./hack/e2e-branch-slug.sh '$(E2E_GIT_BRANCH)')
-E2E_BRANCH_HASH := $(shell ./hack/e2e-hash.sh '$(E2E_GIT_BRANCH)')
-E2E_SESSION_HASH := $(shell ./hack/e2e-hash.sh '$(E2E_GIT_BRANCH):$(CLAUDE_CODE_SESSION_ID)')
-E2E_PROFILE := kstat-e2e-$(E2E_BRANCH_SLUG)-$(E2E_BRANCH_HASH)-$(E2E_SESSION_HASH)
-E2E_KUBECONFIG := $(CURDIR)/.e2e/$(E2E_PROFILE).kubeconfig
+# All local test-e2e/test-e2e-quick runs share one minikube profile, across every
+# worktree/branch/session on this machine -- a profile per branch/session (the
+# previous scheme) meant every worktree you'd touched left its own 4 CPU/6 GB VM
+# running, which piles up fast and starves the host. Trade-off: since the profile
+# is shared, concurrent runs (two worktrees, two Claude Code sessions, a background
+# task) must be serialized -- see the `flock $(E2E_LOCKFILE)` in test-e2e/
+# test-e2e-quick below, which makes a second invocation wait for the first instead
+# of racing it (the e2e suite uses fixed, not generated, scratch namespace names,
+# so two concurrent runs would otherwise collide with "already exists" errors).
+# E2E_HOME/E2E_KUBECONFIG/E2E_LOCKFILE are deliberately host-global ($(HOME)-based),
+# not $(CURDIR)-relative -- each worktree has a different CURDIR, and sharing
+# requires them to all agree on the same paths regardless of which one invokes make.
+E2E_PROFILE := kstat-e2e-shared
+E2E_HOME := $(HOME)/.kstat-e2e
+E2E_KUBECONFIG := $(E2E_HOME)/shared.kubeconfig
+E2E_LOCKFILE := $(E2E_HOME)/shared.lock
 
 # CI (and anyone else who already has a suitable cluster configured) sets
 # ASSUME_MINIKUBE_IS_CONFIGURED=true, in which case we deliberately fall back to the
@@ -105,20 +98,28 @@ install-hooks:
 
 .PHONY: e2e-minikube-up
 e2e-minikube-up:
-	@mkdir -p $(dir $(E2E_KUBECONFIG))
-	# Wipe any previous cluster for this profile first: reusing one leaks resources from a
-	# prior run (e.g. killed mid-suite) into this run, causing spurious "already exists"
-	# failures and cluster-load-related flakiness unrelated to the code under test.
-	-$(E2E_KUBECONFIG_ENV) minikube delete -p $(E2E_PROFILE)
-	# --cpus/--memory: TestE2EParallel's subtests run with -parallel=4 (see test-e2e below),
-	# each doing real cluster work (pod scheduling, image pulls, rollouts) concurrently --
-	# minikube's own defaults are sized for serial usage and get overwhelmed (widespread
-	# `kubectl wait` timeouts) under that load.
-	$(E2E_KUBECONFIG_ENV) minikube start -p $(E2E_PROFILE) --addons=metrics-server --cpus=4 --memory=6g
+	@mkdir -p $(E2E_HOME)
+	# Reuse the shared cluster if it's already up instead of wiping it first (the old
+	# per-branch profile could safely delete-first since nothing else depended on it;
+	# this one is shared across worktrees/sessions, so deleting it here could yank it
+	# out from under another session's run).
+	@if $(E2E_KUBECONFIG_ENV) minikube status -p $(E2E_PROFILE) >/dev/null 2>&1; then \
+		echo "Shared e2e cluster '$(E2E_PROFILE)' already running, reusing it."; \
+	else \
+		echo "$(E2E_KUBECONFIG_ENV) minikube start -p $(E2E_PROFILE) --addons=metrics-server --cpus=4 --memory=6g"; \
+		$(E2E_KUBECONFIG_ENV) minikube start -p $(E2E_PROFILE) --addons=metrics-server --cpus=4 --memory=6g; \
+	fi
+	# --cpus/--memory above: TestE2EParallel's subtests run with -parallel=4 (see test-e2e
+	# below), each doing real cluster work (pod scheduling, image pulls, rollouts)
+	# concurrently -- minikube's own defaults are sized for serial usage and get
+	# overwhelmed (widespread `kubectl wait` timeouts) under that load.
 
 .PHONY: e2e-minikube-down
 e2e-minikube-down:
-	$(E2E_KUBECONFIG_ENV) minikube delete -p $(E2E_PROFILE)
+	# Tears down the cluster every worktree/session on this machine shares -- only run
+	# this when you're sure nobody else (another worktree, another Claude Code session)
+	# still needs it. `flock`ed like test-e2e/test-e2e-quick so it can't race a live run.
+	$(E2E_KUBECONFIG_ENV) flock $(E2E_LOCKFILE) minikube delete -p $(E2E_PROFILE)
 	@rm -f $(E2E_KUBECONFIG)
 
 .PHONY: install-e2e-deps
@@ -152,20 +153,41 @@ test-e2e: vet staticcheck install-e2e-deps
 	# -parallel=4: bounds how many TestE2EParallel subtests hit the cluster at once. Go's
 	# default (GOMAXPROCS, i.e. host core count) can far exceed what the e2e-minikube-up VM
 	# above is sized for, causing widespread `kubectl wait` timeouts instead of a speedup.
-	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
+	# flock: harmless here (CI runs one job at a time anyway) but keeps this branch
+	# consistent with the shared-cluster branch below.
+	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
 else
 test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
-	# The isolated cluster (profile: $(E2E_PROFILE)) is torn down afterwards whether the suite
-	# passes or fails, so local/pre-push runs don't leak minikube profiles. Its exit status is
-	# preserved so a failing suite still fails the target (and blocks the push).
+	# The cluster (profile: $(E2E_PROFILE)) is shared across every worktree/branch/session on
+	# this machine and is left running afterwards -- run `make e2e-minikube-down` yourself when
+	# you're sure nothing else still needs it. `flock $(E2E_LOCKFILE)` serializes this against
+	# any other test-e2e/test-e2e-quick run on the machine (the suite uses fixed scratch
+	# namespace names, so two concurrent runs would otherwise collide).
 	# using count to prevent caching; see the timeout note in the ASSUME_MINIKUBE_IS_CONFIGURED
 	# branch above.
 	# See the gotestsum note, and the -parallel=4 note above the other branch's go test invocation.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'; \
-	status=$$?; \
-	$(MAKE) e2e-minikube-down; \
-	exit $$status
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
 endif
+
+.PHONY: test-e2e-quick
+test-e2e-quick:
+	@if [ -z "$(RUN)" ]; then \
+		echo "Usage: make test-e2e-quick RUN='<go test -run pattern>'"; \
+		echo "Example: make test-e2e-quick RUN='TestE2EParallel/podscheduling'"; \
+		exit 1; \
+	fi
+	@if [ "$(ASSUME_MINIKUBE_IS_CONFIGURED)" != "true" ] && [ ! -f "$(E2E_KUBECONFIG)" ]; then \
+		echo "No shared e2e cluster found ($(E2E_KUBECONFIG))."; \
+		echo "Run 'make e2e-minikube-up install-e2e-deps' once first, then reuse it with test-e2e-quick."; \
+		exit 1; \
+	fi
+	# Skips vet/staticcheck/install-e2e-deps and the minikube up/down that test-e2e does --
+	# for iterating on a single scenario against the shared cluster you already brought up
+	# (and are leaving up) with e2e-minikube-up/install-e2e-deps. Same -parallel=4 as test-e2e:
+	# sized for the e2e-minikube-up VM (see that target's comment), not worth changing for a
+	# narrower -run since it's still the same cluster taking the load. flock $(E2E_LOCKFILE):
+	# see the comment on the shared-cluster branch of test-e2e above.
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=10m -parallel=4 -run '$(RUN)'
 
 #--------------------------
 # Test Artifacts

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,11 @@ test-e2e: vet staticcheck install-e2e-deps
 	# default (GOMAXPROCS, i.e. host core count) can far exceed what the e2e-minikube-up VM
 	# above is sized for, causing widespread `kubectl wait` timeouts instead of a speedup.
 	# flock: harmless here (CI runs one job at a time anyway) but keeps this branch
-	# consistent with the shared-cluster branch below.
+	# consistent with the shared-cluster branch below. mkdir: this branch skips
+	# e2e-minikube-up (the only other target that creates $(E2E_HOME)), so on a bare
+	# CI runner $(E2E_LOCKFILE)'s parent dir wouldn't otherwise exist and flock would
+	# fail outright.
+	@mkdir -p $(E2E_HOME)
 	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
 else
 test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
@@ -181,6 +185,10 @@ test-e2e-quick:
 		echo "Run 'make e2e-minikube-up install-e2e-deps' once first, then reuse it with test-e2e-quick."; \
 		exit 1; \
 	fi
+	# mkdir: mirrors the CI branch of test-e2e -- when ASSUME_MINIKUBE_IS_CONFIGURED=true
+	# this target (like that one) never runs e2e-minikube-up, the only other target that
+	# creates $(E2E_HOME), so $(E2E_LOCKFILE)'s parent dir could otherwise be missing.
+	@mkdir -p $(E2E_HOME)
 	# Skips vet/staticcheck/install-e2e-deps and the minikube up/down that test-e2e does --
 	# for iterating on a single scenario against the shared cluster you already brought up
 	# (and are leaving up) with e2e-minikube-up/install-e2e-deps. Same -parallel=4 as test-e2e:

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -171,14 +171,12 @@ func executeCMD(t *testing.T, args []string, opts ...func(*plugin.RenderConfig))
 
 func startMinikube(t *testing.T) {
 	t.Helper()
-	// `make test-e2e` computes an isolated profile name (branch + Claude Code session
-	// hash, see Makefile) and passes ASSUME_MINIKUBE_IS_CONFIGURED=true, so it never
-	// reaches this function. This fallback only matters for ad hoc
-	// `go test -run TestE2E...` invocations that bypass the Makefile: set E2E_PROFILE
-	// yourself (`make print-e2e-profile` prints the same name the Makefile would use)
-	// to avoid colliding with other worktrees/sessions on a shared t.Name() profile.
-	// TODO: derive branch+session identity here directly instead of relying on the
-	// caller to export E2E_PROFILE, so ad hoc runs are isolated automatically too.
+	// `make test-e2e`/`test-e2e-quick` use one fixed shared profile name (see Makefile)
+	// and pass ASSUME_MINIKUBE_IS_CONFIGURED=true, so they never reach this function.
+	// This fallback only matters for ad hoc `go test -run TestE2E...` invocations that
+	// bypass the Makefile entirely: set E2E_PROFILE yourself (`make print-e2e-profile`
+	// prints the same shared name the Makefile would use) to land on that same cluster
+	// instead of starting (and leaking) a one-off one named after t.Name().
 	clusterName := os.Getenv("E2E_PROFILE")
 	if clusterName == "" {
 		clusterName = t.Name()


### PR DESCRIPTION
## Summary
- Add `make test-e2e-quick RUN='<pattern>'` to rerun a single e2e scenario against an already-up cluster, skipping `vet`/`staticcheck`/`install-e2e-deps` and the full ~60-subtest `TestE2E*` pattern — meant for dev-loop/commit-time iteration (including Claude Code verifying a change before committing) instead of the full suite.
- Replace the per-branch/session isolated minikube profile scheme with one fixed shared cluster (`kstat-e2e-shared`) across all worktrees/branches/sessions on a machine — the old scheme left one 4 CPU/6 GB VM running per worktree/branch/session touched, which piles up and hogs the host.
- `flock` on a host-global lockfile serializes concurrent `test-e2e`/`test-e2e-quick`/`e2e-minikube-down` runs against the shared cluster, since the e2e suite uses fixed (not generated) scratch namespace names and two concurrent runs would otherwise collide.
- `e2e-minikube-up` now reuses an existing cluster instead of deleting it first (safe for a shared cluster only because namespace `t.Cleanup` calls make each run self-cleaning); `test-e2e`'s auto-teardown-after-run is dropped since no single run owns the shared cluster's lifecycle.
- CONTRIBUTING.md documents the new model, the `flock` dependency, and recovery steps for a namespace left behind by an ungracefully-killed run.

## Test plan
- [x] `make -n` dry runs of `test-e2e`, `test-e2e-quick`, `e2e-minikube-up`, `e2e-minikube-down`, `print-e2e-profile` to confirm generated shell commands
- [x] `gofmt`/`go vet` on the touched Go file
- [x] `make e2e-minikube-up install-e2e-deps` then `make test-e2e-quick RUN='TestE2EParallel/podscheduling'` twice in a row against a real cluster — both passed, second run much faster (~6s vs ~106s) confirming clean reuse with no namespace collisions
- [x] Two concurrent `test-e2e-quick` invocations — both passed, second visibly waited on the first's lock (finished ~8s after its own start delay) rather than racing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)