### PR TITLE
Harden against security audit: patch Go toolchain, drop env template funcs, add govulncheck to CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: make test
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: 'go.mod'
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bergerx/kubectl-status
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -133,9 +133,15 @@ func newRenderEngine(streams genericiooptions.IOStreams, cfg *RenderConfig) (*re
 // could be beneficial in the future. But we parse them all once and re-use again for all template executions.
 func getTemplate(cfg *RenderConfig) (*template.Template, error) {
 	klog.V(5).InfoS("Creating new template instance...")
+	sprigFuncMap := sprigin.TxtFuncMap()
+	// env/expandEnv let a template read the process environment, which isn't needed by any
+	// built-in template and would let a stray template dropped into ~/.kubectl-status/templates
+	// leak env vars (e.g. cloud credentials) into rendered output.
+	delete(sprigFuncMap, "env")
+	delete(sprigFuncMap, "expandEnv")
 	tmpl := template.
 		New("templates").
-		Funcs(sprigin.TxtFuncMap()).
+		Funcs(sprigFuncMap).
 		Funcs(cfg.funcMap())
 	return parseTemplates(tmpl)
 }


### PR DESCRIPTION
## Summary
- Bump `go.mod`'s `go` directive from `1.26.0` to `1.26.5`, clearing 14 govulncheck-reachable stdlib crypto/tls/x509 CVEs (including `GO-2026-4866`, a case-sensitive `excludedSubtrees` name-constraint bug causing an x509 auth bypass)
- Drop the `env`/`expandEnv` Sprig template functions (unused by any built-in template) so a stray `.tmpl` file in `~/.kubectl-status/templates` can't leak process environment variables into rendered output
- Add a `govulncheck` step to `ci-test.yml` so future toolchain/dependency CVEs fail CI instead of going unnoticed

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `govulncheck ./...` reports 0 vulnerabilities after the Go bump (was 14)
- [x] Rebased on latest `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)