### PR TITLE
Pod: render required topologySpreadConstraints and required pod (anti-)affinity

### DIFF
--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -6,6 +6,7 @@
     {{- template "application_details" . }}
     {{- .Include "pod_conditions_summary" . | nindent 2 }}
     {{- template "pod_placement_constraints" . }}
+    {{- template "pod_topology_constraints" . }}
     {{- template "pod_node_problems" . }}
     {{- $secCtx := .Spec.securityContext | default dict }}
     {{- $seccomp := index $secCtx "seccompProfile" | default dict }}
@@ -89,6 +90,37 @@
         {{- end }}
         {{- if $terms }}
             {{- "required node affinity:" | bold | nindent 2 }} {{ formatNodeSelectorTerms $terms | cyan }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "pod_topology_constraints" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Renders required topologySpreadConstraints (whenUnsatisfiable: DoNotSchedule) and
+           required podAffinity/podAntiAffinity terms, gated on PodScheduled=False like
+           pod_placement_constraints -- these are hard scheduling blockers, orthogonal to the
+           node-level nodeSelector/nodeAffinity rendered there. Stated as declarative facts
+           ("required spread:", "required anti-affinity:"), never claimed as *the* blocker, since
+           the scheduler's own message (shown by pod_conditions_summary) stays the causal anchor
+           and multiple predicates can be failing simultaneously. ScheduleAnyway spread
+           constraints and preferred pod (anti-)affinity are soft preferences/scoring hints and
+           are deliberately never rendered here. Spec-only: no live fetch, so this renders
+           identically in --shallow/--local/--deep. */ -}}
+    {{- $podScheduledCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
+    {{- if not (isStatusConditionHealthy $podScheduledCondition) }}
+        {{- range .Spec.topologySpreadConstraints }}
+            {{- if eq .whenUnsatisfiable "DoNotSchedule" }}
+                {{- "required spread:" | bold | nindent 2 }} max skew {{ .maxSkew }} across {{ .topologyKey }} for {{ .labelSelector | default dict | labelSelector | cyan }}
+            {{- end }}
+        {{- end }}
+        {{- $affinity := .Spec.affinity | default dict }}
+        {{- $podAffinity := $affinity.podAffinity | default dict }}
+        {{- range $podAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+            {{- "required affinity:" | bold | nindent 2 }} {{ .labelSelector | default dict | labelSelector | cyan }} across {{ .topologyKey }}
+        {{- end }}
+        {{- $podAntiAffinity := $affinity.podAntiAffinity | default dict }}
+        {{- range $podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution }}
+            {{- "required anti-affinity:" | bold | nindent 2 }} {{ .labelSelector | default dict | labelSelector | cyan }} across {{ .topologyKey }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/tests/artifacts/pod-pending-preferred-antiaffinity-only.out
+++ b/tests/artifacts/pod-pending-preferred-antiaffinity-only.out
@@ -1,0 +1,7 @@
+
+Pod/pod-pending-preferred-antiaffinity-only -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
+  Standalone POD.

--- a/tests/artifacts/pod-pending-preferred-antiaffinity-only.yaml
+++ b/tests/artifacts/pod-pending-preferred-antiaffinity-only.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  name: pod-pending-preferred-antiaffinity-only
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe17
+spec:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: api
+          topologyKey: kubernetes.io/hostname
+        weight: 50
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: "0/3 nodes are available: 3 Insufficient cpu."
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/artifacts/pod-pending-required-antiaffinity.out
+++ b/tests/artifacts/pod-pending-required-antiaffinity.out
@@ -1,0 +1,8 @@
+
+Pod/pod-pending-required-antiaffinity -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't satisfy existing pods anti-affinity rules. for 1m
+  required anti-affinity: app=api across kubernetes.io/hostname
+  Standalone POD.

--- a/tests/artifacts/pod-pending-required-antiaffinity.yaml
+++ b/tests/artifacts/pod-pending-required-antiaffinity.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  name: pod-pending-required-antiaffinity
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe16
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: api
+        topologyKey: kubernetes.io/hostname
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: '0/3 nodes are available: 3 node(s) didn''t satisfy existing pods anti-affinity
+      rules.'
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/artifacts/pod-pending-topology-spread-donotschedule.out
+++ b/tests/artifacts/pod-pending-topology-spread-donotschedule.out
@@ -1,0 +1,8 @@
+
+Pod/pod-pending-topology-spread-donotschedule -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match pod topology spread constraints. for 1m
+  required spread: max skew 1 across kubernetes.io/hostname for app=api
+  Standalone POD.

--- a/tests/artifacts/pod-pending-topology-spread-donotschedule.yaml
+++ b/tests/artifacts/pod-pending-topology-spread-donotschedule.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  labels:
+    app: api
+  name: pod-pending-topology-spread-donotschedule
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe14
+spec:
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        app: api
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: "0/3 nodes are available: 3 node(s) didn't match pod topology spread constraints."
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable

--- a/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.out
+++ b/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.out
@@ -1,0 +1,7 @@
+
+Pod/pod-pending-topology-spread-scheduleanyway-only -n default, created 1m ago, gen:1 Pending Burstable
+  Failed: Pod could not be scheduled
+    Stalled: PodUnschedulable, Pod could not be scheduled
+  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+    PodScheduled Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
+  Standalone POD.

--- a/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.yaml
+++ b/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2026-06-28T21:13:57Z"
+  generation: 1
+  labels:
+    app: api
+  name: pod-pending-topology-spread-scheduleanyway-only
+  namespace: default
+  resourceVersion: "182454"
+  uid: 50285956-11ff-446f-9854-46f94842fe15
+spec:
+  containers:
+  - image: nginx:alpine
+    imagePullPolicy: IfNotPresent
+    name: main
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  topologySpreadConstraints:
+  - labelSelector:
+      matchLabels:
+        app: api
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2026-06-28T21:13:57Z"
+    message: "0/3 nodes are available: 3 Insufficient cpu."
+    reason: Unschedulable
+    status: "False"
+    type: PodScheduled
+  phase: Pending
+  qosClass: Burstable


### PR DESCRIPTION
## Summary
- Adds a `pod_topology_constraints` partial to `Pod.tmpl` that renders required (`DoNotSchedule`) topology spread constraints and required `podAffinity`/`podAntiAffinity` terms, gated on `PodScheduled=False` (mirrors the existing `pod_placement_constraints` gating for node selector/affinity).
- Reuses the existing `labelSelector` helper for the selector formatting — pod affinity/spread terms use real `metav1.LabelSelector`s, so no new selector-formatting code was needed.
- `ScheduleAnyway` spread constraints and preferred pod (anti-)affinity are soft preferences/scoring hints and are deliberately never rendered.
- Spec-only: no live fetch, zero new API calls/RBAC — renders identically across `--shallow`/`--local`/`--deep`.

Closes #740

## Test plan
- [x] `go test ./...` passes
- [x] `make update-artifacts` regenerated only the 4 new fixtures' `.out` files (no unrelated diffs)
- [x] New fixtures cover all 4 acceptance scenarios from the issue:
  - `pod-pending-topology-spread-donotschedule` — renders `required spread: ...`
  - `pod-pending-topology-spread-scheduleanyway-only` — silent (ScheduleAnyway is never rendered)
  - `pod-pending-required-antiaffinity` — renders `required anti-affinity: ...`
  - `pod-pending-preferred-antiaffinity-only` — silent (preferred is never rendered)
- [x] Manually verified required `podAffinity` (not just anti-affinity) renders as `required affinity: ...`
- e2e test intentionally omitted — issue marks it optional/low-priority given full offline coverage, and this change makes no live cluster calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)