### PR TITLE
Fix panic in HTTPRoute/GRPCRoute templates when spec.hostnames is unset

### DIFF
--- a/pkg/plugin/templates/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/GRPCRoute.tmpl
@@ -26,8 +26,9 @@
                         {{- $gw := $.KubeGetFirst $gwNs "Gateway" .name }}
                         {{- if $gw.Object }}
                             {{- /* if the route has exactly one hostname, use it for hostname-match checks; skip strictness otherwise */}}
+                            {{- $routeHostnames := $.Spec.hostnames | default (list) }}
                             {{- $routeHostname := "" }}
-                            {{- if eq (len $.Spec.hostnames) 1 }}{{ $routeHostname = index $.Spec.hostnames 0 }}{{ end }}
+                            {{- if eq (len $routeHostnames) 1 }}{{ $routeHostname = index $routeHostnames 0 }}{{ end }}
                             {{- range $gw.Spec.listeners }}
                                 {{- $isMatch := false }}
                                 {{- if $parentRef.sectionName }}
@@ -35,7 +36,7 @@
                                 {{- else if eq .protocol "HTTPS" }}
                                     {{- $hostOk := true }}
                                     {{- with .hostname }}
-                                        {{- if and (gt (len $.Spec.hostnames) 0) (not (has . $.Spec.hostnames)) }}{{ $hostOk = false }}{{ end }}
+                                        {{- if and (gt (len $routeHostnames) 0) (not (has . $routeHostnames)) }}{{ $hostOk = false }}{{ end }}
                                     {{- end }}
                                     {{- if $hostOk }}{{ $isMatch = true }}{{ end }}
                                 {{- end }}

--- a/pkg/plugin/templates/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/HTTPRoute.tmpl
@@ -16,7 +16,7 @@
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- $routeHostnames := .Spec.hostnames }}
+    {{- $routeHostnames := .Spec.hostnames | default (list) }}
     {{- $routeHostname := "" }}
     {{- if eq (len $routeHostnames) 1 }}{{ $routeHostname = index $routeHostnames 0 }}{{ end }}
     {{- with .Spec.parentRefs }}

--- a/tests/artifacts/httproute-no-hostnames.out
+++ b/tests/artifacts/httproute-no-hostnames.out
@@ -1,0 +1,12 @@
+
+HTTPRoute/myapp-prom-prometheus-prometheus -n prom, created 1m ago by HTTPRoute/prom-prometheus-prometheus, gen:1
+  Current: Resource is current
+  Parents:
+    Gateway/myapp-envoy-gateway -n infra-envoy-gateway
+      controller: gateway.envoyproxy.io/gatewayclass-controller
+      Accepted Accepted, Route is accepted for 1m
+      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+  Rules:
+    PathPrefix /
+      header:Host=^prom\.app\..*
+    → Service/prom-prometheus:9090

--- a/tests/artifacts/httproute-no-hostnames.yaml
+++ b/tests/artifacts/httproute-no-hostnames.yaml
@@ -1,0 +1,60 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: "2026-07-20T18:21:38Z"
+  generation: 1
+  labels:
+    myapp.comp.com/mirror-of: prom.prom-prometheus-prometheus
+  name: myapp-prom-prometheus-prometheus
+  namespace: prom
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HTTPRoute
+    name: prom-prometheus-prometheus
+    uid: 7b20e026-5f51-4395-b3da-5aed7ddd84d9
+  resourceVersion: "3210583"
+  uid: 99f0016a-6fbe-475e-a0f9-953b080bf5a0
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: myapp-envoy-gateway
+    namespace: infra-envoy-gateway
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: prom-prometheus
+      port: 9090
+      weight: 1
+    matches:
+    - headers:
+      - name: Host
+        type: RegularExpression
+        value: ^prom\.app\..*
+      path:
+        type: PathPrefix
+        value: /
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-07-22T11:53:18Z"
+      message: Route is accepted
+      observedGeneration: 1
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-07-22T11:53:18Z"
+      message: Resolved all the Object references for the Route
+      observedGeneration: 1
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    parentRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: myapp-envoy-gateway
+      namespace: infra-envoy-gateway


### PR DESCRIPTION
## Summary
- `HTTPRoute.tmpl` panicked (`reflect: call of reflect.Value.Type on zero Value`) rendering any HTTPRoute without `spec.hostnames`, because `.Spec.hostnames` (a missing map key) was assigned straight into a template variable and later passed to `len`, which chokes on the resulting invalid `reflect.Value` — unlike the same field accessed via `with`, which treats it as falsy.
- Found the identical pattern in `GRPCRoute.tmpl` (two call sites doing `len $.Spec.hostnames` / `has . $.Spec.hostnames` directly), reachable in real clusters when a GRPCRoute has no hostnames, isn't `--deep`, and its parent Gateway is resolvable live. `TCPRoute`/`UDPRoute` have no hostnames field, and `TLSRoute` already guards it correctly via `with`.
- Fix: pipe the field through `default (list)` so a missing `hostnames` behaves like an empty list in both templates.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `tests/artifacts/httproute-no-hostnames.{yaml,out}` reproducing the reported crash with `--local -f -`, now rendering cleanly
- [x] Verified via a temporary debug marker that the equivalent GRPCRoute crash path is real (a live Gateway lookup) but unreachable from local/e2e fixtures without a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)