### PR TITLE
Always show a condition's raw status value, not just when Unknown

### DIFF
--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -612,34 +612,41 @@
     {{- end }}
 {{- end }}
 
+{{- define "pod_condition_arrow_label" }}
+    {{- /* args: dict "condition" <condition map> "label" <e.g. "PodScheduled">
+           Always shows the raw "Label:Status" pair (e.g. "PodScheduled:False") rather than a
+           reworded "Not X" -- status:"Unknown" is missing information, not a confirmed fault, so
+           it gets its own yellow rather than being folded into the red used for a confirmed
+           False, see #173. A condition that hasn't been reported at all yet (e.g. Initialized
+           before the kubelet gets that far) has no .status either, and is just as much "we don't
+           know" as an explicit status:"Unknown", so it's treated the same way here. */ -}}
+    {{- $unknown := or (eq .condition.status "Unknown") (not .condition.status) }}
+    {{- $entry := printf "%s:%s" .label (.condition.status | default "Unknown" | toString) }}
+    {{- if isStatusConditionHealthy .condition }}
+        {{- $entry | bold }}
+    {{- else if $unknown }}
+        {{- $entry | yellow | bold }}
+    {{- else }}
+        {{- $entry | red | bold }}
+    {{- end }}
+{{- end -}}
+
 {{- define "pod_conditions_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- $podScheduledCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
     {{- $readyCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "Ready") }}
-    {{- if (isStatusConditionHealthy $podScheduledCondition) }}
-        {{- "PodScheduled" | bold }}
-    {{- else }}
-        {{- "Not PodScheduled" | red | bold }}
-    {{- end }}
+    {{- $.Include "pod_condition_arrow_label" (dict "condition" $podScheduledCondition "label" "PodScheduled") }}
     {{- " -> "}}
     {{- $initializedCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "Initialized") }}
-    {{- if (isStatusConditionHealthy $initializedCondition) }}
-        {{- "Initialized" | bold }}
-    {{- else }}
-        {{- "Not Initialized" | red | bold }}
-    {{- end }}
+    {{- $.Include "pod_condition_arrow_label" (dict "condition" $initializedCondition "label" "Initialized") }}
     {{- " -> "}}
     {{- $containersReadyCondition := .StatusConditions | getMatchingItemInMapList (dict "type" "ContainersReady") }}
-    {{- if (isStatusConditionHealthy $containersReadyCondition) }}
-        {{- "ContainersReady" | bold }}
-    {{- else }}
-        {{- "Not ContainersReady" | red | bold }}
-    {{- end }}
+    {{- $.Include "pod_condition_arrow_label" (dict "condition" $containersReadyCondition "label" "ContainersReady") }}
     {{- " -> "}}
     {{- if (isStatusConditionHealthy $readyCondition) }}
         {{- template "condition_summary" $readyCondition }}
     {{- else }}
-        {{- "Not Ready" | red | bold }}
+        {{- $.Include "pod_condition_arrow_label" (dict "condition" $readyCondition "label" "Ready") }}
     {{- end }}
     {{- range .Status.conditions }}
         {{- /* show details for only unhealthy conditions */ -}}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -329,14 +329,25 @@
 {{- end -}}
 
 {{- define "condition_summary" }}
+    {{- /* The condition's own status ("True"/"False"/"Unknown") is always shown as part of the
+           type label (e.g. "Ready:False"), never collapsed away or reworded (e.g. "NotReady") --
+           status:"Unknown" in particular means the controller couldn't determine the condition,
+           not that it confirmed a fault, so it needs to read differently from a confirmed
+           True/False, see #173. */ -}}
     {{- $notHealthy := not (isStatusConditionHealthy .) }}
+    {{- $unknown := or (eq .status "Unknown") (not .status) }}
     {{- if .type }}
-        {{- .type | redIf $notHealthy | bold }}
+        {{- $label := printf "%s:%s" .type (.status | default "Unknown" | toString) }}
+        {{- if $unknown }}
+            {{- $label | yellow | bold }}
+        {{- else }}
+            {{- $label | redIf $notHealthy | bold }}
+        {{- end }}
     {{- else }}
         {{- "<empty condition type!>" | red | bold }}
     {{- end }}
-    {{- with .reason }} {{ . | redBoldIf $notHealthy }}{{ end }}
-    {{- with .message }}, {{ . | redIf $notHealthy }}{{ end }}
+    {{- with .reason }} {{ if $unknown }}{{ . | yellow | bold }}{{ else }}{{ . | redBoldIf $notHealthy }}{{ end }}{{ end }}
+    {{- with .message }}, {{ if $unknown }}{{ . | yellow }}{{ else }}{{ . | redIf $notHealthy }}{{ end }}{{ end }}
     {{- with .lastTransitionTime }} {{ forOrSince }} {{ . | colorAgo }}{{ end }}
     {{- if .lastUpdateTime }}
         {{- if ne (.lastUpdateTime | colorAgo) (.lastTransitionTime | colorAgo) -}}
@@ -628,12 +639,17 @@
             {{- if $node.Spec.unschedulable }}{{ $flags = append $flags ("node cordoned" | red | bold) }}{{ end }}
             {{- range $node.StatusConditions }}
                 {{- if not (isStatusConditionHealthy .) }}
-                    {{- /* Bare condition types read "abnormal-true" (e.g. MemoryPressure), except
-                           Ready, which is "normal-true" -- name that one explicitly so plain-text
-                           output doesn't read as healthy when it isn't. */ -}}
-                    {{- $label := .type }}
-                    {{- if eq $label "Ready" }}{{ $label = "NotReady" }}{{ end }}
-                    {{- $flags = append $flags (printf "node %s" $label | red | bold) }}
+                    {{- /* Always show the raw type:status pair (e.g. "Ready:False",
+                           "MemoryPressure:True") rather than a reworded label like "NotReady" --
+                           status:"Unknown" is missing information, not a confirmed fault, so it's
+                           flagged separately in yellow rather than folded into the same red
+                           "confirmed bad" label, see #173. */ -}}
+                    {{- $entry := printf "node %s:%s" .type (.status | toString) }}
+                    {{- if eq .status "Unknown" }}
+                        {{- $flags = append $flags ($entry | yellow | bold) }}
+                    {{- else }}
+                        {{- $flags = append $flags ($entry | red | bold) }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
             {{- if taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}

--- a/tests/artifacts/backendtlspolicy-accepted.out
+++ b/tests/artifacts/backendtlspolicy-accepted.out
@@ -8,4 +8,4 @@ BackendTLSPolicy/tls-backend-policy -n default, created 1m ago, gen:1
       ConfigMap/backend-ca-cert
   Status:
     Gateway/multi-proto-gw (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Policy has been accepted. for 1m
+      Accepted:True Accepted, Policy has been accepted. for 1m

--- a/tests/artifacts/certificate-ca-signed.out
+++ b/tests/artifacts/certificate-ca-signed.out
@@ -6,4 +6,4 @@ Certificate/kubectl-status-server -n default, created 1m ago, gen:1
   Usages: server auth, client auth
   Requested lifetime: 8760h, renew 720h before expiry
   Issued 2026-06-26 (1m ago), expires 2027-06-26, auto-renews 2027-05-27 · rev 1
-  Ready Ready, Certificate is up to date and has not expired for 1m
+  Ready:True Ready, Certificate is up to date and has not expired for 1m

--- a/tests/artifacts/certificate-ca.out
+++ b/tests/artifacts/certificate-ca.out
@@ -6,4 +6,4 @@ Certificate/kubectl-status-ca -n default, created 1m ago, gen:1
   Role: Certificate Authority
   Requested lifetime: 87600h, renew 720h before expiry
   Issued 2026-06-26 (1m ago), expires 2036-06-23, auto-renews 2036-05-24 · rev 1
-  Ready Ready, Certificate is up to date and has not expired for 1m
+  Ready:True Ready, Certificate is up to date and has not expired for 1m

--- a/tests/artifacts/certificate-selfsigned.out
+++ b/tests/artifacts/certificate-selfsigned.out
@@ -4,4 +4,4 @@ Certificate/kubectl-status-selfsigned -n default, created 1m ago, gen:1
   Issued by Issuer/kubectl-status-selfsigned-issuer for "kubectl-status-selfsigned" · stored in Secret/kubectl-status-selfsigned-secret
   Requested lifetime: 8760h, renew 720h before expiry
   Issued 2026-06-26 (1m ago), expires 2027-06-26, auto-renews 2027-05-27 · rev 1
-  Ready Ready, Certificate is up to date and has not expired for 1m
+  Ready:True Ready, Certificate is up to date and has not expired for 1m

--- a/tests/artifacts/certificaterequest-ca-signed.out
+++ b/tests/artifacts/certificaterequest-ca-signed.out
@@ -6,5 +6,5 @@ CertificateRequest/kubectl-status-server-1 -n default, created 1m ago by Certifi
     Member of: system:serviceaccounts, system:serviceaccounts:cert-manager, system:authenticated
   Usages: server auth, client auth
   Requested duration: 8760h0m0s
-  Approved cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
-  Ready Issued, Certificate fetched from issuer successfully for 1m
+  Approved:True cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
+  Ready:True Issued, Certificate fetched from issuer successfully for 1m

--- a/tests/artifacts/certificaterequest-ca.out
+++ b/tests/artifacts/certificaterequest-ca.out
@@ -6,5 +6,5 @@ CertificateRequest/kubectl-status-ca-1 -n default, created 1m ago by Certificate
     Member of: system:serviceaccounts, system:serviceaccounts:cert-manager, system:authenticated
   Requesting: Certificate Authority cert
   Requested duration: 87600h0m0s
-  Approved cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
-  Ready Issued, Certificate fetched from issuer successfully for 1m
+  Approved:True cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
+  Ready:True Issued, Certificate fetched from issuer successfully for 1m

--- a/tests/artifacts/certificaterequest-selfsigned.out
+++ b/tests/artifacts/certificaterequest-selfsigned.out
@@ -5,5 +5,5 @@ CertificateRequest/kubectl-status-selfsigned-1 -n default, created 1m ago by Cer
     Via: Issuer/kubectl-status-selfsigned-issuer (cert-manager.io)
     Member of: system:serviceaccounts, system:serviceaccounts:cert-manager, system:authenticated
   Requested duration: 8760h0m0s
-  Approved cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
-  Ready Issued, Certificate fetched from issuer successfully for 1m
+  Approved:True cert-manager.io, Certificate request has been approved by cert-manager.io for 1m
+  Ready:True Issued, Certificate fetched from issuer successfully for 1m

--- a/tests/artifacts/cr-dbconn-mymysql-deleted.out
+++ b/tests/artifacts/cr-dbconn-mymysql-deleted.out
@@ -4,4 +4,4 @@ DatabaseConnection/mymysql -n default, created 1m ago, gen:2
     Finalizers: dbconn-operator1, dbconn-operator2
   Observed generation(1) doesn't match generation(2)
     This usually means related controller has not yet reconciled this resource!
-  Ready ConnectionEstablished, Database connection successfully established. for 1m
+  Ready:True ConnectionEstablished, Database connection successfully established. for 1m

--- a/tests/artifacts/cr-dbconn-mymysql.local.regex
+++ b/tests/artifacts/cr-dbconn-mymysql.local.regex
@@ -1,5 +1,5 @@
 \A
 DatabaseConnection/mymysql -n default, created 1m ago
   Current: Resource is Ready
-  Ready ConnectionEstablished, Database connection successfully established. for 1m
+  Ready:True ConnectionEstablished, Database connection successfully established. for 1m
 \z

--- a/tests/artifacts/cr-dbconn-mymysql.out
+++ b/tests/artifacts/cr-dbconn-mymysql.out
@@ -1,4 +1,4 @@
 
 DatabaseConnection/mymysql -n default, created 1m ago
   Current: Resource is Ready
-  Ready ConnectionEstablished, Database connection successfully established. for 1m
+  Ready:True ConnectionEstablished, Database connection successfully established. for 1m

--- a/tests/artifacts/crd-certificate.out
+++ b/tests/artifacts/crd-certificate.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/certificates.cert-manager.io, created 1m ago, gen:1
   Current: CRD is established
   cert-manager.io, scope: Namespaced, short: cert, certs, categories: cert-manager
   Versions: v1 [storage]
-  NamesAccepted NoConflicts, no conflicts found for 1m
-  Established InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m
+  Established:True InitialNamesAccepted, the initial names have been accepted for 1m

--- a/tests/artifacts/crd-dbconn.out
+++ b/tests/artifacts/crd-dbconn.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/databaseconnections.example.com, created 1m ago, gen:2
   Current: CRD is established
   example.com, scope: Namespaced, short: dbconn
   Versions: v1alpha1 [storage]
-  NamesAccepted NoConflicts, no conflicts found for 1m
-  Established InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m
+  Established:True InitialNamesAccepted, the initial names have been accepted for 1m

--- a/tests/artifacts/crd-prometheus.out
+++ b/tests/artifacts/crd-prometheus.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/prometheuses.monitoring.coreos.com, created 1m ago, gen
   Current: CRD is established
   monitoring.coreos.com, scope: Namespaced, short: prom, categories: prometheus-operator
   Versions: v1 [storage]
-  NamesAccepted NoConflicts, no conflicts found for 1m
-  Established InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m
+  Established:True InitialNamesAccepted, the initial names have been accepted for 1m

--- a/tests/artifacts/crd-servicemonitor.out
+++ b/tests/artifacts/crd-servicemonitor.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/servicemonitors.monitoring.coreos.com, created 1m ago, 
   Current: CRD is established
   monitoring.coreos.com, scope: Namespaced, short: smon, categories: prometheus-operator
   Versions: v1 [storage]
-  NamesAccepted NoConflicts, no conflicts found for 1m
-  Established InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m
+  Established:True InitialNamesAccepted, the initial names have been accepted for 1m

--- a/tests/artifacts/crossplane-managed-resource-details.out
+++ b/tests/artifacts/crossplane-managed-resource-details.out
@@ -8,5 +8,5 @@ Bucket/checkout-bucket, created 1m ago, gen:1
   ProviderConfig/aws-provider
   Management policies: Observe, LateInitialize
   initProvider: tags (applied only at creation time)
-  Synced ReconcileSuccess for 1m
-  Ready Available for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:True Available for 1m

--- a/tests/artifacts/crossplane-managed-resource-drift.out
+++ b/tests/artifacts/crossplane-managed-resource-drift.out
@@ -11,5 +11,5 @@ VPC/checkout-network, created 1m ago, gen:2
     -  environment: production
     +  environment: staging
   Management policies: * (full control)
-  Synced ReconcileSuccess for 1m
-  Ready Available for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:True Available for 1m

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
@@ -6,6 +6,6 @@ XStatusProbe/probe-a, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config
-  Synced ReconcileSuccess for 1m
-  Ready Creating, Unready resources: blocked-workload, config for 1m
-  Responsive WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:False Creating, Unready resources: blocked-workload, config for 1m
+  Responsive:True WatchCircuitClosed for 1m

--- a/tests/artifacts/crossplane-xr-composed.out
+++ b/tests/artifacts/crossplane-xr-composed.out
@@ -6,6 +6,6 @@ XStatusProbe/probe-a -n crossplane-e2e, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config
-  Synced ReconcileSuccess for 1m
-  Ready Creating, Unready resources: blocked-workload, config for 1m
-  Responsive WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:False Creating, Unready resources: blocked-workload, config for 1m
+  Responsive:True WatchCircuitClosed for 1m

--- a/tests/artifacts/csr-approved-issued.out
+++ b/tests/artifacts/csr-approved-issued.out
@@ -9,4 +9,4 @@ CertificateSigningRequest/my-svc.default, created 1m ago
     Key: RSA
   Issued by CN=My Example Signer
     Valid 1m ago, expires 2036-07-04 (in 1m) · serial 235396120524669862452369845749073012805689220907
-  Approved KubectlApprove, This CSR was approved by kubectl certificate approve. for 1m
+  Approved:True KubectlApprove, This CSR was approved by kubectl certificate approve. for 1m

--- a/tests/artifacts/csr-denied.out
+++ b/tests/artifacts/csr-denied.out
@@ -4,4 +4,4 @@ CertificateSigningRequest/my-svc2.default, created 1m ago
   Usages: digital signature, key encipherment, server auth
   Requested for CN=my-pod2.default.pod.cluster.local
     Key: RSA
-  Denied KubectlDeny, This CSR was denied by kubectl certificate deny. for 1m
+  Denied:True KubectlDeny, This CSR was denied by kubectl certificate deny. for 1m

--- a/tests/artifacts/deployment-healthy.out
+++ b/tests/artifacts/deployment-healthy.out
@@ -3,5 +3,5 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:1 rev:1
   Current: Deployment is available. Replicas: 3
   desired:3, existing:3, ready:3, updated:3, available:3
   Selector: run=httpbin-deployment
-  Available MinimumReplicasAvailable, Deployment has minimum availability. for 1m
-  Progressing NewReplicaSetAvailable, ReplicaSet "httpbin-deployment-79f6dfbb9" has successfully progressed. for 1m
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "httpbin-deployment-79f6dfbb9" has successfully progressed. for 1m

--- a/tests/artifacts/deployment-initial-progressing.out
+++ b/tests/artifacts/deployment-initial-progressing.out
@@ -4,6 +4,6 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:1 rev:1
     Reconciling: LessAvailable, Available: 1/3
   desired:3, existing:3, ready:1, updated:3, available:1, unavailable:2
   Selector: run=httpbin-deployment
-  Available MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
-  Progressing ReplicaSetUpdated, ReplicaSet "httpbin-deployment-79f6dfbb9" is progressing. for 1m
+  Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
+  Progressing:True ReplicaSetUpdated, ReplicaSet "httpbin-deployment-79f6dfbb9" is progressing. for 1m
   Ongoing Rollout: Waiting for deployment "httpbin-deployment" rollout to finish: 1 of 3 updated replicas are available...

--- a/tests/artifacts/deployment-non-existing-image.out
+++ b/tests/artifacts/deployment-non-existing-image.out
@@ -4,7 +4,7 @@ Deployment/missing-image -n test1, created 1m ago, gen:1 rev:1
     Reconciling: LessAvailable, Available: 0/1
   desired:1, existing:1, ready:0, updated:1, available:0, unavailable:1
   Selector: run=missing-image
-  Available MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
-  Progressing ReplicaSetUpdated, ReplicaSet "missing-image-755c8c54f7" is progressing. for 1m
+  Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
+  Progressing:True ReplicaSetUpdated, ReplicaSet "missing-image-755c8c54f7" is progressing. for 1m
   Ongoing Rollout: Waiting for deployment "missing-image" rollout to finish: 0 of 1 updated replicas are available...
   Outage: Deployment has no Ready replicas.

--- a/tests/artifacts/deployment-ongoing-rollout.out
+++ b/tests/artifacts/deployment-ongoing-rollout.out
@@ -4,6 +4,6 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:2 rev:2
     Reconciling: LessUpdated, Updated: 1/3
   desired:3, existing:4, ready:3, updated:1, available:3, unavailable:1
   Selector: run=httpbin-deployment
-  Available MinimumReplicasAvailable, Deployment has minimum availability. for 1m
-  Progressing ReplicaSetUpdated, ReplicaSet "httpbin-deployment-d9b875c5b" is progressing. for 1m
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability. for 1m
+  Progressing:True ReplicaSetUpdated, ReplicaSet "httpbin-deployment-d9b875c5b" is progressing. for 1m
   Ongoing Rollout: Waiting for deployment "httpbin-deployment" rollout to finish: 1 out of 3 new replicas have been updated...

--- a/tests/artifacts/deployment-progressing.out
+++ b/tests/artifacts/deployment-progressing.out
@@ -4,6 +4,6 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:1 rev:1
     Reconciling: LessReplicas, Replicas: 0/3
   desired:3, ready:0, updated:0, available:0
   Selector: run=httpbin-deployment
-  Progressing NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
+  Progressing:True NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
   Ongoing Rollout: Waiting for deployment spec update to be observed...
   Outage: Deployment has no Ready replicas.

--- a/tests/artifacts/deployment-unavailable-replicas.out
+++ b/tests/artifacts/deployment-unavailable-replicas.out
@@ -4,7 +4,7 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:1 rev:1
     Reconciling: LessReplicas, Replicas: 0/3
   desired:3, ready:0, updated:0, available:0, unavailable:3
   Selector: run=httpbin-deployment
-  Progressing NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
-  Available MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
+  Progressing:True NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
+  Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
   Ongoing Rollout: Waiting for deployment "httpbin-deployment" rollout to finish: 0 out of 3 new replicas have been updated...
   Outage: Deployment has no Ready replicas.

--- a/tests/artifacts/externalsecret-synced.out
+++ b/tests/artifacts/externalsecret-synced.out
@@ -5,4 +5,4 @@ ExternalSecret/my-secret -n default, created 1m ago, gen:1
   Syncs to Secret/my-generated-secret
     /my/secret@v1 → password
   Refreshes every 1h, last synced 1m ago
-  Ready SecretSynced, secret synced for 1m
+  Ready:True SecretSynced, secret synced for 1m

--- a/tests/artifacts/gateway-not-programmed.out
+++ b/tests/artifacts/gateway-not-programmed.out
@@ -2,10 +2,10 @@
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
-  Programmed AddressNotAssigned, No addresses have been assigned to the Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Programmed:False AddressNotAssigned, No addresses have been assigned to the Gateway for 1m
   Listeners:
     http: port=80/HTTP, namespaces=Same, accepts=HTTPRoute/GRPCRoute, routes=1
-      Programmed Programmed, Sending translated listener configuration to the data plane for 1m
-      Accepted Accepted, Listener has been successfully translated for 1m
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      Programmed:True Programmed, Sending translated listener configuration to the data plane for 1m
+      Accepted:True Accepted, Listener has been successfully translated for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m

--- a/tests/artifacts/gateway-tls-healthy.out
+++ b/tests/artifacts/gateway-tls-healthy.out
@@ -2,11 +2,11 @@
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     https: port=443/HTTPS, host=gateway.example.com, namespaces=Same, accepts=HTTPRoute, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/gateway-tls -n default, created 1m ago
   Certificate for CN=example.com · issued by CN=Test CA

--- a/tests/artifacts/gateway-tls-problems.out
+++ b/tests/artifacts/gateway-tls-problems.out
@@ -2,23 +2,23 @@
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     missing-secret: port=443/HTTPS, namespaces=Same, routes=0
       TLS mode:Terminate, cert:Secret/does-not-exist
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     wrong-type: port=444/HTTPS, namespaces=Same, routes=0
       TLS mode:Terminate, cert:Secret/opaque-secret
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     missing-keys: port=445/HTTPS, namespaces=Same, routes=0
       TLS mode:Terminate, cert:Secret/incomplete-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     self-signed: port=446/HTTPS, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/selfsigned-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     hostname-mismatch: port=447/HTTPS, host=wrong-host.example.com, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/opaque-secret -n default, created 1m ago
   Keys: foo

--- a/tests/artifacts/gatewayclass-accepted.out
+++ b/tests/artifacts/gatewayclass-accepted.out
@@ -2,4 +2,4 @@
 GatewayClass/eg, created 1m ago, gen:1
   Current: Resource is current
   Controller: gateway.envoyproxy.io/gatewayclass-controller
-  Accepted Accepted, Valid GatewayClass for 1m
+  Accepted:True Accepted, Valid GatewayClass for 1m

--- a/tests/artifacts/grpcroute-tls-healthy.out
+++ b/tests/artifacts/grpcroute-tls-healthy.out
@@ -8,16 +8,16 @@ GRPCRoute/grpc-app -n default, created 1m ago, gen:1
     → Service/grpc-app:50051
   Status:
     Gateway/eg [https] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route is accepted for 1m
+      Accepted:True Accepted, Route is accepted for 1m
 
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     https: port=443/HTTPS, host=gateway.example.com, namespaces=Same, accepts=GRPCRoute, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/gateway-tls -n default, created 1m ago
   Certificate for CN=example.com · issued by CN=Test CA

--- a/tests/artifacts/grpcroute-tls-problems.out
+++ b/tests/artifacts/grpcroute-tls-problems.out
@@ -7,16 +7,16 @@ GRPCRoute/grpc-app -n default, created 1m ago, gen:1
     → Service/grpc-app:50051
   Status:
     Gateway/eg [self-signed] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route is accepted for 1m
+      Accepted:True Accepted, Route is accepted for 1m
 
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     self-signed: port=446/HTTPS, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/selfsigned-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/selfsigned-tls -n default, created 1m ago
   Certificate for CN=other.example.com · issued by CN=other.example.com

--- a/tests/artifacts/hpa-at-max-replicas.out
+++ b/tests/artifacts/hpa-at-max-replicas.out
@@ -5,5 +5,5 @@ HorizontalPodAutoscaler/my-app -n default, created 1m ago, last scaled 1m ago
   Replicas: 10/2-10
   Metrics:
     cpu:88%/70%
-  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
-  ScalingLimited TooManyReplicas, the desired replica count is more than the maximum replica count for 1m
+  ScalingActive:True ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited:True TooManyReplicas, the desired replica count is more than the maximum replica count for 1m

--- a/tests/artifacts/hpa-no-last-scale-time.out
+++ b/tests/artifacts/hpa-no-last-scale-time.out
@@ -5,5 +5,5 @@ HorizontalPodAutoscaler/my-app -n default, created 1m ago
   Replicas: 3/2-10
   Metrics:
     cpu:45%/70%
-  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
-  ScalingLimited DesiredWithinRange, recommended size matches current size for 1m
+  ScalingActive:True ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited:False DesiredWithinRange, recommended size matches current size for 1m

--- a/tests/artifacts/hpa-scaling-up.out
+++ b/tests/artifacts/hpa-scaling-up.out
@@ -6,5 +6,5 @@ HorizontalPodAutoscaler/my-app -n default, created 1m ago, last scaled 1m ago
   Metrics:
     cpu:92%/70%
     memory:480Mi/512Mi
-  ScalingActive ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
-  ScalingLimited DesiredWithinRange, the desired count is within the acceptable range for 1m
+  ScalingActive:True ValidMetricFound, the HPA was able to successfully calculate a replica count for 1m
+  ScalingLimited:False DesiredWithinRange, the desired count is within the acceptable range for 1m

--- a/tests/artifacts/httproute-no-hostnames.out
+++ b/tests/artifacts/httproute-no-hostnames.out
@@ -4,8 +4,8 @@ HTTPRoute/myapp-prom-prometheus-prometheus -n prom, created 1m ago by HTTPRoute/
   Parents:
     Gateway/myapp-envoy-gateway -n infra-envoy-gateway
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
   Rules:
     PathPrefix /
       header:Host=^prom\.app\..*

--- a/tests/artifacts/httproute-prometheus.out
+++ b/tests/artifacts/httproute-prometheus.out
@@ -5,8 +5,8 @@ HTTPRoute/prometheus -n default, created 1m ago, gen:1
   Parents:
     Gateway/eg
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
   Rules:
     PathPrefix /
     → Service/kube-prometheus-stack-1782-prometheus:9090

--- a/tests/artifacts/httproute-tls-healthy.out
+++ b/tests/artifacts/httproute-tls-healthy.out
@@ -2,11 +2,11 @@
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     https: port=443/HTTPS, host=gateway.example.com, namespaces=Same, accepts=HTTPRoute, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/gateway-tls -n default, created 1m ago
   Certificate for CN=example.com · issued by CN=Test CA
@@ -20,8 +20,8 @@ HTTPRoute/app -n default, created 1m ago, gen:1
   Parents:
     Gateway/eg [https]
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
   Rules:
     PathPrefix /
     → Service/app-svc:8080

--- a/tests/artifacts/httproute-tls-problems.out
+++ b/tests/artifacts/httproute-tls-problems.out
@@ -2,17 +2,17 @@
 Gateway/eg -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     self-signed: port=446/HTTPS, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/selfsigned-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     hostname-mismatch: port=447/HTTPS, host=wrong-host.example.com, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     missing-secret: port=448/HTTPS, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/does-not-exist
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 Secret/selfsigned-tls -n default, created 1m ago
   Certificate for CN=other.example.com · issued by CN=other.example.com
@@ -32,16 +32,16 @@ HTTPRoute/app -n default, created 1m ago, gen:1
   Parents:
     Gateway/eg [self-signed]
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
     Gateway/eg [hostname-mismatch]
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
     Gateway/eg [missing-secret]
       controller: gateway.envoyproxy.io/gatewayclass-controller
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m
   Rules:
     PathPrefix /
     → Service/app-svc:8080

--- a/tests/artifacts/issuer-ca.out
+++ b/tests/artifacts/issuer-ca.out
@@ -2,4 +2,4 @@
 Issuer/kubectl-status-ca-issuer -n default, created 1m ago, gen:1
   Current: Resource is Ready
   Backend: CA · signing key in Secret/kubectl-status-ca-secret
-  Ready KeyPairVerified, Signing CA verified for 1m
+  Ready:True KeyPairVerified, Signing CA verified for 1m

--- a/tests/artifacts/issuer-selfsigned.out
+++ b/tests/artifacts/issuer-selfsigned.out
@@ -2,4 +2,4 @@
 Issuer/kubectl-status-selfsigned-issuer -n default, created 1m ago, gen:1
   Current: Resource is Ready
   Backend: Self-Signed
-  Ready IsReady for 1m
+  Ready:True IsReady for 1m

--- a/tests/artifacts/job-complete.out
+++ b/tests/artifacts/job-complete.out
@@ -1,4 +1,4 @@
 
 Job/hello-1584493380 -n default, created 1m ago by CronJob/hello, started at 2020-03-18T01:03:07Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
-  Complete for 1m
+  Complete:True for 1m

--- a/tests/artifacts/job-fail-exit1.out
+++ b/tests/artifacts/job-fail-exit1.out
@@ -2,5 +2,5 @@
 Job/job-fail-exit1 -n default, created 1m ago, gen:1, started at 2026-06-29T02:31:34Z (1m ago), Failed: 2/1
   Failed: Job Failed. failed: 2/1
     Stalled: JobFailed, Job Failed. failed: 2/1
-  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
-  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-failed.out
+++ b/tests/artifacts/job-failed.out
@@ -2,5 +2,5 @@
 Job/job-failed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:23Z (1m ago), Failed: 3/2
   Failed: Job Failed. failed: 3/1
     Stalled: JobFailed, Job Failed. failed: 3/1
-  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
-  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-from-cronjob-failed.out
+++ b/tests/artifacts/job-from-cronjob-failed.out
@@ -2,5 +2,5 @@
 Job/cronjob-failing-29711681 -n default, created 1m ago by CronJob/cronjob-failing, gen:1, started at 2026-06-29T02:41:00Z (1m ago), Failed: 1
   Failed: Job Failed. failed: 1/1
     Stalled: JobFailed, Job Failed. failed: 1/1
-  FailureTarget BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
-  Failed BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-indexed-complete.out
+++ b/tests/artifacts/job-indexed-complete.out
@@ -2,5 +2,5 @@
 Job/job-indexed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:52Z (1m ago) and completed in 1m, Succeeded
   Indexed: 5/5 (0-4)
   Current: Job Completed. succeeded: 5/5
-  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
-  Complete CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-indexed-partial-failure.out
+++ b/tests/artifacts/job-indexed-partial-failure.out
@@ -4,5 +4,5 @@ Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29
   Failed indexes: 0,2,4 (limit: 1 per index)
   Failed: Job Failed. failed: 6/6
     Stalled: JobFailed, Job Failed. failed: 6/6
-  FailureTarget FailedIndexes, Job has failed indexes for 1m
-  Failed FailedIndexes, Job has failed indexes for 1m
+  FailureTarget:True FailedIndexes, Job has failed indexes for 1m
+  Failed:True FailedIndexes, Job has failed indexes for 1m

--- a/tests/artifacts/job-simple-complete.out
+++ b/tests/artifacts/job-simple-complete.out
@@ -1,5 +1,5 @@
 
 Job/job-simple -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:22Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
-  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
-  Complete CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-suspended.out
+++ b/tests/artifacts/job-suspended.out
@@ -3,4 +3,4 @@ Job/job-suspended -n default, created 1m ago, gen:1, Suspended
   Indexed: 0/5
   InProgress: Job not started
     Reconciling: JobNotStarted, Job not started
-  Suspended JobSuspended, Job suspended for 1m
+  Suspended:True JobSuspended, Job suspended for 1m

--- a/tests/artifacts/job-with-sidecar-complete.out
+++ b/tests/artifacts/job-with-sidecar-complete.out
@@ -1,5 +1,5 @@
 
 Job/job-with-sidecar -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:55Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
-  SuccessCriteriaMet CompletionsReached, Reached expected number of succeeded pods for 1m
-  Complete CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/listenerset-pending.out
+++ b/tests/artifacts/listenerset-pending.out
@@ -5,5 +5,5 @@ ListenerSet/extra-listeners -n default, created 1m ago, gen:1
     Gateway/multi-proto-gw
   Listeners:
     extra-http: port=8081/HTTP, namespaces=Same
-  Accepted Pending, Waiting for controller for 1m
-  Programmed Pending, Waiting for controller for 1m
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m

--- a/tests/artifacts/multiple-2-pods-docs.out
+++ b/tests/artifacts/multiple-2-pods-docs.out
@@ -1,7 +1,7 @@
 
 Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
   previously: Started 1m ago and Completed after 1m
   livenessProbe: httpGet HTTP://127.0.0.1:2381/health?exclude=NOSPACE&serializable=true (delay 10s, every 10s, timeout 15s, fail after 8x) kill budget: 90s
@@ -12,7 +12,7 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
 
 Pod/storage-provisioner -n kube-system, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: storage-provisioner (gcr.io/k8s-minikube/storage-provisioner:v5) Running for 1m and Ready, restarted 16 times
   previously: Started 1m ago and Error after 1m with exit code exit with 1

--- a/tests/artifacts/multiple-2-pods-list.out
+++ b/tests/artifacts/multiple-2-pods-list.out
@@ -1,7 +1,7 @@
 
 Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: etcd (registry.k8s.io/etcd:3.5.9-0) Running for 1m and Ready, restarted 9 times
   previously: Started 1m ago and Completed after 1m
   livenessProbe: httpGet HTTP://127.0.0.1:2381/health?exclude=NOSPACE&serializable=true (delay 10s, every 10s, timeout 15s, fail after 8x) kill budget: 90s
@@ -12,7 +12,7 @@ Pod/etcd-minikube -n kube-system, created 1m ago by Node/minikube, started after
 
 Pod/storage-provisioner -n kube-system, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: storage-provisioner (gcr.io/k8s-minikube/storage-provisioner:v5) Running for 1m and Ready, restarted 16 times
   previously: Started 1m ago and Error after 1m with exit code exit with 1

--- a/tests/artifacts/node-aks.out
+++ b/tests/artifacts/node-aks.out
@@ -4,9 +4,9 @@ Node/aks-cpuworkers-41776494-vmss00006u, created 1m ago
   cloudprovider eastus0 Standard_D8s_v3, agentpool:cpuworkers, role:agent
   images 50 volumes inuse=1/16, attached=1
   Current: Resource is Ready
-  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
-  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
-  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
-  Ready KubeletReady, kubelet is posting ready status. AppArmor enabled for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status. AppArmor enabled for 1m
   addresses: Hostname=aks-cpuworkers-41776494-vmss00006u InternalIP=10.250.4.65
   allocatable/capacity: pods 30/30, cpu 7.82/8, mem 29.1/33.7GB, ephemeral-storage 59.7/66.4GB

--- a/tests/artifacts/node-and-service.out
+++ b/tests/artifacts/node-and-service.out
@@ -3,10 +3,10 @@ Node/minikube, created 1m ago
   linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41-1-MANJARO, kubelet v1.30.0, kube-proxy v1.30.0, runtime docker://26.1.1
   images 8
   Current: Resource is Ready
-  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
-  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
-  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
-  Ready KubeletReady, kubelet is posting ready status for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.49.2 Hostname=minikube
   allocatable/capacity: pods 110/110, cpu 16/16, mem 33.3/33.3GB, ephemeral-storage 997.3/997.3GB
 

--- a/tests/artifacts/node-minikube-with-metrics.out
+++ b/tests/artifacts/node-minikube-with-metrics.out
@@ -3,9 +3,9 @@ Node/minikube, created 1m ago
   linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
   images 13
   Current: Resource is Ready
-  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
-  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
-  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
-  Ready KubeletReady, kubelet is posting ready status for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.105 Hostname=minikube
   allocatable/capacity: pods 110/110, cpu 2/2, mem 1.9/2GB, ephemeral-storage 16.3/18.2GB

--- a/tests/artifacts/node-minikube.out
+++ b/tests/artifacts/node-minikube.out
@@ -3,9 +3,9 @@ Node/minikube, created 1m ago
   linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
   images 13
   Current: Resource is Ready
-  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
-  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
-  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
-  Ready KubeletReady, kubelet is posting ready status for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.102 Hostname=minikube
   allocatable/capacity: pods 110/110, cpu 2/2, mem 1.9/2GB, ephemeral-storage 16.3/18.2GB

--- a/tests/artifacts/nodeclaim-healthy.out
+++ b/tests/artifacts/nodeclaim-healthy.out
@@ -4,7 +4,7 @@ NodeClaim/default-abcde, created 1m ago by NodePool/default, gen:1
   NodeClass: EC2NodeClass/default
   Capacity: m5.large (spot) in us-east-1a
   Node: Node/ip-10-0-1-23.ec2.internal
-  Launched Launched for 1m
-  Registered Registered for 1m
-  Initialized Initialized for 1m
-  Ready Ready for 1m
+  Launched:True Launched for 1m
+  Registered:True Registered for 1m
+  Initialized:True Initialized for 1m
+  Ready:True Ready for 1m

--- a/tests/artifacts/nodeclaim-launch-failed.out
+++ b/tests/artifacts/nodeclaim-launch-failed.out
@@ -4,7 +4,7 @@ NodeClaim/default-fghij, created 1m ago by NodePool/default, gen:1
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default
   Capacity: (spot)
-  Launched LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
-  Registered AwaitingLaunch for 1m
-  Initialized AwaitingRegistration for 1m
-  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m
+  Launched:False LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
+  Registered:Unknown AwaitingLaunch for 1m
+  Initialized:Unknown AwaitingRegistration for 1m
+  Ready:False NodeClaimNotInitialized, NodeClaim is not initialized for 1m

--- a/tests/artifacts/nodeclaim-registration-failed.out
+++ b/tests/artifacts/nodeclaim-registration-failed.out
@@ -4,7 +4,7 @@ NodeClaim/default-klmno, created 1m ago by NodePool/default, gen:1
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default
   Capacity: m5.large (on-demand) in us-east-1b
-  Launched Launched for 1m
-  Registered NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m
-  Initialized AwaitingRegistration for 1m
-  Ready NodeClaimNotInitialized, NodeClaim is not initialized for 1m
+  Launched:True Launched for 1m
+  Registered:False NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m
+  Initialized:Unknown AwaitingRegistration for 1m
+  Ready:False NodeClaimNotInitialized, NodeClaim is not initialized for 1m

--- a/tests/artifacts/nodepool-healthy.out
+++ b/tests/artifacts/nodepool-healthy.out
@@ -14,6 +14,6 @@ NodePool/default, created 1m ago, gen:3
     cpu: 48/1000
     memory: 206.1GB/1TB
     pods: 220/unlimited
-  Ready Ready for 1m
-  NodeClassReady NodeClassReady for 1m
-  ValidationSucceeded ValidationSucceeded for 1m
+  Ready:True Ready for 1m
+  NodeClassReady:True NodeClassReady for 1m
+  ValidationSucceeded:True ValidationSucceeded for 1m

--- a/tests/artifacts/nodepool-static-replicas.out
+++ b/tests/artifacts/nodepool-static-replicas.out
@@ -8,4 +8,4 @@ NodePool/static-pool, created 1m ago, gen:1
   Replicas: 0
   Resources: (current/limit)
     nodes: n/a/5
-  Ready NodeClassNotReady, EC2NodeClass default is not ready for 1m
+  Ready:False NodeClassNotReady, EC2NodeClass default is not ready for 1m

--- a/tests/artifacts/pdb-prometheus.out
+++ b/tests/artifacts/pdb-prometheus.out
@@ -5,4 +5,4 @@ PodDisruptionBudget/prometheus-pdb -n default, created 1m ago, gen:1
   Selector: app.kubernetes.io/name=prometheus
   healthy:1/expected:1, disruptions allowed:0
     no disruptions allowed — all pods must stay healthy to meet the budget
-  DisruptionAllowed InsufficientPods for 1m
+  DisruptionAllowed:False InsufficientPods for 1m

--- a/tests/artifacts/pod-deleted-due-to-missing-container.out
+++ b/tests/artifacts/pod-deleted-due-to-missing-container.out
@@ -1,8 +1,8 @@
 
 Pod/prometheus-operator-5c5784bc5f-4h65z -n prometheus, created 1m ago by ReplicaSet/prometheus-operator-5c5784bc5f, started after 1m Failed Evicted BestEffort, message: The node was low on resource: ephemeral-storage. Container kube-prometheus-stack was using 19212Ki, which exceeds its request of 0.
   Current: Pod has completed, but not successfully
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready PodFailed for 1m
-    ContainersReady PodFailed for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False PodFailed for 1m
+    ContainersReady:False PodFailed for 1m
   Containers: kube-prometheus-stack (quay.io/prometheus-operator/prometheus-operator:v0.58.0) Terminated as ContainerStatusUnknown with "The container could not be located when the pod was terminated" exit with 137 (SIGKILL), restarted 1 times
   previously: Terminated as ContainerStatusUnknown with "The container could not be located when the pod was deleted.  The container used to be Running" exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-ephemeral-imagepullbackoff.out
+++ b/tests/artifacts/pod-ephemeral-imagepullbackoff.out
@@ -1,7 +1,7 @@
 
 Pod/pod-ephemeral-imagepullbackoff -n default, created 1m ago, gen:2, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: main (nginx:alpine) Running for 1m and Ready
   Debug containers:

--- a/tests/artifacts/pod-imagepullbackoff-never-policy.out
+++ b/tests/artifacts/pod-imagepullbackoff-never-policy.out
@@ -2,8 +2,8 @@
 Pod/backoff-never-policy -n test1, created 1m ago, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [main] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [main] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [main] for 1m
   Standalone POD.
   Containers: main (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"

--- a/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
+++ b/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
@@ -2,9 +2,9 @@
 Pod/backoff-with-valid-secret -n test1, created 1m ago, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [main] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [main] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [main] for 1m
   Standalone POD.
   Containers: main (private-registry.example.com/some/image:latest) Waiting ImagePullBackOff: Back-off pulling image "private-registry.example.com/some/image:latest"
 

--- a/tests/artifacts/pod-job-completed.out
+++ b/tests/artifacts/pod-job-completed.out
@@ -1,7 +1,7 @@
 
 Pod/hello-1584492660-d2c6p -n default, created 1m ago by Job/hello-1584492660, started after 1m Succeeded BestEffort
   Current: Pod has completed successfully
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready PodCompleted for 1m
-    ContainersReady PodCompleted for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False PodCompleted for 1m
+    ContainersReady:False PodCompleted for 1m
   Containers: hello (busybox:latest) Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-liveness-kill-137.out
+++ b/tests/artifacts/pod-liveness-kill-137.out
@@ -2,9 +2,9 @@
 Pod/pod-liveness-kill-137 -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   Failed: Containers in CrashLoop state: app
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: app
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [app] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (busybox:1.36) Waiting CrashLoopBackOff: back-off 20s restarting failed container=app pod=pod-liveness-kill-137_default(d2bf2b74-5f4b-45e4-b391-5b8cd9d253eb), restarted 3 times
   previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-marked-for-deletion-completed.out
+++ b/tests/artifacts/pod-marked-for-deletion-completed.out
@@ -1,7 +1,7 @@
 
 Pod/hello-1584492660-d2c6p -n default, created 1m ago by Job/hello-1584492660, started after 1m Succeeded BestEffort
   Terminating: Resource scheduled for deletion
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready PodCompleted for 1m
-    ContainersReady PodCompleted for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False PodCompleted for 1m
+    ContainersReady:False PodCompleted for 1m
   Containers: hello (busybox:latest) Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-marked-for-deletion.out
+++ b/tests/artifacts/pod-marked-for-deletion.out
@@ -1,7 +1,7 @@
 
 Pod/web-0 -n test1, created 1m ago by StatefulSet/web, started after 1m Running BestEffort
   Terminating: Resource scheduled for deletion
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: nginx (k8s.gcr.io/nginx-slim:0.8) Running for 1m and Ready, restarted 2 times
   previously: Started 1m ago and Completed after 1m
   Volumes: www (PersistentVolumeClaim/www-web-0)

--- a/tests/artifacts/pod-missing-pvc.include-all-volumes.out
+++ b/tests/artifacts/pod-missing-pvc.include-all-volumes.out
@@ -2,8 +2,8 @@
 Pod/web-0 -n test1, created 1m ago by StatefulSet/web Pending BestEffort
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
   Volumes:
     www (PersistentVolumeClaim/www-web-0)
     default-token-xqj2x (Secret/default-token-xqj2x)

--- a/tests/artifacts/pod-missing-pvc.out
+++ b/tests/artifacts/pod-missing-pvc.out
@@ -2,6 +2,6 @@
 Pod/web-0 -n test1, created 1m ago by StatefulSet/web Pending BestEffort
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, error while running "VolumeBinding" filter plugin for pod "web-0": pod has unbound immediate PersistentVolumeClaims for 1m
   Volumes: www (PersistentVolumeClaim/www-web-0)

--- a/tests/artifacts/pod-native-sidecar.out
+++ b/tests/artifacts/pod-native-sidecar.out
@@ -1,7 +1,7 @@
 
 Pod/pod-native-sidecar -n default, created 1m ago, gen:1, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   InitContainers:
     log-collector [sidecar] (busybox:latest) Running for 1m and Ready

--- a/tests/artifacts/pod-non-existing-image.out
+++ b/tests/artifacts/pod-non-existing-image.out
@@ -2,8 +2,8 @@
 Pod/missing-image-755c8c54f7-26v4c -n test1, created 1m ago by ReplicaSet/missing-image-755c8c54f7, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [missing-image] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [missing-image] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [missing-image] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [missing-image] for 1m
   Containers: missing-image (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"
   (no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)

--- a/tests/artifacts/pod-pending-nodeselector.out
+++ b/tests/artifacts/pod-pending-nodeselector.out
@@ -2,7 +2,7 @@
 Pod/pod-pending-nodeselector -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
   node selector: disktype=ssd,kubernetes.io/arch=arm64
   Standalone POD.

--- a/tests/artifacts/pod-pending-preferred-antiaffinity-only.out
+++ b/tests/artifacts/pod-pending-preferred-antiaffinity-only.out
@@ -2,6 +2,6 @@
 Pod/pod-pending-preferred-antiaffinity-only -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
   Standalone POD.

--- a/tests/artifacts/pod-pending-preferred-nodeaffinity-only.out
+++ b/tests/artifacts/pod-pending-preferred-nodeaffinity-only.out
@@ -2,6 +2,6 @@
 Pod/pod-pending-preferred-nodeaffinity-only -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
   Standalone POD.

--- a/tests/artifacts/pod-pending-required-antiaffinity.out
+++ b/tests/artifacts/pod-pending-required-antiaffinity.out
@@ -2,7 +2,7 @@
 Pod/pod-pending-required-antiaffinity -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't satisfy existing pods anti-affinity rules. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 node(s) didn't satisfy existing pods anti-affinity rules. for 1m
   required anti-affinity: app=api across kubernetes.io/hostname
   Standalone POD.

--- a/tests/artifacts/pod-pending-required-nodeaffinity.out
+++ b/tests/artifacts/pod-pending-required-nodeaffinity.out
@@ -2,7 +2,7 @@
 Pod/pod-pending-required-nodeaffinity -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 node(s) didn't match Pod's node affinity/selector. for 1m
   required node affinity: (topology.kubernetes.io/zone in (us-east-1a,us-east-1b)) or (node.kubernetes.io/instance-type in (m5.large),karpenter.sh/capacity-type notin (spot))
   Standalone POD.

--- a/tests/artifacts/pod-pending-scheduled.out
+++ b/tests/artifacts/pod-pending-scheduled.out
@@ -2,4 +2,4 @@
 Pod/hello-1584492840-kqf62 -n default, created 1m ago by Job/hello-1584492840 Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+  PodScheduled:True -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown

--- a/tests/artifacts/pod-pending-topology-spread-donotschedule.out
+++ b/tests/artifacts/pod-pending-topology-spread-donotschedule.out
@@ -2,7 +2,7 @@
 Pod/pod-pending-topology-spread-donotschedule -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 node(s) didn't match pod topology spread constraints. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 node(s) didn't match pod topology spread constraints. for 1m
   required spread: max skew 1 across kubernetes.io/hostname for app=api
   Standalone POD.

--- a/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.out
+++ b/tests/artifacts/pod-pending-topology-spread-scheduleanyway-only.out
@@ -2,6 +2,6 @@
 Pod/pod-pending-topology-spread-scheduleanyway-only -n default, created 1m ago, gen:1 Pending Burstable
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/3 nodes are available: 3 Insufficient cpu. for 1m
   Standalone POD.

--- a/tests/artifacts/pod-pending-waiting-container.out
+++ b/tests/artifacts/pod-pending-waiting-container.out
@@ -2,7 +2,7 @@
 Pod/hello-1584492840-kqf62 -n default, created 1m ago by Job/hello-1584492840, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [hello] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [hello] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [hello] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [hello] for 1m
   Containers: hello (busybox) Waiting ContainerCreating

--- a/tests/artifacts/pod-pending.out
+++ b/tests/artifacts/pod-pending.out
@@ -2,4 +2,4 @@
 Pod/hello-1584492840-kqf62 -n default, created 1m ago by Job/hello-1584492840 Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
+  PodScheduled:Unknown -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown

--- a/tests/artifacts/pod-poststart-hook-error.out
+++ b/tests/artifacts/pod-poststart-hook-error.out
@@ -2,9 +2,9 @@
 Pod/pod-poststart-hook-error -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [app] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (busybox:1.36) Waiting PostStartHookError: Exec lifecycle hook ([/bin/sh -c exit 1]) for Container "app" in Pod "pod-poststart-hook-error_default(9af6a317-3023-4f5d-b537-68ca9118a791)" failed - error: command '/bin/sh -c exit 1' exited with 1: , message: ""
   previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-probe-liveness-restarting.out
+++ b/tests/artifacts/pod-probe-liveness-restarting.out
@@ -2,9 +2,9 @@
 Pod/probe-liveness-restarting -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [app] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready, restarted 1 times
   previously: Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-probe-readiness-failing.out
+++ b/tests/artifacts/pod-probe-readiness-failing.out
@@ -2,9 +2,9 @@
 Pod/probe-readiness-failing -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: [app] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: [app] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready
   readinessProbe: httpGet HTTP://localhost:8080/ready (delay 1s, every 5s, timeout 1s, fail after 3x)

--- a/tests/artifacts/pod-psa-baseline.out
+++ b/tests/artifacts/pod-psa-baseline.out
@@ -1,6 +1,6 @@
 
 Pod/pod-psa-baseline -n psa-baseline, created 1m ago, gen:1, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: main (nginx:alpine) Running for 1m and Ready

--- a/tests/artifacts/pod-readiness-gate.out
+++ b/tests/artifacts/pod-readiness-gate.out
@@ -2,8 +2,8 @@
 Pod/pod-readiness-gate -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
-  PodScheduled -> Initialized -> ContainersReady -> Not Ready
-    Ready ReadinessGatesNotReady, corresponding condition of pod readiness gate "custom.io/feature-ready" does not exist. for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:False
+    Ready:False ReadinessGatesNotReady, corresponding condition of pod readiness gate "custom.io/feature-ready" does not exist. for 1m
     Readiness gate: custom.io/feature-ready: condition not yet set
   Standalone POD.
   Containers: app (registry.k8s.io/pause:3.9) Running for 1m and Ready

--- a/tests/artifacts/pod-scheduling-gated.out
+++ b/tests/artifacts/pod-scheduling-gated.out
@@ -2,8 +2,8 @@
 Pod/pod-scheduling-gated -n default, created 1m ago, gen:1 Pending Burstable
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
     Scheduling gates (2):
       example.com/feature-gate
       example.com/capacity-gate

--- a/tests/artifacts/pod-seccomp-unconfined.out
+++ b/tests/artifacts/pod-seccomp-unconfined.out
@@ -1,7 +1,7 @@
 
 Pod/pod-seccomp-unconfined -n default, created 1m ago, gen:1, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   seccomp: Unconfined (no syscall filtering)
   Standalone POD.
   Containers: main (nginx:alpine) Running for 1m and Ready

--- a/tests/artifacts/pod-standalone-ineractive.out
+++ b/tests/artifacts/pod-standalone-ineractive.out
@@ -1,6 +1,6 @@
 
 Pod/test-pod -n test1, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD, interactive with attached TTY.
   Containers: test-pod (k8s.gcr.io/pause:3.1) Running for 1m and Ready

--- a/tests/artifacts/pod-standalone.absolute-time.out
+++ b/tests/artifacts/pod-standalone.absolute-time.out
@@ -1,6 +1,6 @@
 
 Pod/test-pod -n test1, created 2020-03-18T02:05:46Z Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready since 2020-03-18T02:05:47Z
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True since 2020-03-18T02:05:47Z
   Standalone POD.
   Containers: test-pod (k8s.gcr.io/pause:3.1) Running since 2020-03-18T02:05:47Z and Ready

--- a/tests/artifacts/pod-standalone.include-all-volumes.out
+++ b/tests/artifacts/pod-standalone.include-all-volumes.out
@@ -1,7 +1,7 @@
 
 Pod/test-pod -n test1, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: test-pod (k8s.gcr.io/pause:3.1) Running for 1m and Ready
   Volume Mounts:

--- a/tests/artifacts/pod-standalone.out
+++ b/tests/artifacts/pod-standalone.out
@@ -1,6 +1,6 @@
 
 Pod/test-pod -n test1, created 1m ago, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: test-pod (k8s.gcr.io/pause:3.1) Running for 1m and Ready

--- a/tests/artifacts/pod-with-ephemeral-container.out
+++ b/tests/artifacts/pod-with-ephemeral-container.out
@@ -1,7 +1,7 @@
 
 Pod/pod-ephemeral-base -n default, created 1m ago, gen:2, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD.
   Containers: main (nginx:alpine) Running for 1m and Ready
   Debug containers:

--- a/tests/artifacts/pod-with-metrics-and-events.out
+++ b/tests/artifacts/pod-with-metrics-and-events.out
@@ -1,5 +1,5 @@
 
 Pod/test-7d7bf58f7d-pvk2s -n test1, created 1m ago by ReplicaSet/test-7d7bf58f7d, started after 1m Running Burstable
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: test (k8s.gcr.io/pause:3.1) Running for 1m and Ready

--- a/tests/artifacts/pvc-resize-in-progress.out
+++ b/tests/artifacts/pvc-resize-in-progress.out
@@ -1,6 +1,6 @@
 
 PersistentVolumeClaim/data-web-0 -n default, created 1m ago Bound
   Current: PVC is Bound
-  FileSystemResizePending FileSystemResizePending, Waiting for user to (re-)start a pod to finish file system resize of volume on node. for 1m
+  FileSystemResizePending:True FileSystemResizePending, Waiting for user to (re-)start a pod to finish file system resize of volume on node. for 1m
   PVC uses PersistentVolume/pvc-23498768-c86b-4102-a660-139ed9044bc2 via StorageClass/standard, with Filesystem mode, asks for 10Gi
   Resize: storage 10Gi → 20Gi NodeExpansionRequired

--- a/tests/artifacts/secretstore-fake.out
+++ b/tests/artifacts/secretstore-fake.out
@@ -2,4 +2,4 @@
 SecretStore/fake-store -n default, created 1m ago, gen:1
   Current: Resource is Ready
   Provider: Fake
-  Ready Valid, store validated for 1m
+  Ready:True Valid, store validated for 1m

--- a/tests/artifacts/tcproute-accepted.out
+++ b/tests/artifacts/tcproute-accepted.out
@@ -7,5 +7,5 @@ TCPRoute/tcp-backend-route -n default, created 1m ago, gen:1
     → Service/tcp-backend:8080
   Status:
     Gateway/multi-proto-gw [tcp] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m

--- a/tests/artifacts/tlsroute-tls-healthy.out
+++ b/tests/artifacts/tlsroute-tls-healthy.out
@@ -2,11 +2,11 @@
 Gateway/tls-gw -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     tls: port=443/TLS, accepts=TLSRoute, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 TLSRoute/tls-route -n default, created 1m ago, gen:1
   Current: Resource is current
@@ -17,7 +17,7 @@ TLSRoute/tls-route -n default, created 1m ago, gen:1
     → Service/tls-backend:443
   Status:
     Gateway/tls-gw [tls] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route was valid for 1m
+      Accepted:True Accepted, Route was valid for 1m
 
 Secret/gateway-tls -n default, created 1m ago
   Certificate for CN=example.com · issued by CN=Test CA

--- a/tests/artifacts/tlsroute-tls-problems.out
+++ b/tests/artifacts/tlsroute-tls-problems.out
@@ -2,14 +2,14 @@
 Gateway/tls-gw-problems -n default, created 1m ago, gen:1
   Current: Resource is current
   Class: eg
-  Accepted Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
+  Accepted:True Accepted, The Gateway has been scheduled by Envoy Gateway for 1m
   Listeners:
     tls-selfsigned: port=443/TLS, routes=1
       TLS mode:Terminate, cert:Secret/selfsigned-tls
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
     tls-passthrough: port=444/TLS, routes=1
       TLS mode:Passthrough
-      ResolvedRefs ResolvedRefs, Listener references have been resolved for 1m
+      ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
 
 TLSRoute/tls-route-selfsigned -n default, created 1m ago, gen:1
   Current: Resource is current
@@ -20,7 +20,7 @@ TLSRoute/tls-route-selfsigned -n default, created 1m ago, gen:1
     → Service/tls-backend:443
   Status:
     Gateway/tls-gw-problems [tls-selfsigned] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route was valid for 1m
+      Accepted:True Accepted, Route was valid for 1m
 
 TLSRoute/tls-route-passthrough -n default, created 1m ago, gen:1
   Current: Resource is current
@@ -30,7 +30,7 @@ TLSRoute/tls-route-passthrough -n default, created 1m ago, gen:1
     → Service/tls-backend:444
   Status:
     Gateway/tls-gw-problems [tls-passthrough] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route was valid for 1m
+      Accepted:True Accepted, Route was valid for 1m
 
 Secret/selfsigned-tls -n default, created 1m ago
   Certificate for CN=other.example.com · issued by CN=other.example.com

--- a/tests/artifacts/udproute-accepted.out
+++ b/tests/artifacts/udproute-accepted.out
@@ -7,5 +7,5 @@ UDPRoute/udp-backend-route -n default, created 1m ago, gen:1
     → Service/udp-backend:9090
   Status:
     Gateway/multi-proto-gw [udp] (gateway.envoyproxy.io/gatewayclass-controller)
-      Accepted Accepted, Route is accepted for 1m
-      ResolvedRefs ResolvedRefs, Resolved all the Object references for the Route for 1m
+      Accepted:True Accepted, Route is accepted for 1m
+      ResolvedRefs:True ResolvedRefs, Resolved all the Object references for the Route for 1m

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -13,8 +13,8 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
           Failed: Pod could not be scheduled
             Stalled: PodUnschedulable, Pod could not be scheduled
           Managed by probe-a-blocked application
-          Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-            PodScheduled Unschedulable, [^\n]*node\(s\) didn't match Pod's node affinity/selector[^\n]* for 1m
+          PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+            PodScheduled:False Unschedulable, [^\n]*node\(s\) didn't match Pod's node affinity/selector[^\n]* for 1m
           node selector: kubectl-status\.io/e2e-never-schedules=true
           Volumes: kube-api-access-[a-z0-9]+ \(Projected\)
           Owners:
@@ -29,8 +29,8 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
               Owners:
                 Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
       Not matched by any Service
-      Available MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
-      Progressing ReplicaSetUpdated, ReplicaSet "probe-a-blocked-[a-z0-9]+" is progressing\. for 1m
+      Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
+      Progressing:True ReplicaSetUpdated, ReplicaSet "probe-a-blocked-[a-z0-9]+" is progressing\. for 1m
       Ongoing Rollout: Waiting for deployment "probe-a-blocked" rollout to finish: 0 of 1 updated replicas are available\.\.\.
       Outage: Deployment has no Ready replicas\.
       Rollouts:
@@ -51,14 +51,14 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                   Composed resources:
                     Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
                     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
-                  Synced ReconcileSuccess for 1m
-                  Ready Creating, Unready resources: blocked-workload, config for 1m
-                  Responsive WatchCircuitClosed for 1m
-          Synced ReconcileSuccess for 1m
-          Ready Creating, Unready resources: blocked-workload, config for 1m
-          Responsive WatchCircuitClosed for 1m
+                  Synced:True ReconcileSuccess for 1m
+                  Ready:False Creating, Unready resources: blocked-workload, config for 1m
+                  Responsive:True WatchCircuitClosed for 1m
+          Synced:True ReconcileSuccess for 1m
+          Ready:False Creating, Unready resources: blocked-workload, config for 1m
+          Responsive:True WatchCircuitClosed for 1m
     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
-  Synced ReconcileSuccess for 1m
-  Ready Creating, Unready resources: blocked-workload, config for 1m
-  Responsive WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:False Creating, Unready resources: blocked-workload, config for 1m
+  Responsive:True WatchCircuitClosed for 1m
 \z

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -6,7 +6,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked, created 1m ago, 0/1 ready, rolling out
     ConfigMap/probe-a-config, created 1m ago, Current: Resource is always ready
-  Synced ReconcileSuccess for 1m
-  Ready Creating, Unready resources: blocked-workload, config for 1m
-  Responsive WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
+  Ready:False Creating, Unready resources: blocked-workload, config for 1m
+  Responsive:True WatchCircuitClosed for 1m
 \z

--- a/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.deep.regex
@@ -4,12 +4,12 @@ ListenerSet/e2e-listenerset -n e2e-listenerset, created 1m ago, gen:1
   Gateway:
     Gateway/e2e-lset-gw -n e2e-listenerset, created 1m ago, gen:1
       Current: Resource is current
-      Accepted Pending, Waiting for controller for 1m
-      Programmed Pending, Waiting for controller for 1m
+      Accepted:Unknown Pending, Waiting for controller for 1m
+      Programmed:Unknown Pending, Waiting for controller for 1m
       Listeners:
         http: port=80/HTTP, namespaces=Same
   Listeners:
     extra-http: port=8081/HTTP, namespaces=Same
-  Accepted Pending, Waiting for controller for 1m
-  Programmed Pending, Waiting for controller for 1m
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
 \z

--- a/tests/e2e-artifacts/listenerset-with-gateway.regex
+++ b/tests/e2e-artifacts/listenerset-with-gateway.regex
@@ -5,6 +5,6 @@ ListenerSet/e2e-listenerset -n e2e-listenerset, created 1m ago, gen:1
     Gateway/e2e-lset-gw
   Listeners:
     extra-http: port=8081/HTTP, namespaces=Same
-  Accepted Pending, Waiting for controller for 1m
-  Programmed Pending, Waiting for controller for 1m
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
 \z

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -4,10 +4,10 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
   images \d+
   Current: Resource is Ready
   kubelet ok(?:, \S+:\S+)*, container logs: retains up to [\d.]+[A-Za-z]+ per container \(\S+ x \d+ files\)
-  MemoryPressure KubeletHasSufficientMemory, kubelet has sufficient memory available for \d+[a-z]+
-  DiskPressure KubeletHasNoDiskPressure, kubelet has no disk pressure for \d+[a-z]+
-  PIDPressure KubeletHasSufficientPID, kubelet has sufficient PID available for \d+[a-z]+
-  Ready KubeletReady, kubelet is posting ready status for \d+[a-z]+
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for \d+[a-z]+
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for \d+[a-z]+
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for \d+[a-z]+
+  Ready:True KubeletReady, kubelet is posting ready status for \d+[a-z]+
   addresses: InternalIP=[\d.]+ Hostname=[a-z0-9.-]+
     network: rx/tx [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, rx/tx errors \d+/\d+
   allocatable/capacity: pods \d+/\d+, cpu [\d.]+/[\d.]+, mem [\d.]+/[\d.]+[A-Za-z]+, ephemeral-storage [\d.]+/[\d.]+[A-Za-z]+

--- a/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
+++ b/tests/e2e-artifacts/pdb-empty-selector-conflict.pod.regex
@@ -2,7 +2,7 @@
 Pod/pdb-conflict-test-0 -n e2e-pdb-conflict, created 1m ago by StatefulSet/pdb-conflict-test, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by pdb-conflict-test application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: pdb-conflict-test \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -2,9 +2,9 @@
 Pod/e2e-pod-container-logs -n e2e-pod-container-logs, created 1m ago, gen:1, started after 1m Running BestEffort
   Failed: Containers in CrashLoop state: crasher
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: crasher
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: \[crasher\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[crasher\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: \[crasher\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[crasher\] for 1m
   Standalone POD\.
   InitContainers:
     init-setup \(busybox:latest\) Started 1m ago and Completed after 1m

--- a/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
@@ -2,9 +2,9 @@
 Pod/e2e-pod-healthy-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
 \z

--- a/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
@@ -2,9 +2,9 @@
 Pod/e2e-pod-missing-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*

--- a/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
@@ -2,9 +2,9 @@
 Pod/e2e-pod-wrong-type-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*

--- a/tests/e2e-artifacts/pod-karpenter-satisfiable.regex
+++ b/tests/e2e-artifacts/pod-karpenter-satisfiable.regex
@@ -3,8 +3,8 @@ Pod/karpenter-satisfiable-pod -n e2e-karpenter-pod, created 1m ago, gen:1 Pendin
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
   Managed by karpenter-satisfiable-pod application
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
   node selector: topology\.kubernetes\.io/zone=e2e-zone-a
   Standalone POD\.
 \z

--- a/tests/e2e-artifacts/pod-karpenter-unsatisfiable.regex
+++ b/tests/e2e-artifacts/pod-karpenter-unsatisfiable.regex
@@ -3,8 +3,8 @@ Pod/karpenter-unsatisfiable-pod -n e2e-karpenter-pod, created 1m ago, gen:1 Pend
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
   Managed by karpenter-unsatisfiable-pod application
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
   node selector: workload\.example\.com/tier=stateful
   No NodePool can satisfy: workload\.example\.com/tier
   Standalone POD\.

--- a/tests/e2e-artifacts/pod-metrics-server-missing.regex
+++ b/tests/e2e-artifacts/pod-metrics-server-missing.regex
@@ -1,7 +1,7 @@
 \A
 Pod/e2e-pod-metrics-server-missing -n default, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: main \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(metrics-server is not installed\)

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -1,1 +1,1 @@
-Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned, node NotReady, node MemoryPressure, untolerated node taint
+Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned, node Ready:False, node MemoryPressure:True, untolerated node taint

--- a/tests/e2e-artifacts/pod-on-bad-node.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node.regex
@@ -1,5 +1,5 @@
 Node/kubectl-status-test-bad-node-[a-z0-9]+ cordoned \(unschedulable\)
-.*Ready KubeletNotReady, kubelet is not ready.*
-.*MemoryPressure KubeletHasInsufficientMemory, kubelet has insufficient memory available.*
+.*Ready:False KubeletNotReady, kubelet is not ready.*
+.*MemoryPressure:True KubeletHasInsufficientMemory, kubelet has insufficient memory available.*
 .*taint dedicated=gpu:NoSchedule \(not tolerated\)
 .*OOM / eviction risk.*Node kubectl-status-test-bad-node-[a-z0-9]+ has MemoryPressure.*Pod is BestEffort.*

--- a/tests/e2e-artifacts/pod-pv-zone-restricted.regex
+++ b/tests/e2e-artifacts/pod-pv-zone-restricted.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-zone-restricted -n e2e-pv-zone, created 1m ago, gen:1 Pending BestEf
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
   Managed by e2e-pod-zone-restricted application
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match PersistentVolume's node affinity\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match PersistentVolume's node affinity\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
   Standalone POD\.
   Volumes: data \(PersistentVolumeClaim/e2e-pvc-zone-restricted, asked 1Gi\)
   PV node affinity: PersistentVolume/e2e-pv-zone-restricted \(backing PersistentVolumeClaim/e2e-pvc-zone-restricted\) restricts placement to topology\.kubernetes\.io/zone in \(e2e-no-such-zone\)

--- a/tests/e2e-artifacts/pod-selected-by-cilium-and-calico-network-policies.regex
+++ b/tests/e2e-artifacts/pod-selected-by-cilium-and-calico-network-policies.regex
@@ -2,7 +2,7 @@
 Pod/cni-policy-selected-pod -n e2e-cni-policy-pod, created 1m ago, gen:1(, started after [0-9.]+[A-Za-z]+)? Running BestEffort
   Current: Pod is Ready
   Managed by kubectl-status-test-cni-policy-target application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: app \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
+++ b/tests/e2e-artifacts/pod-selected-by-multiple-network-policies.regex
@@ -2,7 +2,7 @@
 Pod/netpol-multi-selected-pod -n e2e-netpol-multi-pod, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by kubectl-status-test-netpol-multi-target application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: app \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-selected-by-network-policy.regex
+++ b/tests/e2e-artifacts/pod-selected-by-network-policy.regex
@@ -2,7 +2,7 @@
 Pod/netpol-selected-pod -n e2e-netpol-pod, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by kubectl-status-test-netpol-target application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: app \(busybox:latest\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-healthy.regex
@@ -1,7 +1,7 @@
 \A
 Pod/e2e-pod-volume-healthy -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
@@ -2,10 +2,10 @@
 Pod/e2e-pod-volume-missing-configmap -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    PodReadyToStartContainers for 1m
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    PodReadyToStartContainers:False for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: cfg \(ConfigMap/e2e-cm-does-not-exist\) doesn't exist

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
@@ -2,10 +2,10 @@
 Pod/e2e-pod-volume-missing-key -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    PodReadyToStartContainers for 1m
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    PodReadyToStartContainers:False for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: cfg \(ConfigMap/e2e-cm-with-data\) missing key "missing-key"

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
@@ -2,10 +2,10 @@
 Pod/e2e-pod-volume-missing-secret -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Pending BestEffort
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
-  PodScheduled -> Initialized -> Not ContainersReady -> Not Ready
-    PodReadyToStartContainers for 1m
-    Ready ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady ContainersNotReady, containers with unready status: \[main\] for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    PodReadyToStartContainers:False for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: sec \(Secret/e2e-secret-does-not-exist\) doesn't exist

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing-key.regex
@@ -1,7 +1,7 @@
 \A
 Pod/e2e-pod-volume-optional-missing-key -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-optional-missing.regex
@@ -1,7 +1,7 @@
 \A
 Pod/e2e-pod-volume-optional-missing -n e2e-pod-volume-configmap-secret, created 1m ago, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))

--- a/tests/e2e-artifacts/pod-wfc-topologies-unbound.regex
+++ b/tests/e2e-artifacts/pod-wfc-topologies-unbound.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-wfc-topologies -n e2e-pv-zone-wfc, created 1m ago, gen:1 Pending Bes
   Failed: Pod could not be scheduled
     Stalled: PodUnschedulable, Pod could not be scheduled
   Managed by e2e-pod-wfc-topologies application
-  Not PodScheduled -> Not Initialized -> Not ContainersReady -> Not Ready
-    PodScheduled Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False Unschedulable, 0/1 nodes are available: 1 node\(s\) didn't match Pod's node affinity/selector\. no new claims to deallocate, preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling\. for 1m
   node selector: e2e-no-such-label=true
   Standalone POD\.
   Volumes: data \(PersistentVolumeClaim/e2e-wfc-topologies-pvc, asked 1Gi\)

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -5,8 +5,8 @@ Deployment/rollout-diff-test -n e2e-rollout-diff, created \d+[a-z]+ ago, gen:\d+
   Selector: app=rollout-diff-test
 (?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+, created \d+[a-z]+ ago Running, 1/1 ready
 )+  Not matched by any Service
-  Available MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
-  Progressing NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
   Rollouts:
     \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-f96b445cf
     \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-7cf6c88cf8, has 1 replicas

--- a/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-blocked-deployment.regex
@@ -6,8 +6,8 @@ Deployment/e2e-rollouts-blocked-deployment -n e2e-rollouts-blocked-deployment, c
   Selector: app=e2e-rollouts-blocked-deployment
     Pod/e2e-rollouts-blocked-deployment-[a-z0-9]+-[a-z0-9]+, created 1m ago Pending, 0/1 ready ImagePullBackOff
   Not matched by any Service
-  Available MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
-  Progressing ReplicaSetUpdated, ReplicaSet "e2e-rollouts-blocked-deployment-[a-z0-9]+" is progressing\. for 1m
+  Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
+  Progressing:True ReplicaSetUpdated, ReplicaSet "e2e-rollouts-blocked-deployment-[a-z0-9]+" is progressing\. for 1m
   Ongoing Rollout: Waiting for deployment "e2e-rollouts-blocked-deployment" rollout to finish: 0 of 1 updated replicas are available\.\.\.
   Outage: Deployment has no Ready replicas\.
   Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!

--- a/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
+++ b/tests/e2e-artifacts/rollouts-single-healthy-deployment.regex
@@ -5,6 +5,6 @@ Deployment/e2e-rollouts-healthy-deployment -n e2e-rollouts-healthy-deployment, c
   Selector: app=e2e-rollouts-healthy-deployment
     Pod/e2e-rollouts-healthy-deployment-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
   Not matched by any Service
-  Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
-  Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-healthy-deployment-[a-z0-9]+" has successfully progressed\. for 1m
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-healthy-deployment-[a-z0-9]+" has successfully progressed\. for 1m
 \z

--- a/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
+++ b/tests/e2e-artifacts/rollouts-three-revisions-with-diffs.regex
@@ -5,8 +5,8 @@ Deployment/e2e-rollouts-three-revisions -n e2e-rollouts-three-revisions, created
   Selector: app=e2e-rollouts-three-revisions
     Pod/e2e-rollouts-three-revisions-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
   Not matched by any Service
-  Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
-  Progressing NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-three-revisions-[a-z0-9]+" has successfully progressed\. for 1m
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "e2e-rollouts-three-revisions-[a-z0-9]+" has successfully progressed\. for 1m
   Rollouts:
     1m ago, managed by ReplicaSet/e2e-rollouts-three-revisions-[a-z0-9]+
     1m ago, managed by ReplicaSet/e2e-rollouts-three-revisions-[a-z0-9]+

--- a/tests/e2e-artifacts/sts-with-ingress-routes.deep.regex
+++ b/tests/e2e-artifacts/sts-with-ingress-routes.deep.regex
@@ -13,8 +13,8 @@ Service/sts-with-ingress -n e2e-sts-with-ingress-routes, created 1m ago, last en
       Parents:
         Gateway/sts-gw -n e2e-sts-with-ingress-routes, created 1m ago, gen:1
           Current: Resource is current
-          Accepted Pending, Waiting for controller for 1m
-          Programmed Pending, Waiting for controller for 1m
+          Accepted:Unknown Pending, Waiting for controller for 1m
+          Programmed:Unknown Pending, Waiting for controller for 1m
           Listeners:
             http: port=80/HTTP, namespaces=Same
             tcp: port=8080/TCP, namespaces=Same

--- a/tests/e2e-artifacts/sts-with-ingress.pod.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.pod.regex
@@ -2,7 +2,7 @@
 Pod/sts-with-ingress-0 -n e2e-sts-with-ingress, created 1m ago by StatefulSet/sts-with-ingress, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-ingress application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: sts-with-ingress \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)

--- a/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pdb.regex
@@ -7,5 +7,5 @@ PodDisruptionBudget/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, gen:1
     Pod/sts-with-nodeport-0, created 1m ago Running, 1/1 ready
   healthy:1/expected:1, disruptions allowed:0
     no disruptions allowed — all pods must stay healthy to meet the budget
-  DisruptionAllowed InsufficientPods for 1m
+  DisruptionAllowed:False InsufficientPods for 1m
 \z

--- a/tests/e2e-artifacts/sts-with-nodeport.pod.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.pod.regex
@@ -2,7 +2,7 @@
 Pod/sts-with-nodeport-0 -n e2e-sts-nodeport, created 1m ago by StatefulSet/sts-with-nodeport, gen:1, started after 1m Running BestEffort
   Current: Pod is Ready
   Managed by sts-with-nodeport application
-  PodScheduled -> Initialized -> ContainersReady -> Ready for 1m
+  PodScheduled:True -> Initialized:True -> ContainersReady:True -> Ready:True for 1m
   Containers: sts-with-nodeport \(registry\.k8s\.io/pause:3\.9\) Running for 1m and Ready \(logs: [0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)
   (?:usage cpu usage:[0-9.]+/\[no-req, no-lim\], mem usage:[0-9.]+[A-Za-z]+/\[no-req, no-lim\]|cpu: \[no-req, no-lim\], mem: \[no-req, no-lim\], \(no metrics yet\))
   Volumes: ephemeral-storage \([0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\[[0-9]+%\]\)

--- a/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/tcproute-with-gateway.deep.regex
@@ -4,8 +4,8 @@ TCPRoute/e2e-tcproute -n e2e-tcproute, created 1m ago, gen:1
   Parents:
     Gateway/e2e-tcp-gw -n e2e-tcproute, created 1m ago, gen:1
       Current: Resource is current
-      Accepted Pending, Waiting for controller for 1m
-      Programmed Pending, Waiting for controller for 1m
+      Accepted:Unknown Pending, Waiting for controller for 1m
+      Programmed:Unknown Pending, Waiting for controller for 1m
       Listeners:
         tcp: port=8080/TCP, namespaces=Same
   Rules:

--- a/tests/e2e-artifacts/udproute-with-gateway.deep.regex
+++ b/tests/e2e-artifacts/udproute-with-gateway.deep.regex
@@ -4,8 +4,8 @@ UDPRoute/e2e-udproute -n e2e-udproute, created 1m ago, gen:1
   Parents:
     Gateway/e2e-udp-gw -n e2e-udproute, created 1m ago, gen:1
       Current: Resource is current
-      Accepted Pending, Waiting for controller for 1m
-      Programmed Pending, Waiting for controller for 1m
+      Accepted:Unknown Pending, Waiting for controller for 1m
+      Programmed:Unknown Pending, Waiting for controller for 1m
       Listeners:
         udp: port=9090/UDP, namespaces=Same
   Rules:

--- a/tests/e2e-artifacts/vpa-standalone.regex
+++ b/tests/e2e-artifacts/vpa-standalone.regex
@@ -7,7 +7,7 @@ VerticalPodAutoscaler/vpa-burner -n e2e-vpa, created 1m ago, gen:1
   Policy\[burner\]: min cpu=10m, min mem=16Mi, max cpu=500m, max mem=128Mi
   Recommendation:
     burner: cpu=\d+m \(min \d+m, max \d+m\), mem=\d+Mi \(min \d+Mi, max \d+Mi\)
-  RecommendationProvided for 1m
+  RecommendationProvided:True for 1m
   Events:
     vpa-updater EvictedPod involving VerticalPodAutoscaler/vpa-burner \(in e2e-vpa\) 1m ago VPA Updater evicted Pod vpa-burner-[a-z0-9]+-[a-z0-9]+ to apply resource recommendation\.
 \z

--- a/tests/e2e-artifacts/vpa-workload-reverse-match.regex
+++ b/tests/e2e-artifacts/vpa-workload-reverse-match.regex
@@ -6,5 +6,5 @@ Deployment/vpa-burner -n e2e-vpa, created 1m ago, gen:1 rev:1
     Pod/vpa-burner-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
   Not matched by any Service
   VerticalPodAutoscaler: VerticalPodAutoscaler/vpa-burner, Recreate, burner: cpu=\d+m mem=\d+Mi
-  (?:Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n  Progressing NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m|Progressing NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m\n  Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
+  (?:Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n  Progressing:True NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m|Progressing:True NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m\n  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
 \z

--- a/tests/e2e-artifacts/web-cert.deep.regex
+++ b/tests/e2e-artifacts/web-cert.deep.regex
@@ -5,11 +5,11 @@ Secret/web-tls -n e2e-web-cert, created 1m ago
       Current: Resource is Ready
       Issued by Issuer/web-ca-issuer for "web\.ks-demo\.svc" · stored in Secret/web-tls
       Issued \d{4}-\d{2}-\d{2} \(1m ago\), expires \d{4}-\d{2}-\d{2}, auto-renews \d{4}-\d{2}-\d{2}(?: · rev [0-9]+)?
-      Ready Ready, Certificate is up to date and has not expired for 1m
+      Ready:True Ready, Certificate is up to date and has not expired for 1m
     Issuer/web-ca-issuer -n e2e-web-cert, created 1m ago, gen:1
       Current: Resource is Ready
       Backend: CA · signing key in Secret/web-ca-secret
-      Ready KeyPairVerified, Signing CA verified for 1m
+      Ready:True KeyPairVerified, Signing CA verified for 1m
   Certificate for CN=web\.ks-demo\.svc · issued by CN=kubectl-status-demo-ca
     Valid 1m ago, expires \d{4}-\d{2}-\d{2} \(in 1m\)
     Key: RSA · serial [0-9]+

--- a/tests/e2e-artifacts/web-policies.regex
+++ b/tests/e2e-artifacts/web-policies.regex
@@ -9,6 +9,6 @@ Deployment/web -n e2e-web-policies, created 1m ago, gen:1 rev:1
   Not matched by any Service
   PodDisruptionBudgets: PodDisruptionBudget/web, created 1m ago, min available=1, disruptions allowed
   NetworkPolicy: selected by NetworkPolicy web \(ingress restricted\)
-  Available MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
-  Progressing NewReplicaSetAvailable, ReplicaSet "web-[a-z0-9]+" has successfully progressed\. for 1m(?:, last update was 1m ago)?
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "web-[a-z0-9]+" has successfully progressed\. for 1m(?:, last update was 1m ago)?
 \z


### PR DESCRIPTION
## Summary
- `status.conditions` are now always rendered as `Type:Status` (e.g. `Ready:True`, `Ready:False`, `Registered:Unknown`) instead of hiding `True`, rewording `False` as `NotReady`/`Not X`, and only calling out `Unknown` — closes #173.
- A condition with no `.status` at all yet (not yet reported by the controller/kubelet) is now treated the same as `status:"Unknown"` instead of being asserted as `False`.
- `Unknown` keeps its own yellow rather than being folded into the red used for a confirmed `False`, since missing information isn't a confirmed fault.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Regenerated `tests/artifacts/*.out` via `make update-artifacts`, plus the `include-all-volumes`/`absolute-time` golden variants it doesn't cover
- [x] Manually updated `tests/e2e-artifacts/*.regex` fixtures to match (these only run against a live cluster via `make test-e2e`, not available in this environment — worth a live e2e run before merging to confirm)
- [x] Rebased onto master (`a657f51`) to pick up #757/#766; the one conflict was in `tests/e2e-artifacts/node-metrics-multi-namespace.regex`, where master added a `kubelet ok ...` line to the same block — resolved by keeping master's new line alongside the `Type:Status` condition lines. Master's `conditions_summary` change (skipping content-free conditions) is orthogonal to this PR's `condition_summary` change and merged cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
