### PR TITLE
Document single-maintainer project continuity in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,12 @@ kubectl-status only supports the latest released version. Security fixes are
 made against `master` and shipped in the next release; older versions are not
 patched separately.
 
+## Project Continuity
+
+kubectl-status is maintained by a single person, with no formal succession
+plan. If the project goes dormant, forking is the expected path for continued
+maintenance.
+
 ## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues,


### PR DESCRIPTION
## Summary
- Adds a short "Project Continuity" section to SECURITY.md noting the project has a single maintainer, no formal succession plan, and forking is the expected path if it goes dormant.

## Test plan
- Docs-only change; no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)