### PR TITLE
Minimize GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add an explicit `permissions: contents: read` block to `ci-test.yml`, which previously had none and relied on the repo's default (broad) token permissions.
- Repo-level `default_workflow_permissions` was also switched from `write` to `read`, and `can_approve_pull_request_reviews` disabled (applied directly via the GitHub API, not part of this diff) — `release.yml` and `codeql-analysis.yml` already declare their own explicit `permissions` blocks so they're unaffected.

## Test plan
- [ ] Confirm `ci-test` workflow run succeeds with read-only token
- [ ] Confirm `release` workflow (tag push) still succeeds with its own declared `contents: write` / `id-token: write` permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)