### PR TITLE
Secret: support Helm release-storage secrets (revision/status/manifest)

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -15,6 +19,25 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// buildHelmReleaseSecretData encodes release the same way Helm's own storage driver does for its
+// Secret backend (base64(gzip(JSON)), see encodeRelease in
+// https://github.com/helm/helm/blob/main/pkg/storage/driver/util.go) -- this single explicit
+// encoding, plus the outer base64 the Kubernetes API/dynamic client applies automatically to every
+// []byte Secret data value on the wire, reproduces the double-base64 layering
+// parseHelmReleaseSecret (pkg/plugin/template_functions_static.go) decodes.
+func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(release)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	require.NoError(t, err)
+	_, err = gw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
+}
 
 func TestE2EDynamicManifests(t *testing.T) {
 	e2eMinikubeTest(t)
@@ -842,6 +865,82 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"pod/" + podName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-wfc-topologies-unbound.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("Helm release Secret flags a superseded revision and resolves its manifest's live objects", func(t *testing.T) {
+		// A Helm release Secret's data.release is opaque (base64(gzip(JSON))) until decoded, and
+		// there was previously no indication at all that a Secret was Helm's own release-storage
+		// object, let alone whether it was superseded by a later revision or what it actually
+		// deployed. Offline artifact tests (tests/artifacts/secret-helm-release-*) already cover
+		// the parse itself and the --shallow/--local fallback (resource_ref, no "Newer revision"
+		// line); this exercises the two live-query-only branches: the sibling-Secret revision scan
+		// ($.KubeGetByLabelsMap) and resolving a manifest entry to its live object ($.KubeGetFirst
+		// / $.IncludeRenderableObject in --deep).
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-helm-release"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		configMapName := "e2e-helm-release-config"
+		_, err = clientset.CoreV1().ConfigMaps(ns).Create(context.TODO(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: ns},
+			Data:       map[string]string{"foo": "bar"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		manifest := "---\n# Source: e2e-chart/templates/configmap.yaml\n" +
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + configMapName + "\ndata:\n  foo: bar\n"
+
+		releaseName := "e2e-helm-release"
+		newRelease := func(revision int, status string) map[string]interface{} {
+			return map[string]interface{}{
+				"name":      releaseName,
+				"namespace": ns,
+				"version":   revision,
+				"manifest":  manifest,
+				"info":      map[string]interface{}{"status": status, "description": "Install complete"},
+				"chart": map[string]interface{}{"metadata": map[string]interface{}{
+					"name": "e2e-chart", "version": "1.2.3", "appVersion": "2.0.0",
+				}},
+			}
+		}
+		newReleaseSecret := func(revision int, status string) *corev1.Secret {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("sh.helm.release.v1.%s.v%d", releaseName, revision),
+					Namespace: ns,
+					Labels: map[string]string{
+						"name":    releaseName,
+						"owner":   "helm",
+						"status":  status,
+						"version": fmt.Sprintf("%d", revision),
+					},
+				},
+				Type: "helm.sh/release.v1",
+				Data: map[string][]byte{"release": buildHelmReleaseSecretData(t, newRelease(revision, status))},
+			}
+		}
+
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(1, "superseded"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(2, "deployed"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		oldSecretName := fmt.Sprintf("sh.helm.release.v1.%s.v1", releaseName)
+		cmdTest{
+			args:            []string{"secret/" + oldSecretName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the manifest's resolved ConfigMap in full -- offline artifact tests can't
+		// reach this branch either, since --shallow/--local (used by every offline test) makes the
+		// KubeGetFirst behind it a no-op.
+		cmdTest{
+			args:            []string{"secret/" + oldSecretName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded-deep.regex",
 		}.assert(t, nil, opts...)
 	})
 }

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -2,11 +2,13 @@ package plugin
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/bergerx/kubectl-status/pkg/plugin/calicoselector"
 	"github.com/bergerx/kubectl-status/pkg/plugin/crossplanedrift"
@@ -145,6 +148,8 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"parseSSHAuthSecret":              parseSSHAuthSecret,
 		"parseServiceAccountTokenSecret":  parseServiceAccountTokenSecret,
 		"parseBootstrapTokenSecret":       cfg.parseBootstrapTokenSecret,
+		"parseHelmReleaseSecret":          parseHelmReleaseSecret,
+		"helmReleaseManifestResources":    helmReleaseManifestResources,
 		"secretDataKeys":                  secretDataKeys,
 		"crossplaneManagedResourceDrift":  crossplaneManagedResourceDrift,
 		"crossplaneDriftLabel":            crossplaneDriftLabel,
@@ -713,11 +718,11 @@ func colorKeyword(phase string) string {
 	    * pvc: .status.phase Bound
 	*/
 	switch phase {
-	case "Running", "Succeeded", "Available", "Bound", "valid", "Guaranteed", "Completed", "Current":
+	case "Running", "Succeeded", "Available", "Bound", "valid", "Guaranteed", "Completed", "Current", "deployed":
 		return color.GreenString(phase)
-	case "Pending", "Released", "Burstable", "Active", "InProgress":
+	case "Pending", "Released", "Burstable", "Active", "InProgress", "superseded", "pending-install", "pending-upgrade", "pending-rollback", "uninstalling":
 		return color.YellowString(phase)
-	case "Failed", "Unknown", "Terminating", "Evicted", "BestEffort", "OOMKilled", "ContainerCannotRun", "Error", "NotFound":
+	case "Failed", "Unknown", "Terminating", "Evicted", "BestEffort", "OOMKilled", "ContainerCannotRun", "Error", "NotFound", "failed", "unknown":
 		return color.New(color.FgRed, color.Bold).Sprintf("%s", phase)
 	default:
 		return phase
@@ -1876,6 +1881,136 @@ func (cfg *RenderConfig) parseBootstrapTokenSecret(secret RenderableObject) map[
 	}
 
 	return result
+}
+
+// helmReleaseDataStruct is the subset of Helm's release.v1 JSON payload this template needs --
+// intentionally not the full helm.sh/helm/v3/pkg/release.Release struct, to avoid pulling in the
+// Helm SDK as a dependency just to read a handful of fields.
+type helmReleaseDataStruct struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Version   int    `json:"version"`
+	Manifest  string `json:"manifest"`
+	Info      struct {
+		Status      string `json:"status"`
+		Description string `json:"description"`
+	} `json:"info"`
+	Chart struct {
+		Metadata struct {
+			Name       string `json:"name"`
+			Version    string `json:"version"`
+			AppVersion string `json:"appVersion"`
+		} `json:"metadata"`
+	} `json:"chart"`
+}
+
+// parseHelmReleaseSecret decodes a Secret of type helm.sh/release.v1 -- Helm (v3+)'s default
+// release storage backend, one Secret per (release name, revision) -- into the fields the
+// template needs. data.release is encoded twice: once as an ordinary Secret data entry (plain
+// base64, per the Kubernetes API convention every Secret data value uses), then again by Helm's
+// own storage driver as base64(gzip(JSON)); see decodeRelease/encodeRelease in
+// https://github.com/helm/helm/blob/main/pkg/storage/driver/util.go.
+func parseHelmReleaseSecret(secret RenderableObject) map[string]interface{} {
+	result := map[string]interface{}{
+		"Exists":       false,
+		"ParseError":   "",
+		"ReleaseName":  "",
+		"Namespace":    "",
+		"Revision":     0,
+		"Status":       "",
+		"Description":  "",
+		"ChartName":    "",
+		"ChartVersion": "",
+		"AppVersion":   "",
+		"Manifest":     "",
+	}
+	if secret.Object == nil {
+		return result
+	}
+	data, _ := secret.Object["data"].(map[string]interface{})
+	encoded, ok := data["release"].(string)
+	if !ok {
+		result["ParseError"] = "missing data.release"
+		return result
+	}
+	result["Exists"] = true
+	outer, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		result["ParseError"] = fmt.Sprintf("failed to base64-decode release: %v", err)
+		return result
+	}
+	inner, err := base64.StdEncoding.DecodeString(string(outer))
+	if err != nil {
+		result["ParseError"] = fmt.Sprintf("failed to base64-decode release payload: %v", err)
+		return result
+	}
+	gzReader, err := gzip.NewReader(bytes.NewReader(inner))
+	if err != nil {
+		result["ParseError"] = fmt.Sprintf("failed to gzip-decode release payload: %v", err)
+		return result
+	}
+	defer gzReader.Close()
+	plain, err := io.ReadAll(gzReader)
+	if err != nil {
+		result["ParseError"] = fmt.Sprintf("failed to decompress release payload: %v", err)
+		return result
+	}
+	var release helmReleaseDataStruct
+	if err := json.Unmarshal(plain, &release); err != nil {
+		result["ParseError"] = fmt.Sprintf("failed to parse release JSON: %v", err)
+		return result
+	}
+	result["ReleaseName"] = release.Name
+	result["Namespace"] = release.Namespace
+	result["Revision"] = release.Version
+	result["Status"] = release.Info.Status
+	result["Description"] = release.Info.Description
+	result["ChartName"] = release.Chart.Metadata.Name
+	result["ChartVersion"] = release.Chart.Metadata.Version
+	result["AppVersion"] = release.Chart.Metadata.AppVersion
+	result["Manifest"] = release.Manifest
+	return result
+}
+
+// helmManifestDocSeparator matches Helm's own document separator convention: each rendered
+// template in release.manifest is joined with a "---" line of its own (usually followed by a
+// "# Source: <chart>/templates/..." comment), the same convention plain multi-document YAML uses.
+var helmManifestDocSeparator = regexp.MustCompile(`(?m)^---\s*$`)
+
+// helmReleaseManifestResources splits a Helm release's rendered manifest into its individual
+// Kubernetes objects and extracts just enough (apiVersion/kind/name/namespace) to look each one
+// up live -- never re-rendering the full object spec here, since $.KubeGetFirst below fetches the
+// object's actual current state rather than trusting what Helm last applied. Malformed or
+// non-object documents (stray comments, empty docs from a trailing separator) are skipped rather
+// than failing the whole list.
+func helmReleaseManifestResources(manifest string) []map[string]interface{} {
+	var out []map[string]interface{}
+	for _, doc := range helmManifestDocSeparator.Split(manifest, -1) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var parsed struct {
+			APIVersion string `json:"apiVersion"`
+			Kind       string `json:"kind"`
+			Metadata   struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		}
+		if err := yaml.Unmarshal([]byte(doc), &parsed); err != nil {
+			continue
+		}
+		if parsed.Kind == "" || parsed.Metadata.Name == "" {
+			continue
+		}
+		out = append(out, map[string]interface{}{
+			"apiVersion": parsed.APIVersion,
+			"kind":       parsed.Kind,
+			"name":       parsed.Metadata.Name,
+			"namespace":  parsed.Metadata.Namespace,
+		})
+	}
+	return out
 }
 
 // secretDataKeys returns the sorted union of a Secret's data and stringData key names, for

--- a/pkg/plugin/templates/Secret.tmpl
+++ b/pkg/plugin/templates/Secret.tmpl
@@ -7,12 +7,13 @@
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
     {{- /* Opaque is the Kubernetes default -- suppressed per the "omit defaults" convention.
-           kubernetes.io/tls and the dockerconfigjson/dockercfg pair already get their own
-           dedicated sections below (Certificate for.../Registries:), which imply the type, so
-           spelling it out here too would be redundant. Every other declared type (basic-auth,
-           ssh-auth, service-account-token, bootstrap.kubernetes.io/token, custom types, ...) has
-           no other indicator anywhere in the output, so show it. */ -}}
-    {{- if and .Object.type (ne .Object.type "Opaque") (not (has .Object.type (list "kubernetes.io/tls" "kubernetes.io/dockerconfigjson" "kubernetes.io/dockercfg"))) }}
+           kubernetes.io/tls, the dockerconfigjson/dockercfg pair and helm.sh/release.v1 already
+           get their own dedicated sections below (Certificate for.../Registries:/Helm release),
+           which imply the type, so spelling it out here too would be redundant. Every other
+           declared type (basic-auth, ssh-auth, service-account-token,
+           bootstrap.kubernetes.io/token, custom types, ...) has no other indicator anywhere in
+           the output, so show it. */ -}}
+    {{- if and .Object.type (ne .Object.type "Opaque") (not (has .Object.type (list "kubernetes.io/tls" "kubernetes.io/dockerconfigjson" "kubernetes.io/dockercfg" "helm.sh/release.v1"))) }}
         {{- "Type" | bold | nindent 2 }}: {{ .Object.type | cyan }}
         {{- if eq .Object.type "kubernetes.io/service-account-token" }}
             {{- with (parseServiceAccountTokenSecret .).ServiceAccountName }}
@@ -172,6 +173,46 @@
         {{- end }}
         {{- "Usage" | bold | nindent 2 }}: authentication {{ if $bt.UsageAuthentication }}{{ "enabled" | green }}{{ else }}{{ "disabled" | red }}{{ end }} · signing {{ if $bt.UsageSigning }}{{ "enabled" | green }}{{ else }}{{ "disabled" | red }}{{ end }}
     {{- end }}
+    {{- if eq .Object.type "helm.sh/release.v1" }}
+        {{- $release := parseHelmReleaseSecret . }}
+        {{- if $release.ParseError }}
+            {{- "Failed to parse Helm release data" | red | bold | nindent 2 }}: {{ $release.ParseError | red }}
+        {{- else }}
+            {{- "Helm release" | bold | nindent 2 }}: {{ $release.ReleaseName | cyan }}, revision {{ $release.Revision | toString | cyan }}
+            {{- with $release.Status }} ({{ . | colorKeyword }}){{ end }}
+            {{- with $release.ChartName }}
+                {{- ", chart " }}{{ . | cyan }}{{ with $release.ChartVersion }}-{{ . | cyan }}{{ end }}
+            {{- end }}
+            {{- with $release.AppVersion }}, app version {{ . | cyan }}{{ end }}
+            {{- if eq $release.Status "failed" }}
+                {{- with $release.Description }}
+                    {{- "Failure" | red | bold | nindent 4 }}: {{ . | red }}
+                {{- end }}
+            {{- end }}
+            {{- if not (.LiveQueriesDisabled) }}
+                {{- $siblings := .KubeGetByLabelsMap .Namespace "secrets" (dict "owner" "helm" "name" $release.ReleaseName) }}
+                {{- $maxRevision := $release.Revision | int }}
+                {{- range $siblings }}
+                    {{- $v := index .Labels "version" | int }}
+                    {{- if gt $v $maxRevision }}{{ $maxRevision = $v }}{{ end }}
+                {{- end }}
+                {{- if gt $maxRevision ($release.Revision | int) }}
+                    {{- "Newer revision available" | yellow | bold | nindent 2 }}: revision {{ $maxRevision | toString | cyan }} exists, this Secret holds revision {{ $release.Revision | toString | cyan }}
+                {{- end }}
+            {{- end }}
+            {{- $resources := helmReleaseManifestResources $release.Manifest }}
+            {{- with $resources }}
+                {{- if eq (len .) 1 }}
+                    {{- "Manifest:" | bold | nindent 2 }} {{ template "helm_release_manifest_entry" (dict "ctx" $ "entry" (index . 0)) }}
+                {{- else }}
+                    {{- "Manifests" | bold | nindent 2 }} ({{ len . | toString | cyan }}):
+                    {{- range . }}
+                        {{- "" | nindent 4 }}{{ template "helm_release_manifest_entry" (dict "ctx" $ "entry" .) }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
     {{- if or (eq .Object.type "Opaque") (not .Object.type) }}
         {{- with secretDataKeys . }}
             {{- "Keys" | bold | nindent 2 }}: {{ join ", " . | cyan }}
@@ -205,4 +246,28 @@
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
+{{- end }}
+
+{{- define "helm_release_manifest_entry" }}
+    {{- /* Expects dict "ctx" (the Secret RenderableObject) "entry" (dict kind/name/namespace/
+           apiVersion parsed by helmReleaseManifestResources from one document in the release
+           manifest). The manifest rarely sets metadata.namespace explicitly (charts usually rely
+           on the install-time --namespace instead), so a namespace-less entry falls back to the
+           Secret's own namespace, which is where Helm always stores its release; this only
+           matters for namespaced kinds; passing a namespace for a cluster-scoped kind (e.g.
+           ClusterRole) is harmless, $.KubeGetFirst's builder ignores it based on the kind's actual
+           scope. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $entry := .entry }}
+    {{- $ns := $entry.namespace | default $ctx.Namespace }}
+    {{- $obj := $ctx.KubeGetFirst $ns $entry.kind $entry.name }}
+    {{- if $obj.Object }}
+        {{- if $ctx.Config.GetBool "deep" }}
+            {{- $ctx.IncludeRenderableObject $obj }}
+        {{- else }}
+            {{- $ctx.Include "resource_health_summary" (dict "obj" $obj "callerNamespace" $ctx.Namespace) }}
+        {{- end }}
+    {{- else }}
+        {{- template "resource_ref" (dict "kind" $entry.kind "name" $entry.name "namespace" $ns "callerNamespace" $ctx.Namespace) }}
+    {{- end }}
 {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -544,7 +544,11 @@
         {{- $instance := coalesce (get $annotations "meta.helm.sh/release-name") $labels.release (get $labels "app.kubernetes.io/instance") }}
         {{- $releaseNamespace := get $annotations "meta.helm.sh/release-namespace" }}
         {{- $namespace := eq $releaseNamespace .Namespace | ternary "" $releaseNamespace }}
-        {{- $version := coalesce (get $labels "app.kubernetes.io/version") $labels.version }}
+        {{- /* Helm's own release-storage Secret (type helm.sh/release.v1) carries a "version"
+               label too, but there it's the release revision number, not an app version -- the
+               dedicated Helm section in Secret.tmpl already reports the revision explicitly, so
+               falling back to it here would print a misleading "using version 1" line. */ -}}
+        {{- $version := coalesce (get $labels "app.kubernetes.io/version") (ternary "" $labels.version (eq .Object.type "helm.sh/release.v1")) }}
         {{- if or $clusterService $addonManager $managedBy $createdBy $name $partOf $component $instance $namespace $version }}
             {{- "Managed" | nindent 2 }}
             {{- with $addonManager }} by {{ "AddonManager" | bold | yellow }} in {{ . | redBoldIf (eq . "Reconcile") }} mode{{ end }}

--- a/tests/artifacts/secret-helm-release-deployed.out
+++ b/tests/artifacts/secret-helm-release-deployed.out
@@ -1,0 +1,6 @@
+
+Secret/sh.helm.release.v1.my-release.v3 -n default, created 1m ago
+  Helm release: my-release, revision 3 (deployed), chart mychart-1.2.3, app version 2.0.0
+  Manifests (2):
+    Deployment/my-release-mychart
+    ConfigMap/my-release-mychart-config

--- a/tests/artifacts/secret-helm-release-deployed.yaml
+++ b/tests/artifacts/secret-helm-release-deployed.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  release: SDRzSUFBOHhZbW9DLzQxVHkyNERJUXo4RlVTdjNjMUx2WEJ0TDVYYVU2V2V1RGlzTjBFRmc0Q05Ha1g1OThLK2traVJHdDlzRHpPRERTZE9ZSkVMeHUyeENtZ1FJdkpueGpXMUxsZFBQQ1pJWFN5QUJyMXhSMnhLdThHb2d2WkpPeXF0ZDhvd1k1aHkxaHRNeU04Wm8vWVFVczloTVVFRENmcmtvamNBTXZLQUlZNU1xM3BkYjBvTnZQKytsTmYxc2w3eWMwL3JxTlc3UWxVeUM2UmJqRVdIVjFVbDZZbDl1UzRvRkd3VVdDVE1waUJoWEF3M3NFaXBQb0kxa3NEclVVU3dMQmdYaDVXa0gwMk5ZRzh6VnRMa1gwaGlyUGd2NU5PMHFsR245QXhzMGNRZXhncGgvZE50TVZDZVNLeTFXMHhIWi93OWtDNnpKSFdqSVNsNlZEMXZ5TDYwZ2lqWXFxUXhBMVJ5WWRTMGtOVCs0OXJGUXo2bUVVMHMxL2N0WVc0Wkg3emI3TGxFWGxzQ1RYbmFWelFWdTNOc0NHMWhsenUwMC9RcjhxdDRrZlR2Zm9lblljSGZXZTlsczY4OTZoUDhnNHV0QmxwSk03SjFUckF0QkVtM3IzZVRzOElTUFNnY3Zrd0xuVW44L0FjS0dkSEJad01BQUE9PQ==
+kind: Secret
+metadata:
+  creationTimestamp: "2026-07-19T00:58:24Z"
+  labels:
+    modifiedAt: "1752886704"
+    name: my-release
+    owner: helm
+    status: deployed
+    version: "3"
+  name: sh.helm.release.v1.my-release.v3
+  namespace: default
+  resourceVersion: "476"
+  uid: aa1594e1-e2a9-4d3f-b225-e279f54f78ee
+type: helm.sh/release.v1

--- a/tests/e2e-artifacts/secret-helm-release-superseded-deep.regex
+++ b/tests/e2e-artifacts/secret-helm-release-superseded-deep.regex
@@ -1,0 +1,6 @@
+\A
+Secret/sh\.helm\.release\.v1\.e2e-helm-release\.v1 -n e2e-helm-release, created 1m ago
+  Helm release: e2e-helm-release, revision 1 \(superseded\), chart e2e-chart-1\.2\.3, app version 2\.0\.0
+  Newer revision available: revision 2 exists, this Secret holds revision 1
+  Manifest: ConfigMap/e2e-helm-release-config -n e2e-helm-release, created 1m ago
+\z

--- a/tests/e2e-artifacts/secret-helm-release-superseded.regex
+++ b/tests/e2e-artifacts/secret-helm-release-superseded.regex
@@ -1,0 +1,6 @@
+\A
+Secret/sh\.helm\.release\.v1\.e2e-helm-release\.v1 -n e2e-helm-release, created 1m ago
+  Helm release: e2e-helm-release, revision 1 \(superseded\), chart e2e-chart-1\.2\.3, app version 2\.0\.0
+  Newer revision available: revision 2 exists, this Secret holds revision 1
+  Manifest: ConfigMap/e2e-helm-release-config, created 1m ago, Current: Resource is always ready
+\z


### PR DESCRIPTION
## Summary
- Recognizes Secrets of type `helm.sh/release.v1` (Helm's default release-storage backend) and decodes the `data.release` payload (base64(gzip(JSON))) to show release name, revision, status, chart name/version, and app version.
- Cross-checks sibling release Secrets in the same namespace (`owner=helm,name=<release>`) to flag when this Secret holds a superseded revision and a newer one already exists in-cluster.
- Lists the release manifest's resources, resolving each live via `resource_health_summary`/`generic_health_summary` (falls back to `resource_ref` under `--shallow`/`--local`, full inline render under `--deep`).
- Fixes a latent bug in `application_details` this surfaced: Helm's own `version` label (the release revision number) collided with the generic `app.kubernetes.io/version` convention, printing a misleading `Managed using version N` line on every Helm release Secret.

## Test plan
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./...` (offline artifact fixtures + regex-anchoring check)
- [x] `make test-e2e-quick RUN='TestE2EDynamicManifests/Helm_release'` against the shared minikube cluster — both the default and `--deep` assertions pass, exercising the sibling-revision scan and live manifest resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)