### PR TITLE
Detect the StatefulSet RollingUpdate rollback recovery trap (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ re-shuffling of `kubectl get`/`describe` fields. Every template answers a questi
 * colors carry meaning, not decoration: white-ish means everything is ok, red-ish strongly indicates something's wrong
   — and it's never color-only, the words say it too,
 * explicit messages for not-so-easy-to-understand status (e.g., ongoing rollout),
-* goes further where it's warranted (e.g., shows a spec diff for ongoing rollouts),
+* goes further where it's warranted (e.g., shows a spec diff for ongoing rollouts, or names the
+  specific Pod blocking a stuck StatefulSet rollback and the command to unstick it),
 * compact, non-extensive output to keep it sharp,
 * no external dependencies, doesn't shell out, and so doesn't depend on client/workstation configuration,
 * optionally show absolute timestamps with `--absolute-time` for building timelines

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -390,6 +390,47 @@ func waitForPodByLabel(t *testing.T, namespace, labelSelector string) string {
 	return ""
 }
 
+// waitForStatefulSetUpdateRevisionChange polls until the StatefulSet's status.updateRevision no
+// longer equals staleRevision -- used after reverting spec.template, so the assertion that
+// follows reads the controller's reconciled state rather than racing a stale one.
+func waitForStatefulSetUpdateRevisionChange(t *testing.T, namespace, name, staleRevision string) {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", "statefulset", name, "-n", namespace,
+			"-o", "jsonpath={.status.updateRevision}")
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			rev := strings.TrimSpace(string(output))
+			if rev != "" && rev != staleRevision {
+				t.Logf("statefulset %s/%s updateRevision changed from %s to %s", namespace, name, staleRevision, rev)
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for statefulset %s/%s updateRevision to change from %s", namespace, name, staleRevision)
+}
+
+// waitForPodReadyInNamespace polls a Pod's Ready condition instead of using `kubectl wait`, which
+// errors immediately if the Pod doesn't exist yet -- needed right after deleting a Pod, before the
+// owning controller has recreated it.
+func waitForPodReadyInNamespace(t *testing.T, namespace, podName string) {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(deadline) {
+		cmd := exec.Command("kubectl", "get", "pod", podName, "-n", namespace,
+			"-o", `jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
+		output, err := cmd.CombinedOutput()
+		if err == nil && strings.TrimSpace(string(output)) == "True" {
+			t.Logf("pod %s/%s is Ready", namespace, podName)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timed out waiting for pod %s/%s to become Ready", namespace, podName)
+}
+
 // waitForContainerWaitingReasonInNamespace targets a namespace explicitly via `kubectl -n`
 // instead of the kubeconfig's default; pass "" to use the kubeconfig's default namespace.
 func waitForContainerWaitingReasonInNamespace(t *testing.T, resource, containerName, reason, namespace string) {

--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -137,6 +138,73 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			cmdTest{
 				args:            []string{"statefulset/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/rollouts-single-blocked-statefulset.regex",
+			}.assert(t, nil, opts...)
+		})
+		t.Run("statefulset rollback recovery trap (#169)", func(t *testing.T) {
+			// Reproduces the kubernetes/kubernetes#78709 trap: an updated Pod that never becomes
+			// Ready blocks the rollout even after spec.template is reverted to the known-good
+			// image, because the StatefulSet controller keeps waiting on that specific Pod. Only
+			// deleting the Pod itself unsticks it.
+			opts := combineOpts(hackOpts, viperTestHackOpts())
+			ns := "e2e-rollouts-statefulset-rollback-trap"
+			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			})
+			name := "e2e-rollouts-statefulset-rollback-trap"
+			one := int32(1)
+			goodImage := "nginx:1.27"
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:    &one,
+					ServiceName: name,
+					Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: goodImage}}},
+					},
+				},
+			}
+			_, err = clientset.AppsV1().StatefulSets(ns).Create(context.TODO(), sts, metav1.CreateOptions{})
+			require.NoError(t, err)
+			defer clientset.AppsV1().StatefulSets(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+			waitForPodReadyInNamespace(t, ns, name+"-0")
+
+			// Break the rollout: the replacement Pod for ordinal 0 gets stuck on the bad image.
+			live, err := clientset.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			require.NoError(t, err)
+			live.Spec.Template.Spec.Containers[0].Image = badImage
+			_, err = clientset.AppsV1().StatefulSets(ns).Update(context.TODO(), live, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			waitForContainerWaitingReasonInNamespace(t, "pod/"+name+"-0", "app", "ImagePullBackOff", ns)
+			live, err = clientset.AppsV1().StatefulSets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+			require.NoError(t, err)
+			stuckRevision := live.Status.UpdateRevision
+
+			// Revert the template to the known-good image WITHOUT deleting the stuck Pod -- the
+			// trap: the Pod is still there, still unready, still on the now-orphaned bad revision.
+			live.Spec.Template.Spec.Containers[0].Image = goodImage
+			_, err = clientset.AppsV1().StatefulSets(ns).Update(context.TODO(), live, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			waitForStatefulSetUpdateRevisionChange(t, ns, name, stuckRevision)
+
+			trapOpts := combineOpts(opts, []func(*plugin.RenderConfig){
+				func(cfg *plugin.RenderConfig) { cfg.StatefulSetRollbackTrapThreshold = 2 * time.Second },
+			})
+			cmdTest{
+				args:            []string{"statefulset/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/rollouts-statefulset-rollback-trap.regex",
+			}.assert(t, nil, trapOpts...)
+
+			// Deleting only the blocking Pod recreates it on the target revision and recovers.
+			require.NoError(t, clientset.CoreV1().Pods(ns).Delete(context.TODO(), name+"-0", metav1.DeleteOptions{}))
+			waitForPodReadyInNamespace(t, ns, name+"-0")
+			cmdTest{
+				args:            []string{"statefulset/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/rollouts-statefulset-rollback-trap-recovered.regex",
 			}.assert(t, nil, opts...)
 		})
 		t.Run("daemonset", func(t *testing.T) {

--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -141,10 +141,11 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			}.assert(t, nil, opts...)
 		})
 		t.Run("statefulset rollback recovery trap (#169)", func(t *testing.T) {
-			// Reproduces the kubernetes/kubernetes#78709 trap: an updated Pod that never becomes
+			// Reproduces the kubernetes/kubernetes#67250 trap: an updated Pod that never becomes
 			// Ready blocks the rollout even after spec.template is reverted to the known-good
 			// image, because the StatefulSet controller keeps waiting on that specific Pod. Only
-			// deleting the Pod itself unsticks it.
+			// deleting the Pod itself unsticks it. Relies on the defaulted RollingUpdate strategy
+			// and OrderedReady Pod management -- the trap needs both.
 			opts := combineOpts(hackOpts, viperTestHackOpts())
 			ns := "e2e-rollouts-statefulset-rollback-trap"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -768,21 +768,27 @@ func (r RenderableObject) RolloutStatus(obj RenderableObject) map[string]interfa
 	}
 }
 
-// StatefulSetRollbackTrap detects the kubernetes/kubernetes#78709 StatefulSet RollingUpdate
-// recovery trap: the controller only ever creates the next replacement Pod once the current one
-// it's waiting on is Ready, so a Pod that was created for an update and never became Ready blocks
-// the rollout even after spec.template is fixed or reverted -- that specific Pod has to be
-// deleted so it gets recreated on the (possibly reverted) target revision.
+// StatefulSetRollbackTrap detects the kubernetes/kubernetes#67250 StatefulSet RollingUpdate
+// recovery trap, documented upstream as "Forced rollback"
+// (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback): with
+// the default OrderedReady Pod management the controller stops its sync at the first Pod that
+// isn't Running and Ready and never reaches the phase where it would delete Pods that are off the
+// update revision. So a Pod created for an update that never becomes Ready blocks the rollout even
+// after spec.template is fixed or reverted -- that specific Pod has to be deleted by hand so it
+// gets recreated on the (possibly reverted) target revision.
 //
-// A Pod qualifies when it's within the partition's update range, its controller-revision-hash
-// doesn't match status.updateRevision (so it hasn't reached the target -- this deliberately isn't
-// compared against status.currentRevision, which collapses back to equal updateRevision once a
-// bad template is reverted, even though the already-created stuck Pod still carries the orphaned
-// bad revision), and it has been unready for at least Config's StatefulSetRollbackTrapThreshold.
+// Closed upstream as working-as-intended: auto-deleting a Pod that may already have run containers
+// isn't safe for workloads that own data, so RollingUpdate will never self-heal. The escape hatch
+// is instead the opt-in `Recreate` update strategy (KEP-3541, alpha in v1.37 behind the
+// StatefulSetRecreateStrategy feature gate), which is excluded here along with OnDelete.
 //
-// Returns nil when the StatefulSet isn't using RollingUpdate, is missing revision status, or no
-// owned Pod matches. Callers are expected to already be inside a "rollout isn't done" gate (e.g.
-// StatefulSet.tmpl checks RolloutStatus first), but this is also correct standalone.
+// Only OrderedReady is affected: with `podManagementPolicy: Parallel` the sync isn't monotonic, so
+// the controller reaches its update phase and deletes the stuck off-revision Pod itself.
+//
+// Returns nil unless the StatefulSet is an OrderedReady RollingUpdate one with revision status,
+// and the Pod its sync is blocked on is one this trap explains -- see
+// statefulSetRollbackTrapBlocker. Callers are expected to already be inside a "rollout isn't done"
+// gate (e.g. StatefulSet.tmpl checks RolloutStatus first), but this is also correct standalone.
 func (r RenderableObject) StatefulSetRollbackTrap() map[string]interface{} {
 	if r.LiveQueriesDisabled() {
 		return nil
@@ -790,46 +796,104 @@ func (r RenderableObject) StatefulSetRollbackTrap() map[string]interface{} {
 	if strategyType, found, _ := unstructured.NestedString(r.Object, "spec", "updateStrategy", "type"); found && strategyType != "RollingUpdate" {
 		return nil
 	}
+	if policy, found, _ := unstructured.NestedString(r.Object, "spec", "podManagementPolicy"); found && policy != "OrderedReady" {
+		return nil
+	}
 	updateRevision, found, _ := unstructured.NestedString(r.Object, "status", "updateRevision")
 	if !found || updateRevision == "" {
 		return nil
 	}
+	replicas, found, _ := unstructured.NestedInt64(r.Object, "spec", "replicas")
+	if !found {
+		replicas = 1
+	}
+	startOrdinal, _, _ := unstructured.NestedInt64(r.Object, "spec", "ordinals", "start")
 	partition, _, _ := unstructured.NestedInt64(r.Object, "spec", "updateStrategy", "rollingUpdate", "partition")
 	matchLabels, _, _ := unstructured.NestedMap(r.Object, "spec", "selector", "matchLabels")
-	namePrefix := r.Name() + "-"
-	threshold := r.engine.cfg.StatefulSetRollbackTrapThreshold
 
+	blocker, blockerRevision, found := statefulSetRollbackTrapBlocker(
+		r.KubeGetByLabelsMap(r.Namespace(), "pods", matchLabels),
+		statefulSetRollbackTrapParams{
+			namePrefix:     r.Name() + "-",
+			startOrdinal:   startOrdinal,
+			replicas:       replicas,
+			partition:      partition,
+			updateRevision: updateRevision,
+			threshold:      r.engine.cfg.StatefulSetRollbackTrapThreshold,
+			now:            time.Now(),
+		})
+	if !found {
+		return nil
+	}
+	return map[string]interface{}{
+		"pod":            blocker,
+		"podRevision":    blockerRevision,
+		"targetRevision": updateRevision,
+	}
+}
+
+// statefulSetRollbackTrapParams carries the StatefulSet-level inputs of the trap detection, so the
+// decision itself stays a pure function over already-fetched Pods.
+type statefulSetRollbackTrapParams struct {
+	namePrefix     string
+	startOrdinal   int64
+	replicas       int64
+	partition      int64
+	updateRevision string
+	threshold      time.Duration
+	now            time.Time
+}
+
+// statefulSetRollbackTrapBlocker returns the Pod whose unreadiness is trapping the rollout, and its
+// revision. It first picks the Pod the controller's OrderedReady sync is stopped at -- the
+// lowest-ordinal Pod in the replica range that isn't Ready -- because that's the only Pod deleting
+// which can make the rollout progress: any higher-ordinal one gets recreated, but the sync still
+// stops at the lower one.
+//
+// That Pod is only reported when every signal says the trap (rather than something else) explains
+// it: it isn't already terminating (the controller is then just waiting out graceful deletion, and
+// deleting it again changes nothing), it's within the partition's update range (a Pod below the
+// partition gets recreated at the current revision, so deleting it doesn't move the rollout), its
+// controller-revision-hash doesn't match status.updateRevision (deliberately not compared against
+// status.currentRevision, which collapses back to equal updateRevision once a bad template is
+// reverted, even though the already-created stuck Pod still carries the orphaned bad revision), and
+// it has been unready long enough to rule out ordinary startup/image-pull latency.
+func statefulSetRollbackTrapBlocker(pods []RenderableObject, params statefulSetRollbackTrapParams) (RenderableObject, string, bool) {
 	var blocker RenderableObject
-	blockerOrdinal := -1
-	for _, pod := range r.KubeGetByLabelsMap(r.Namespace(), "pods", matchLabels) {
-		ordinal, ok := statefulSetPodOrdinal(namePrefix, pod.Name())
-		if !ok || int64(ordinal) < partition || ordinal <= blockerOrdinal {
+	blockerOrdinal := int64(-1)
+	var blockerReadyCondition map[string]interface{}
+	for _, pod := range pods {
+		parsedOrdinal, ok := statefulSetPodOrdinal(params.namePrefix, pod.Name())
+		ordinal := int64(parsedOrdinal)
+		if !ok || ordinal < params.startOrdinal || ordinal >= params.startOrdinal+params.replicas {
 			continue
 		}
-		podRevision, _ := pod.Labels()["controller-revision-hash"].(string)
-		if podRevision == "" || podRevision == updateRevision {
+		if blockerOrdinal >= 0 && ordinal > blockerOrdinal {
 			continue
 		}
 		readyCondition := getMatchingItemInMapList(map[string]interface{}{"type": "Ready"}, pod.StatusConditions())
 		if isStatusConditionHealthy(readyCondition) {
 			continue
 		}
-		unreadySince := statefulSetPodUnreadySince(pod, readyCondition)
-		if unreadySince.IsZero() || time.Since(unreadySince) < threshold {
-			continue
-		}
 		blocker = pod
 		blockerOrdinal = ordinal
+		blockerReadyCondition = readyCondition
 	}
-	if blockerOrdinal < 0 {
-		return nil
+	if blockerOrdinal < 0 || blockerOrdinal < params.partition {
+		return RenderableObject{}, "", false
+	}
+	if _, terminating, _ := unstructured.NestedString(blocker.Object, "metadata", "deletionTimestamp"); terminating {
+		return RenderableObject{}, "", false
 	}
 	blockerRevision, _ := blocker.Labels()["controller-revision-hash"].(string)
-	return map[string]interface{}{
-		"pod":            blocker,
-		"podRevision":    blockerRevision,
-		"targetRevision": updateRevision,
+	if blockerRevision == "" || blockerRevision == params.updateRevision {
+		return RenderableObject{}, "", false
 	}
+	unreadySince := statefulSetPodUnreadySince(blocker, blockerReadyCondition)
+	if unreadySince.IsZero() || params.now.Sub(unreadySince) < params.threshold {
+		return RenderableObject{}, "", false
+	}
+	return blocker, blockerRevision, true
 }
 
 // statefulSetPodOrdinal extracts the ordinal suffix from a StatefulSet Pod name (e.g. "web-2" with

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -5,6 +5,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -765,4 +766,95 @@ func (r RenderableObject) RolloutStatus(obj RenderableObject) map[string]interfa
 		"message": strings.TrimSpace(message),
 		"error":   strings.TrimSpace(errString),
 	}
+}
+
+// StatefulSetRollbackTrap detects the kubernetes/kubernetes#78709 StatefulSet RollingUpdate
+// recovery trap: the controller only ever creates the next replacement Pod once the current one
+// it's waiting on is Ready, so a Pod that was created for an update and never became Ready blocks
+// the rollout even after spec.template is fixed or reverted -- that specific Pod has to be
+// deleted so it gets recreated on the (possibly reverted) target revision.
+//
+// A Pod qualifies when it's within the partition's update range, its controller-revision-hash
+// doesn't match status.updateRevision (so it hasn't reached the target -- this deliberately isn't
+// compared against status.currentRevision, which collapses back to equal updateRevision once a
+// bad template is reverted, even though the already-created stuck Pod still carries the orphaned
+// bad revision), and it has been unready for at least Config's StatefulSetRollbackTrapThreshold.
+//
+// Returns nil when the StatefulSet isn't using RollingUpdate, is missing revision status, or no
+// owned Pod matches. Callers are expected to already be inside a "rollout isn't done" gate (e.g.
+// StatefulSet.tmpl checks RolloutStatus first), but this is also correct standalone.
+func (r RenderableObject) StatefulSetRollbackTrap() map[string]interface{} {
+	if r.LiveQueriesDisabled() {
+		return nil
+	}
+	if strategyType, found, _ := unstructured.NestedString(r.Object, "spec", "updateStrategy", "type"); found && strategyType != "RollingUpdate" {
+		return nil
+	}
+	updateRevision, found, _ := unstructured.NestedString(r.Object, "status", "updateRevision")
+	if !found || updateRevision == "" {
+		return nil
+	}
+	partition, _, _ := unstructured.NestedInt64(r.Object, "spec", "updateStrategy", "rollingUpdate", "partition")
+	matchLabels, _, _ := unstructured.NestedMap(r.Object, "spec", "selector", "matchLabels")
+	namePrefix := r.Name() + "-"
+	threshold := r.engine.cfg.StatefulSetRollbackTrapThreshold
+
+	var blocker RenderableObject
+	blockerOrdinal := -1
+	for _, pod := range r.KubeGetByLabelsMap(r.Namespace(), "pods", matchLabels) {
+		ordinal, ok := statefulSetPodOrdinal(namePrefix, pod.Name())
+		if !ok || int64(ordinal) < partition || ordinal <= blockerOrdinal {
+			continue
+		}
+		podRevision, _ := pod.Labels()["controller-revision-hash"].(string)
+		if podRevision == "" || podRevision == updateRevision {
+			continue
+		}
+		readyCondition := getMatchingItemInMapList(map[string]interface{}{"type": "Ready"}, pod.StatusConditions())
+		if isStatusConditionHealthy(readyCondition) {
+			continue
+		}
+		unreadySince := statefulSetPodUnreadySince(pod, readyCondition)
+		if unreadySince.IsZero() || time.Since(unreadySince) < threshold {
+			continue
+		}
+		blocker = pod
+		blockerOrdinal = ordinal
+	}
+	if blockerOrdinal < 0 {
+		return nil
+	}
+	blockerRevision, _ := blocker.Labels()["controller-revision-hash"].(string)
+	return map[string]interface{}{
+		"pod":            blocker,
+		"podRevision":    blockerRevision,
+		"targetRevision": updateRevision,
+	}
+}
+
+// statefulSetPodOrdinal extracts the ordinal suffix from a StatefulSet Pod name (e.g. "web-2" with
+// namePrefix "web-" -> 2, true). Returns false for anything that doesn't match, rather than
+// erroring, since template callers must never fail to render on an unexpected Pod name.
+func statefulSetPodOrdinal(namePrefix, podName string) (int, bool) {
+	if !strings.HasPrefix(podName, namePrefix) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(podName, namePrefix))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// statefulSetPodUnreadySince returns when pod became unready: the Ready condition's
+// lastTransitionTime when present, otherwise the Pod's creation time (covers a Pod stuck before
+// any conditions were ever populated, e.g. unschedulable). Returns the zero Time when neither is
+// available.
+func statefulSetPodUnreadySince(pod RenderableObject, readyCondition map[string]interface{}) time.Time {
+	if lastTransitionTime, ok := readyCondition["lastTransitionTime"].(string); ok && lastTransitionTime != "" {
+		if t, err := time.Parse(time.RFC3339, lastTransitionTime); err == nil {
+			return t
+		}
+	}
+	return pod.GetCreationTimestamp().Time
 }

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -48,15 +48,23 @@ type RenderConfig struct {
 	Now                func() time.Time
 	DurationRound      func(duration interface{}) string
 	StartedAfterClause func(createdKubeDate, startedKubeDate string) string
+	// StatefulSetRollbackTrapThreshold is how long a StatefulSet-owned Pod must have been unready
+	// before StatefulSetRollbackTrap treats it as evidence of the kubernetes/kubernetes#78709
+	// "stuck rollback" trap, rather than ordinary image-pull/startup latency. Deliberately
+	// compared against real wall-clock time (not Now, which tests freeze to a fixed date for
+	// deterministic rendering) and left overridable here so e2e tests don't need to wait out the
+	// real default.
+	StatefulSetRollbackTrapThreshold time.Duration
 }
 
 // NewRenderConfig builds a RenderConfig backed by v, with the real Now/DurationRound/
 // StartedAfterClause implementations.
 func NewRenderConfig(v *viper.Viper) *RenderConfig {
 	cfg := &RenderConfig{
-		Viper:         v,
-		Now:           time.Now,
-		DurationRound: DefaultDurationRound(),
+		Viper:                            v,
+		Now:                              time.Now,
+		DurationRound:                    DefaultDurationRound(),
+		StatefulSetRollbackTrapThreshold: 10 * time.Minute,
 	}
 	cfg.StartedAfterClause = defaultStartedAfterClause(cfg)
 	return cfg

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -49,7 +49,7 @@ type RenderConfig struct {
 	DurationRound      func(duration interface{}) string
 	StartedAfterClause func(createdKubeDate, startedKubeDate string) string
 	// StatefulSetRollbackTrapThreshold is how long a StatefulSet-owned Pod must have been unready
-	// before StatefulSetRollbackTrap treats it as evidence of the kubernetes/kubernetes#78709
+	// before StatefulSetRollbackTrap treats it as evidence of the kubernetes/kubernetes#67250
 	// "stuck rollback" trap, rather than ordinary image-pull/startup latency. Deliberately
 	// compared against real wall-clock time (not Now, which tests freeze to a fixed date for
 	// deterministic rendering) and left overridable here so e2e tests don't need to wait out the

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -2370,3 +2370,103 @@ func TestStatefulSetPodUnreadySince(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulSetRollbackTrapBlocker(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	longUnready := now.Add(-time.Hour).Format(time.RFC3339)
+	justUnready := now.Add(-time.Second).Format(time.RFC3339)
+	defaultParams := statefulSetRollbackTrapParams{
+		namePrefix:     "web-",
+		replicas:       3,
+		updateRevision: "web-good",
+		threshold:      10 * time.Minute,
+		now:            now,
+	}
+	// pod builds a StatefulSet-owned Pod as the trap detection sees it: named with an ordinal,
+	// labelled with the revision it was created on, and with a Ready condition.
+	pod := func(name, revision, ready, lastTransitionTime string) RenderableObject {
+		return RenderableObject{Unstructured: unstructured.Unstructured{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":              name,
+				"labels":            map[string]interface{}{"controller-revision-hash": revision},
+				"creationTimestamp": longUnready,
+			},
+			"status": map[string]interface{}{"conditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": ready, "lastTransitionTime": lastTransitionTime},
+			}},
+		}}}
+	}
+	terminating := func(pod RenderableObject) RenderableObject {
+		pod.Object["metadata"].(map[string]interface{})["deletionTimestamp"] = longUnready
+		return pod
+	}
+
+	tests := []struct {
+		name      string
+		pods      []RenderableObject
+		params    statefulSetRollbackTrapParams
+		wantPod   string
+		wantFound bool
+	}{
+		{
+			name:      "Pod stuck unready on an outdated revision is the trap",
+			pods:      []RenderableObject{pod("web-0", "web-bad", "False", longUnready)},
+			wantPod:   "web-0",
+			wantFound: true,
+		},
+		{
+			name: "reports the lowest-ordinal unready Pod, the one the sync is stopped at",
+			pods: []RenderableObject{
+				pod("web-2", "web-bad", "False", longUnready),
+				pod("web-1", "web-bad", "False", longUnready),
+			},
+			wantPod:   "web-1",
+			wantFound: true,
+		},
+		{
+			name: "no trap while a lower-ordinal Pod is already on the target revision",
+			pods: []RenderableObject{
+				// The rollout is stopped at web-0, and deleting web-2 wouldn't get it going.
+				pod("web-0", "web-good", "False", longUnready),
+				pod("web-2", "web-bad", "False", longUnready),
+			},
+		},
+		{name: "no trap when every Pod is Ready", pods: []RenderableObject{pod("web-0", "web-bad", "True", longUnready)}},
+		{name: "no trap when the Pod already reached the target revision", pods: []RenderableObject{pod("web-0", "web-good", "False", longUnready)}},
+		{name: "no trap without a revision label", pods: []RenderableObject{pod("web-0", "", "False", longUnready)}},
+		{name: "no trap before the unready threshold, still ordinary startup latency", pods: []RenderableObject{pod("web-0", "web-bad", "False", justUnready)}},
+		{name: "no trap for an already terminating Pod, the controller is awaiting its deletion", pods: []RenderableObject{terminating(pod("web-0", "web-bad", "False", longUnready))}},
+		{
+			name:   "no trap below the partition, such a Pod is recreated on the current revision",
+			pods:   []RenderableObject{pod("web-0", "web-bad", "False", longUnready)},
+			params: statefulSetRollbackTrapParams{namePrefix: "web-", replicas: 3, partition: 1, updateRevision: "web-good", threshold: 10 * time.Minute, now: now},
+		},
+		{
+			name:   "no trap for a condemned Pod outside the replica range",
+			pods:   []RenderableObject{pod("web-3", "web-bad", "False", longUnready)},
+			params: defaultParams,
+		},
+		{name: "no trap for a Pod of another workload sharing the selector", pods: []RenderableObject{pod("web-canary-0", "web-bad", "False", longUnready)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := tt.params
+			if params.namePrefix == "" {
+				params = defaultParams
+			}
+			gotPod, gotRevision, gotFound := statefulSetRollbackTrapBlocker(tt.pods, params)
+			if gotFound != tt.wantFound {
+				t.Fatalf("statefulSetRollbackTrapBlocker() found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if !tt.wantFound {
+				return
+			}
+			if gotPod.Name() != tt.wantPod {
+				t.Errorf("statefulSetRollbackTrapBlocker() pod = %q, want %q", gotPod.Name(), tt.wantPod)
+			}
+			if gotRevision != "web-bad" {
+				t.Errorf("statefulSetRollbackTrapBlocker() revision = %q, want %q", gotRevision, "web-bad")
+			}
+		})
+	}
+}

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -2304,3 +2304,69 @@ func TestSecretDataKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestStatefulSetPodOrdinal(t *testing.T) {
+	tests := []struct {
+		name       string
+		namePrefix string
+		podName    string
+		wantN      int
+		wantOK     bool
+	}{
+		{name: "valid ordinal", namePrefix: "web-", podName: "web-2", wantN: 2, wantOK: true},
+		{name: "ordinal zero", namePrefix: "web-", podName: "web-0", wantN: 0, wantOK: true},
+		{name: "non-numeric suffix", namePrefix: "web-", podName: "web-abc", wantN: 0, wantOK: false},
+		{name: "name not prefixed by the StatefulSet name", namePrefix: "web-", podName: "other-2", wantN: 0, wantOK: false},
+		{name: "prefix with no suffix", namePrefix: "web-", podName: "web-", wantN: 0, wantOK: false},
+		{name: "STS name that's itself a prefix of another STS's pods", namePrefix: "web-", podName: "web-canary-2", wantN: 0, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotN, gotOK := statefulSetPodOrdinal(tt.namePrefix, tt.podName)
+			if gotN != tt.wantN || gotOK != tt.wantOK {
+				t.Errorf("statefulSetPodOrdinal(%q, %q) = (%d, %v), want (%d, %v)", tt.namePrefix, tt.podName, gotN, gotOK, tt.wantN, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestStatefulSetPodUnreadySince(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	podWithCreationTime := RenderableObject{Unstructured: unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"creationTimestamp": created.Format(time.RFC3339)},
+	}}}
+
+	tests := []struct {
+		name           string
+		pod            RenderableObject
+		readyCondition map[string]interface{}
+		want           time.Time
+	}{
+		{
+			name:           "uses Ready condition's lastTransitionTime when present",
+			pod:            podWithCreationTime,
+			readyCondition: map[string]interface{}{"lastTransitionTime": "2026-01-02T00:00:00Z"},
+			want:           time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:           "falls back to Pod creation time when no Ready condition",
+			pod:            podWithCreationTime,
+			readyCondition: map[string]interface{}{},
+			want:           created,
+		},
+		{
+			name:           "falls back to Pod creation time on unparseable lastTransitionTime",
+			pod:            podWithCreationTime,
+			readyCondition: map[string]interface{}{"lastTransitionTime": "not-a-time"},
+			want:           created,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statefulSetPodUnreadySince(tt.pod, tt.readyCondition)
+			if !got.Equal(tt.want) {
+				t.Errorf("statefulSetPodUnreadySince() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -36,6 +36,22 @@
         {{- if eq ($status.updatedCount | default 0) 0 }}
             {{- "Stuck Rollout?" | yellow | bold | nindent 2 }}: Still replacing the first Pod, may indicate a stuck rollout.
         {{- end }}
+        {{- /* kubernetes/kubernetes#78709: the StatefulSet controller only ever creates the next
+               replacement Pod once the current one it's waiting on is Ready. So if an updated Pod
+               never becomes Ready, the rollout is stuck on that specific Pod -- reverting
+               spec.template alone does not unstick it, since the controller just keeps waiting on
+               the same still-unready Pod. .StatefulSetRollbackTrap (template_functions_dynamic.go)
+               finds that Pod: it's within the partition's update range, its
+               controller-revision-hash doesn't match status.updateRevision (hasn't reached the
+               target), and it's been unready long enough to rule out ordinary startup/image-pull
+               latency. Returns nil when nothing matches. */ -}}
+        {{- with .StatefulSetRollbackTrap }}
+            {{- $readyCondition := .pod.StatusConditions | getMatchingItemInMapList (dict "type" "Ready") }}
+            {{- "Rollout blocked" | red | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Pod" "name" .pod.Name) }} has been {{ "Not Ready" | red }} for {{ $readyCondition.lastTransitionTime | default .pod.Metadata.creationTimestamp | colorAgo }}, still on revision {{ .podRevision | cyan }} while the target is {{ .targetRevision | cyan }}.
+            {{- "" | nindent 4 }}If the Pod template was already fixed or reverted, the StatefulSet controller will keep waiting on this Pod -- delete it to recreate it on the target revision:
+            {{- "" | nindent 6 }}{{ printf "kubectl delete pod/%s -n %s" .pod.Name .pod.Namespace | cyan }}
+            {{- "" | nindent 4 }}Inspect the Pod first to confirm the original rollout failure.
+        {{- end }}
         {{- if and (hasKey $status "currentRevision") (hasKey $status "updateRevision") }}
             {{- with .KubeGetUnifiedDiffString "ControllerRevision" .Namespace $status.currentRevision $status.updateRevision }}
                 {{- "Active Rollout Diff:" | nindent 2 }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -36,21 +36,24 @@
         {{- if eq ($status.updatedCount | default 0) 0 }}
             {{- "Stuck Rollout?" | yellow | bold | nindent 2 }}: Still replacing the first Pod, may indicate a stuck rollout.
         {{- end }}
-        {{- /* kubernetes/kubernetes#78709: the StatefulSet controller only ever creates the next
-               replacement Pod once the current one it's waiting on is Ready. So if an updated Pod
-               never becomes Ready, the rollout is stuck on that specific Pod -- reverting
-               spec.template alone does not unstick it, since the controller just keeps waiting on
-               the same still-unready Pod. .StatefulSetRollbackTrap (template_functions_dynamic.go)
-               finds that Pod: it's within the partition's update range, its
-               controller-revision-hash doesn't match status.updateRevision (hasn't reached the
-               target), and it's been unready long enough to rule out ordinary startup/image-pull
-               latency. Returns nil when nothing matches. */ -}}
+        {{- /* kubernetes/kubernetes#67250, upstream's "Forced rollback": with the default
+               OrderedReady Pod management the controller stops its sync at the first Pod that
+               isn't Running and Ready, so it never reaches the phase that would delete Pods left
+               on an outdated revision. An updated Pod that never becomes Ready therefore blocks
+               the rollout even after spec.template is fixed or reverted -- the controller just
+               keeps waiting on that same Pod, and only deleting it by hand unsticks the rollout.
+               Closed upstream as working-as-intended (auto-deleting a Pod that may already have
+               run isn't safe for workloads owning data); the opt-in Recreate strategy is the fix,
+               and it's excluded here along with OnDelete and Parallel Pod management, none of
+               which can hit this. .StatefulSetRollbackTrap (template_functions_dynamic.go) finds
+               the Pod, and returns nil unless every signal says this trap explains it. */ -}}
         {{- with .StatefulSetRollbackTrap }}
             {{- $readyCondition := .pod.StatusConditions | getMatchingItemInMapList (dict "type" "Ready") }}
             {{- "Rollout blocked" | red | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Pod" "name" .pod.Name) }} has been {{ "Not Ready" | red }} for {{ $readyCondition.lastTransitionTime | default .pod.Metadata.creationTimestamp | colorAgo }}, still on revision {{ .podRevision | cyan }} while the target is {{ .targetRevision | cyan }}.
             {{- "" | nindent 4 }}If the Pod template was already fixed or reverted, the StatefulSet controller will keep waiting on this Pod -- delete it to recreate it on the target revision:
             {{- "" | nindent 6 }}{{ printf "kubectl delete pod/%s -n %s" .pod.Name .pod.Namespace | cyan }}
             {{- "" | nindent 4 }}Inspect the Pod first to confirm the original rollout failure.
+            {{- "" | nindent 4 }}Long standing upstream issue, closed as intended behavior: https://github.com/kubernetes/kubernetes/issues/67250
         {{- end }}
         {{- if and (hasKey $status "currentRevision") (hasKey $status "updateRevision") }}
             {{- with .KubeGetUnifiedDiffString "ControllerRevision" .Namespace $status.currentRevision $status.updateRevision }}

--- a/tests/e2e-artifacts/rollouts-statefulset-rollback-trap-recovered.regex
+++ b/tests/e2e-artifacts/rollouts-statefulset-rollback-trap-recovered.regex
@@ -1,0 +1,11 @@
+\A
+StatefulSet/e2e-rollouts-statefulset-rollback-trap -n e2e-rollouts-statefulset-rollback-trap, created 1m ago, gen:3
+  Current: Partition rollout complete. updated: 1
+  Selector: app=e2e-rollouts-statefulset-rollback-trap
+    Pod/e2e-rollouts-statefulset-rollback-trap-0, created 1m ago Running, 1/1 ready
+  Not matched by any Service
+  desired:1, existing:1, ready:1, current:1, updated:1, available:1
+  Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!
+    1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
+    1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
+\z

--- a/tests/e2e-artifacts/rollouts-statefulset-rollback-trap.regex
+++ b/tests/e2e-artifacts/rollouts-statefulset-rollback-trap.regex
@@ -13,6 +13,7 @@ StatefulSet/e2e-rollouts-statefulset-rollback-trap -n e2e-rollouts-statefulset-r
     If the Pod template was already fixed or reverted, the StatefulSet controller will keep waiting on this Pod -- delete it to recreate it on the target revision:
       kubectl delete pod/e2e-rollouts-statefulset-rollback-trap-0 -n e2e-rollouts-statefulset-rollback-trap
     Inspect the Pod first to confirm the original rollout failure\.
+    Long standing upstream issue, closed as intended behavior: https://github\.com/kubernetes/kubernetes/issues/67250
   Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!
     1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
     1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.

--- a/tests/e2e-artifacts/rollouts-statefulset-rollback-trap.regex
+++ b/tests/e2e-artifacts/rollouts-statefulset-rollback-trap.regex
@@ -1,0 +1,19 @@
+\A
+StatefulSet/e2e-rollouts-statefulset-rollback-trap -n e2e-rollouts-statefulset-rollback-trap, created 1m ago, gen:3
+  InProgress: Ready: 0/1
+    Reconciling: LessReady, Ready: 0/1
+  Selector: app=e2e-rollouts-statefulset-rollback-trap
+    Pod/e2e-rollouts-statefulset-rollback-trap-0, created 1m ago Pending, 0/1 ready ImagePullBackOff
+  Not matched by any Service
+  desired:1, existing:1, ready:0, current:1, available:0
+  Outage: StatefulSet has no Ready replicas\.
+  Ongoing rollout: Waiting for 1 pods to be ready\.\.\.
+  Stuck Rollout\?: Still replacing the first Pod, may indicate a stuck rollout\.
+  Rollout blocked: Pod/e2e-rollouts-statefulset-rollback-trap-0 has been Not Ready for 1m, still on revision e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+ while the target is e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
+    If the Pod template was already fixed or reverted, the StatefulSet controller will keep waiting on this Pod -- delete it to recreate it on the target revision:
+      kubectl delete pod/e2e-rollouts-statefulset-rollback-trap-0 -n e2e-rollouts-statefulset-rollback-trap
+    Inspect the Pod first to confirm the original rollout failure\.
+  Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!
+    1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
+    1m ago used ControllerRevision/e2e-rollouts-statefulset-rollback-trap-[a-z0-9]+\.
+\z


### PR DESCRIPTION
## Summary
- Closes #169: detects the [kubernetes/kubernetes#67250](https://github.com/kubernetes/kubernetes/issues/67250) StatefulSet `RollingUpdate` trap — upstream's ["Forced rollback"](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#forced-rollback) — where an updated Pod that never becomes Ready blocks the rollout even after `spec.template` is reverted, because the OrderedReady sync stops at the first not-Ready Pod and never reaches the phase that would delete Pods left on an outdated revision.
- Surfaces which Pod is blocking, its revision vs. the StatefulSet's target revision, the exact `kubectl delete pod/...` command to recover, and the upstream issue — only shown once every signal is unambiguous.
- New `RenderableObject.StatefulSetRollbackTrap()` (`pkg/plugin/template_functions_dynamic.go`) does the detection; `StatefulSet.tmpl` renders the message inside the existing "rollout not done" branch, so `OnDelete` strategy and healthy/completed rollouts are excluded for free by reusing `RolloutStatus`.
- Detection mirrors the controller (`stateful_set_control.go`) rather than approximating it, so it stays quiet where the trap can't apply or where deleting the Pod wouldn't help:
  - only OrderedReady Pod management (`Parallel` reaches the update phase and deletes the stuck Pod itself), only `RollingUpdate` (`Recreate`, KEP-3541 alpha in 1.37, is upstream's opt-in fix),
  - reports the lowest-ordinal not-Ready Pod in the replica range — the one the sync is stopped at, and the only one whose deletion makes progress,
  - skips Pods already terminating, below the partition, or condemned by a scale-down.
- Threshold (`RenderConfig.StatefulSetRollbackTrapThreshold`, default 10m) uses real wall-clock time rather than the frozen test `Now`, and is test-overridable so the new e2e case doesn't need to wait out the real default.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] Unit tests for the ordinal-parsing and unready-duration helpers, plus table-driven tests over the (now pure) blocker selection: each trap signal, and each case where we must stay quiet
- [x] New e2e subtest (`cmd/e2e_rollout_test.go`) reproducing the full trap against the shared minikube cluster: bad image → stuck Pod → revert without deleting → blocked-rollout message appears naming the Pod/revisions → delete the Pod → recovers and the message disappears
- [x] Existing rollout e2e subtests still pass (`make test-e2e-quick RUN='TestE2EParallel/rollout'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)