### PR TITLE
Sign release artifacts with cosign and generate SBOMs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -19,6 +22,10 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,3 +32,16 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+sboms:
+  - artifacts: archive
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - --yes
+    artifacts: checksum
+    output: true


### PR DESCRIPTION
## Summary
- Add keyless (Sigstore) `cosign` signing of the release `checksums.txt`, producing `.sig`/`.pem` files as extra release assets — no private key management required.
- Generate a per-archive SPDX-JSON SBOM via Syft (`sboms:` block in `.goreleaser.yml`), listing every Go module dependency with version, checksum, and license info.
- Wire up `.github/workflows/release.yml` with `id-token: write` permission (needed for cosign's OIDC-based keyless signing) and pinned `cosign-installer`/`sbom-action` steps, matching the repo's existing commit-SHA pinning convention.

## Test plan
- [x] `goreleaser check` validates the updated config
- [x] Local snapshot build (`goreleaser release --snapshot --clean --skip=sign,publish`) succeeds with builds/archives/checksums/SBOMs all generated
- [x] Spot-checked a generated SBOM (`status_linux_amd64.tar.gz.sbom.json`): valid SPDX-JSON, 87 packages with versions/checksums/licenses
- [ ] Cosign signing itself can only be exercised in CI (keyless signing needs the Actions OIDC token) — verify on the next tagged release
- [ ] After the next release, verify with:
  ```
  cosign verify-blob \
    --certificate status_<version>_checksums.txt.pem \
    --signature status_<version>_checksums.txt.sig \
    --certificate-identity-regexp 'https://github.com/bergerx/kubectl-status/.github/workflows/release.yml@.*' \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
    status_<version>_checksums.txt
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)