### PR TITLE
Fix expandenv alias bypass of template env-var blocklist

### DIFF
--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -136,9 +136,13 @@ func getTemplate(cfg *RenderConfig) (*template.Template, error) {
 	sprigFuncMap := sprigin.TxtFuncMap()
 	// env/expandEnv let a template read the process environment, which isn't needed by any
 	// built-in template and would let a stray template dropped into ~/.kubectl-status/templates
-	// leak env vars (e.g. cloud credentials) into rendered output.
+	// leak env vars (e.g. cloud credentials) into rendered output. sprigin's sprig-compat layer
+	// also registers "expandenv" as a separate lowercase alias for the same function (see
+	// bc_registerSprigFuncs in go-sprout/sprout/sprigin), so it must be deleted too or it'd
+	// still let a template read the environment despite the deletions above.
 	delete(sprigFuncMap, "env")
 	delete(sprigFuncMap, "expandEnv")
+	delete(sprigFuncMap, "expandenv")
 	tmpl := template.
 		New("templates").
 		Funcs(sprigFuncMap).


### PR DESCRIPTION
## Summary
- `getTemplate()` deletes the sprig/sprout `env`/`expandEnv` template functions so a template can't leak process environment variables (e.g. cloud credentials) into rendered output.
- sprigin's sprig-compat layer also registers `expandenv` (lowercase) as a separate alias key pointing at the same `os.ExpandEnv`-backed function, which was never deleted — a template dropped into `~/.kubectl-status/templates/*.tmpl` could still call `{{ expandenv "$SOME_SECRET" }}` and bypass the intended control.
- Verified directly against the pinned `go-sprout/sprout` dependency that after this fix `env`, `expandEnv`, and `expandenv` are all absent from the function map.

## Test plan
- [x] `go build ./...`
- [x] Standalone script confirming `env`/`expandEnv`/`expandenv` are all removed from `sprigin.TxtFuncMap()` after the deletes