### PR TITLE
Add generic fallback health-summary for unknown-kind resource lists

### DIFF
--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -421,9 +421,10 @@
                 {{- end }}
             {{- else }}
                 {{- $obj := $.KubeGetFirst $ns .kind .name }}
-                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $ns "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- if $obj.Object }}
-                    {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ with .Message }}: {{ . }}{{ end }}{{ end }}
+                    {{- $.Include "resource_health_summary" (dict "obj" $obj "callerNamespace" $.Namespace) | nindent 4 }}
+                {{- else }}
+                    {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $ns "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -1204,5 +1205,71 @@
         {{- $ready := .Status.readyReplicas | default 0 | int }}
         {{- if lt $ready $desired }}{{ printf ", %d/%d" $ready $desired | red | bold }}{{ else }}{{ printf ", %d/%d" $ready $desired | green }}{{ end }} ready
         {{- with .RolloutStatus . }}{{ if not .done }}, {{ "rolling out" | yellow }}{{ end }}{{ end }}
+    {{- end }}
+{{- end }}
+
+{{- define "generic_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (RenderableObject of any kind) "callerNamespace" (optional, forwarded
+           to resource_ref so obj's own namespace is dropped when it's redundant). Fallback one-
+           line summary for kinds with no dedicated *_health_summary template -- used by
+           resource_health_summary for kinds it doesn't recognize. Rather than anything kind-
+           specific, this leans on the same conventions kstatus.Compute already uses to make sense
+           of arbitrary/CRD kinds (a status.conditions[type=Ready] entry, status.observedGeneration
+           vs metadata.generation), plus a couple of widely-used conventions kstatus doesn't check:
+           a bare status.ready boolean, and an observedGeneration recorded on the Ready condition
+           itself rather than at status.observedGeneration (controller-runtime's metav1.Condition
+           carries its own per-condition observedGeneration; some operators only set it there). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ with .Message }}: {{ . }}{{ end }}{{ end }}
+    {{- if hasKey $obj.Status "ready" }}
+        {{- $ready := $obj.Status.ready }}
+        {{- if kindIs "bool" $ready }}
+            {{- ", ready:" }}{{ if $ready }}{{ "true" | green }}{{ else }}{{ "false" | red | bold }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- $readyCond := getMatchingItemInMapList (dict "type" "Ready") $obj.StatusConditions }}
+    {{- $observedGen := 0 }}{{ $haveObservedGen := false }}
+    {{- if hasKey $obj.Status "observedGeneration" }}
+        {{- $observedGen = $obj.Status.observedGeneration }}{{ $haveObservedGen = true }}
+    {{- else if and $readyCond (hasKey $readyCond "observedGeneration") }}
+        {{- $observedGen = $readyCond.observedGeneration }}{{ $haveObservedGen = true }}
+    {{- end }}
+    {{- if and $haveObservedGen $obj.Metadata.generation (ne $observedGen $obj.Metadata.generation) }}
+        {{- ", observed gen " }}{{ $observedGen | toString | red | bold }}{{ " != gen " }}{{ $obj.Metadata.generation | toString | red | bold }}
+    {{- end }}
+{{- end }}
+
+{{- define "resource_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (RenderableObject of any kind) "callerNamespace" (optional, forwarded
+           through to pod_health_summary/generic_health_summary). Dispatches to the same compact
+           one-line summary the caller would reach for if it knew obj's kind ahead of time, falling
+           back to generic_health_summary for anything else. For use where a list mixes resources
+           of a kind that isn't known ahead of time, e.g. crossplane_composed_resources. */ -}}
+    {{- $obj := .obj }}
+    {{- $callerNamespace := .callerNamespace }}
+    {{- if eq $obj.Kind "Pod" }}
+        {{- template "pod_health_summary" (dict "pod" $obj "callerNamespace" $callerNamespace) }}
+    {{- else if eq $obj.Kind "Service" }}
+        {{- template "service_health_summary" $obj }}
+    {{- else if eq $obj.Kind "Ingress" }}
+        {{- template "ingress_health_summary" $obj }}
+    {{- else if has $obj.Kind (list "HTTPRoute" "GRPCRoute" "TCPRoute" "UDPRoute" "TLSRoute") }}
+        {{- template "route_health_summary" $obj }}
+    {{- else if eq $obj.Kind "Job" }}
+        {{- template "job_health_summary" $obj }}
+    {{- else if eq $obj.Kind "PodDisruptionBudget" }}
+        {{- template "pdb_health_summary" $obj }}
+    {{- else if has $obj.Kind (list "Deployment" "StatefulSet" "DaemonSet" "ReplicaSet") }}
+        {{- template "workload_health_summary" $obj }}
+    {{- else if eq $obj.Kind "HorizontalPodAutoscaler" }}
+        {{- template "hpa_health_summary" $obj }}
+    {{- else if eq $obj.Kind "VerticalPodAutoscaler" }}
+        {{- template "vpa_health_summary" $obj }}
+    {{- else }}
+        {{- template "generic_health_summary" (dict "obj" $obj "callerNamespace" $callerNamespace) }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -917,3 +917,153 @@ func TestManagedResourceDetailsTemplate_NotAManagedResource(t *testing.T) {
 		t.Errorf("expected no output for a non-managed-resource object, got = %q", got)
 	}
 }
+
+// renderObjHealthSummary renders "generic_health_summary" or "resource_health_summary" -- both
+// expect dict "obj" (RenderableObject) "callerNamespace" (optional) rather than the bare object
+// renderCrossplaneTemplate's callers pass.
+func renderObjHealthSummary(t *testing.T, templateName string, obj map[string]interface{}, callerNamespace string) (string, error) {
+	t.Helper()
+	v := viper.New()
+	cfg := NewRenderConfig(v)
+	tmpl, _ := getTemplate(cfg)
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f, cfg.Viper)
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	r := newRenderableObject(obj, e, repo)
+	return r.renderTemplate(templateName, map[string]interface{}{"obj": r, "callerNamespace": callerNamespace})
+}
+
+func TestGenericHealthSummaryTemplate(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]interface{}
+		want string
+	}{
+		{
+			name: "Ready condition true falls back to kstatus Current",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget", "generation": int64(2)},
+				"status": map[string]interface{}{
+					"observedGeneration": int64(2),
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True"},
+					},
+				},
+			},
+			want: "Current: Resource is Ready",
+		},
+		{
+			name: "Ready condition false surfaces its message as InProgress",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget"},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "False", "reason": "Blocked", "message": "still blocked"},
+					},
+				},
+			},
+			want: "InProgress: still blocked",
+		},
+		{
+			name: "bare status.ready boolean is surfaced even without a Ready condition",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget"},
+				"status":   map[string]interface{}{"ready": false},
+			},
+			want: "ready:",
+		},
+		{
+			name: "observedGeneration mismatch at status.observedGeneration is flagged",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget", "generation": int64(3)},
+				"status":   map[string]interface{}{"observedGeneration": int64(2)},
+			},
+			want: "!= gen",
+		},
+		{
+			name: "observedGeneration recorded only on the Ready condition is still flagged (#kstatus doesn't check this)",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget", "generation": int64(5)},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True", "observedGeneration": int64(4)},
+					},
+				},
+			},
+			want: "!= gen",
+		},
+		{
+			name: "matching observedGeneration on the Ready condition is silent",
+			obj: map[string]interface{}{
+				"kind":     "Widget",
+				"metadata": map[string]interface{}{"name": "my-widget", "generation": int64(4)},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{"type": "Ready", "status": "True", "observedGeneration": int64(4)},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := renderObjHealthSummary(t, "generic_health_summary", tt.obj, "")
+			if err != nil {
+				t.Fatalf("renderTemplate() error = %v", err)
+			}
+			if tt.want == "" {
+				if strings.Contains(got, "!=") {
+					t.Errorf("got = %q, want no observed-generation mismatch flag", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("got = %q, want it to contain %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceHealthSummaryTemplate_DispatchesToKnownKind(t *testing.T) {
+	obj := map[string]interface{}{
+		"kind":     "Job",
+		"metadata": map[string]interface{}{"name": "my-job", "namespace": "test"},
+		"status":   map[string]interface{}{"succeeded": float64(1)},
+	}
+	got, err := renderObjHealthSummary(t, "resource_health_summary", obj, "test")
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Succeeded") {
+		t.Errorf("got = %q, want job_health_summary's Succeeded flag, not the generic fallback", got)
+	}
+}
+
+func TestResourceHealthSummaryTemplate_FallsBackToGenericForUnknownKind(t *testing.T) {
+	obj := map[string]interface{}{
+		"kind":     "Widget",
+		"metadata": map[string]interface{}{"name": "my-widget", "namespace": "test"},
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+		},
+	}
+	got, err := renderObjHealthSummary(t, "resource_health_summary", obj, "test")
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Current: Resource is Ready") {
+		t.Errorf("got = %q, want the generic_health_summary fallback", got)
+	}
+}

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -4,8 +4,8 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
     Reconciling: Creating, Unready resources: blocked-workload, config
   Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
-    Deployment/probe-a-blocked, InProgress: Available: 0/1
-    ConfigMap/probe-a-config, Current: Resource is always ready
+    Deployment/probe-a-blocked, created 1m ago, 0/1 ready, rolling out
+    ConfigMap/probe-a-config, created 1m ago, Current: Resource is always ready
   Synced ReconcileSuccess for 1m
   Ready Creating, Unready resources: blocked-workload, config for 1m
   Responsive WatchCircuitClosed for 1m


### PR DESCRIPTION
## Summary
- Add `generic_health_summary`: fallback one-line summary for kinds with no dedicated `*_health_summary` template. Leans on the same conventions `kstatus.Compute` uses for arbitrary CRDs (`Ready` status condition, `status.observedGeneration` vs `metadata.generation`), plus two conventions kstatus doesn't check: a bare `status.ready` boolean, and `observedGeneration` recorded on the `Ready` condition itself rather than at `status.observedGeneration`.
- Add `resource_health_summary`: dispatches to the matching kind-specific `*_health_summary` (Pod, Service, Ingress, Route family, Job, PodDisruptionBudget, workload family, HPA, VPA) when known, falling back to `generic_health_summary` otherwise. For use anywhere a list mixes resources of a kind that isn't known ahead of time.
- Wire it into `crossplane_composed_resources`'s non-deep branch — the existing case of rendering a list of unknown-kind resources — so a composed Deployment now shows ready-replica counts and rollout state instead of just a raw kstatus string.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` — added 8 new unit tests in `templates_common_test.go` covering both new templates directly (Ready condition true/false, bare `status.ready`, observedGeneration mismatch at both locations, dispatch to a known kind vs. generic fallback)
- [x] `make update-artifacts` — zero diff across all offline golden files (`--local` mode never populates `$obj.Object` for the crossplane composed-resources lookup, so this path wasn't previously exercised there)
- [ ] `tests/e2e-artifacts/crossplane-xr.regex` was updated by hand (derived from reading `workload_health_summary`/`RolloutStatus` source) since it's the one place a *found* composed resource is asserted against, and that requires a live cluster (`make test-e2e`) I don't have access to here — please run that suite before merging to confirm it's accurate.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>