### PR TITLE
Don't let typeless placeholder conditions look like node problems

### DIFF
--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -39,7 +39,10 @@ type cmdTest struct {
 
 // createBadNode creates a synthetic Node (no real kubelet backs it) that's cordoned, tainted,
 // and reporting NotReady/MemoryPressure -- everything pod_node_problems/pod_node_problem_flags
-// are meant to surface. It registers cleanup and returns the Node's name.
+// are meant to surface. It also carries the content-free placeholder condition real clusters are
+// seen leaving behind (an empty type with nothing but a status and heartbeats, see #768), which
+// must stay invisible in every render; that rides along here rather than on the cluster's own
+// Node, which no test ever mutates. It registers cleanup and returns the Node's name.
 func createBadNode(t *testing.T, clientset *kubernetes.Clientset) string {
 	t.Helper()
 	node := &corev1.Node{
@@ -78,6 +81,12 @@ func createBadNode(t *testing.T, clientset *kubernetes.Clientset) string {
 				Status:             corev1.ConditionTrue,
 				Reason:             "KubeletHasInsufficientMemory",
 				Message:            "kubelet has insufficient memory available",
+				LastTransitionTime: metav1.Now(),
+			},
+			{
+				Type:               "",
+				Status:             corev1.ConditionFalse,
+				LastHeartbeatTime:  metav1.Now(),
 				LastTransitionTime: metav1.Now(),
 			},
 		}

--- a/cmd/e2e_pod_scheduling_test.go
+++ b/cmd/e2e_pod_scheduling_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,23 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 			args:            []string{"pod/pod-on-bad-node", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-on-bad-node.regex",
 		}.assert(t, nil, opts...)
+
+		// The Node also carries a content-free placeholder condition (empty type, nothing but a
+		// status and heartbeats -- see createBadNode and #768). It must stay invisible in both
+		// the Pod's node-problem flags and the Node's own conditions summary, so that a Node
+		// genuinely worth flagging isn't also reported with problems it doesn't have. These are
+		// absence assertions, which a .regex fixture can't express (assert.Regexp only says what
+		// the output must contain), hence the inline checks.
+		for _, args := range [][]string{
+			{"pod/pod-on-bad-node", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			{"node/" + nodeName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+		} {
+			stdout, _, err := executeCMD(t, args, opts...)
+			require.NoError(t, err)
+			assert.Contains(t, stdout, "Ready:False", "the node's real conditions should still render")
+			assert.NotContains(t, stdout, "empty condition type")
+			assert.NotContains(t, stdout, "node :False")
+		}
 	})
 	t.Run("pod's serviceAccountName resolves to the ServiceAccount and surfaces automount/imagePullSecrets", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -183,7 +183,10 @@
                 {{- $unhealthy := list }}
                 {{- $memoryPressure := false }}
                 {{- range $node.StatusConditions }}
-                    {{- if not (isStatusConditionHealthy .) }}
+                    {{- /* Skip content-free placeholder entries (empty type, no reason/message),
+                           same as conditions_summary in common.tmpl -- flagging the Node as
+                           problematic over one would be a false alarm. */ -}}
+                    {{- if and (or .type .reason .message) (not (isStatusConditionHealthy .)) }}
                         {{- $unhealthy = append $unhealthy . }}
                         {{- if and (eq .type "MemoryPressure") (eq .status "True") }}
                             {{- $memoryPressure = true }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -318,11 +318,13 @@
 {{- define "conditions_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- range .StatusConditions }}
-        {{- /* Some controllers leave placeholder entries in status.conditions carrying neither a
-               type nor a status; they hold no information, so drop them silently rather than
-               rendering an "<empty condition type!>" warning. A typeless entry that does have a
-               status is a real, if malformed, condition and still gets the warning. */ -}}
-        {{- if or .type (hasKey (. | default dict) "status") }}
+        {{- /* Some controllers leave placeholder entries in status.conditions with an empty type;
+               a bare status ("False" with only heartbeat timestamps, as seen on Nodes) says
+               nothing without a type to attach it to, so drop those silently rather than
+               rendering an "<empty condition type!>" warning. A typeless entry carrying a reason
+               or a message does hold information and still gets the warning, so the text isn't
+               lost. */ -}}
+        {{- if or .type .reason .message }}
   {{ template "condition_summary" . }}
         {{- end }}
     {{- end }}
@@ -629,28 +631,38 @@
     {{- /* Expects the Pod RenderableObject. Returns a compact, comma-joined inline fragment (no
            leading separator) naming Node-side problems that explain trouble with this Pod --
            unhealthy conditions, cordoned state, untolerated taints -- or "" when there's nothing
-           to report. Used where a single-line-per-pod summary is needed; see "pod_node_problems"
-           in Pod.tmpl for the fuller per-condition block used on the Pod's own render. */ -}}
+           to report. Everything read off the Node's own state is grouped behind a single "node "
+           prefix and "&"-joined ("node cordoned & Ready:False & MemoryPressure:True") rather than
+           repeating "node " per flag, which read like several separate findings. Used where a
+           single-line-per-pod summary is needed; see "pod_node_problems" in Pod.tmpl for the
+           fuller per-condition block used on the Pod's own render. */ -}}
     {{- $nodeName := get .Spec "nodeName" }}
     {{- if $nodeName }}
         {{- $node := .KubeGetFirst "" "Node" $nodeName }}
         {{- if $node.Object }}
-            {{- $flags := list }}
-            {{- if $node.Spec.unschedulable }}{{ $flags = append $flags ("node cordoned" | red | bold) }}{{ end }}
+            {{- $nodeFlags := list }}
+            {{- if $node.Spec.unschedulable }}{{ $nodeFlags = append $nodeFlags ("cordoned" | red | bold) }}{{ end }}
             {{- range $node.StatusConditions }}
-                {{- if not (isStatusConditionHealthy .) }}
+                {{- /* Typeless placeholder entries carry no information to report and would
+                       render as a meaningless ":False" flag, so they're skipped here; this whole
+                       fragment is built from type:status pairs, see #768. */ -}}
+                {{- if and .type (not (isStatusConditionHealthy .)) }}
                     {{- /* Always show the raw type:status pair (e.g. "Ready:False",
                            "MemoryPressure:True") rather than a reworded label like "NotReady" --
                            status:"Unknown" is missing information, not a confirmed fault, so it's
                            flagged separately in yellow rather than folded into the same red
                            "confirmed bad" label, see #173. */ -}}
-                    {{- $entry := printf "node %s:%s" .type (.status | toString) }}
+                    {{- $entry := printf "%s:%s" .type (.status | toString) }}
                     {{- if eq .status "Unknown" }}
-                        {{- $flags = append $flags ($entry | yellow | bold) }}
+                        {{- $nodeFlags = append $nodeFlags ($entry | yellow | bold) }}
                     {{- else }}
-                        {{- $flags = append $flags ($entry | red | bold) }}
+                        {{- $nodeFlags = append $nodeFlags ($entry | red | bold) }}
                     {{- end }}
                 {{- end }}
+            {{- end }}
+            {{- $flags := list }}
+            {{- with $nodeFlags }}
+                {{- $flags = append $flags (printf "node %s" (join " & " .)) }}
             {{- end }}
             {{- if taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}
                 {{- $flags = append $flags ("untolerated node taint" | red | bold) }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -1,6 +1,9 @@
 package plugin
 
 import (
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -8,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/resource"
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
@@ -116,17 +120,32 @@ func TestConditionsSummaryTemplate(t *testing.T) {
 			conditions: []interface{}{map[string]interface{}{"type": "Ready", "status": "True"}},
 			want:       "Ready",
 		}, {
-			name:       "condition with neither type nor status is silently skipped",
-			conditions: []interface{}{map[string]interface{}{"message": "no type here"}},
+			name:       "condition with no type key at all is silently skipped",
+			conditions: []interface{}{map[string]interface{}{"status": "True"}},
 			notWant:    "empty condition type",
 		}, {
-			name:       "typeless condition with a status still warns",
-			conditions: []interface{}{map[string]interface{}{"status": "True"}},
+			// Nodes are seen carrying such a placeholder entry, see #768. An explicit empty type
+			// is skipped just like a missing one -- both are equally content-free.
+			name: "typeless condition with only a status and heartbeats is silently skipped",
+			conditions: []interface{}{map[string]interface{}{
+				"type":               "",
+				"status":             "False",
+				"lastHeartbeatTime":  "2026-07-27T20:56:37Z",
+				"lastTransitionTime": "2026-07-23T10:34:38Z",
+			}},
+			notWant: "empty condition type",
+		}, {
+			name:       "typeless condition with a message still warns",
+			conditions: []interface{}{map[string]interface{}{"status": "True", "message": "no type here"}},
+			want:       "empty condition type",
+		}, {
+			name:       "typeless condition with a reason still warns",
+			conditions: []interface{}{map[string]interface{}{"status": "True", "reason": "NoTypeHere"}},
 			want:       "empty condition type",
 		}, {
 			name: "skipping one condition keeps the others",
 			conditions: []interface{}{
-				map[string]interface{}{"message": "no type here"},
+				map[string]interface{}{"status": "False", "type": ""},
 				map[string]interface{}{"type": "Ready", "status": "True"},
 			},
 			want:    "Ready",
@@ -144,6 +163,89 @@ func TestConditionsSummaryTemplate(t *testing.T) {
 			}
 			if tt.notWant != "" && strings.Contains(got, tt.notWant) {
 				t.Errorf("conditions_summary got = %q, should not contain %q", got, tt.notWant)
+			}
+		})
+	}
+}
+
+// TestPodNodeProblemFlags covers #768 on the Pod side: a Node carrying a content-free placeholder
+// condition (empty type, only a status and heartbeats) must not make every Pod scheduled on it
+// look like it's sitting on a broken Node. The unhealthy case is kept alongside as a control, so
+// the skip case can't pass just because the Node lookup silently returned nothing.
+func TestPodNodeProblemFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		spec       string
+		conditions string
+		want       string
+	}{
+		{
+			name:       "typeless placeholder condition is not a node problem",
+			conditions: `{"type":"Ready","status":"True"},{"type":"","status":"False","lastHeartbeatTime":"2026-07-27T20:56:37Z","lastTransitionTime":"2026-07-23T10:34:38Z"}`,
+			want:       "",
+		}, {
+			name:       "genuinely unhealthy condition is still a node problem",
+			conditions: `{"type":"Ready","status":"False"}`,
+			want:       "node Ready:False",
+		}, {
+			// Everything read off the Node shares one "node " prefix, joined with "&", so it
+			// reads as one finding about one Node rather than several unrelated ones. A
+			// placeholder condition in the middle must not leave a stray "&" behind either.
+			name:       "everything the node itself reports is grouped behind one node prefix",
+			spec:       `"unschedulable":true`,
+			conditions: `{"type":"Ready","status":"False"},{"type":"","status":"False"},{"type":"MemoryPressure","status":"True"}`,
+			want:       "node cordoned & Ready:False & MemoryPressure:True",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := fmt.Sprintf(`{"apiVersion":"v1","kind":"Node","metadata":{"name":"node-1"},"spec":{%s},"status":{"conditions":[%s]}}`, tt.spec, tt.conditions)
+			f := cmdtesting.NewTestFactory().WithNamespace("test")
+			f.UnstructuredClient = &fake.RESTClient{
+				NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+				Client: fake.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     cmdtesting.DefaultHeader(),
+						Body:       io.NopCloser(strings.NewReader(node)),
+					}, nil
+				}),
+			}
+			f.Client = f.UnstructuredClient
+			t.Cleanup(func() { f.Cleanup() })
+			cfg := NewRenderConfig(viper.New())
+			tmpl, _ := getTemplate(cfg)
+			repo, err := input.NewResourceRepo(f, cfg.Viper)
+			if err != nil {
+				t.Fatal(err)
+			}
+			e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+			e.Template = *tmpl
+			pod := newRenderableObject(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata":   map[string]interface{}{"name": "pod-1", "namespace": "test"},
+				"spec":       map[string]interface{}{"nodeName": "node-1"},
+			}, e, repo)
+			got, err := pod.renderTemplate("pod_node_problem_flags", pod)
+			if err != nil {
+				t.Fatalf("renderTemplate() error = %v", err)
+			}
+			if strings.TrimSpace(got) != tt.want {
+				t.Errorf("pod_node_problem_flags got = %q, want %q", got, tt.want)
+			}
+			// pod_health_summary is where those flags actually reach a reader (it renders one
+			// line per Pod under a Job/ReplicaSet/PDB/...), so it's asserted on directly rather
+			// than trusted to pass the fragment through unchanged.
+			summary, err := pod.renderTemplate("pod_health_summary", map[string]interface{}{"pod": pod})
+			if err != nil {
+				t.Fatalf("renderTemplate() error = %v", err)
+			}
+			if tt.want == "" && strings.Contains(summary, "node ") {
+				t.Errorf("pod_health_summary got = %q, want no node problems reported", summary)
+			}
+			if tt.want != "" && !strings.Contains(summary, tt.want) {
+				t.Errorf("pod_health_summary got = %q, should contain %q", summary, tt.want)
 			}
 		})
 	}

--- a/tests/artifacts/node-empty-condition.out
+++ b/tests/artifacts/node-empty-condition.out
@@ -1,0 +1,11 @@
+
+Node/node-with-empty-condition, created 1m ago
+  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
+  images 13
+  Current: Resource is Ready
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
+  addresses: InternalIP=192.168.99.102 Hostname=minikube
+  allocatable/capacity: pods 110/110, cpu 2/2, mem 1.9/2GB, ephemeral-storage 16.3/18.2GB

--- a/tests/artifacts/node-empty-condition.yaml
+++ b/tests/artifacts/node-empty-condition.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    kubeadm.alpha.kubernetes.io/cri-socket: /var/run/dockershim.sock
+    node.alpha.kubernetes.io/ttl: "0"
+    volumes.kubernetes.io/controller-managed-attach-detach: "true"
+  creationTimestamp: "2020-02-24T20:05:52Z"
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: minikube
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/master: ""
+  name: node-with-empty-condition
+  resourceVersion: "381343"
+  selfLink: /api/v1/nodes/minikube
+  uid: b2665321-4843-4c32-8e45-4fdb7024c4d7
+spec: {}
+status:
+  addresses:
+  - address: 192.168.99.102
+    type: InternalIP
+  - address: minikube
+    type: Hostname
+  allocatable:
+    cpu: "2"
+    ephemeral-storage: "16390427417"
+    hugepages-2Mi: "0"
+    memory: 1884340Ki
+    pods: "110"
+  capacity:
+    cpu: "2"
+    ephemeral-storage: 17784752Ki
+    hugepages-2Mi: "0"
+    memory: 1986740Ki
+    pods: "110"
+  conditions:
+  - lastHeartbeatTime: "2020-03-18T17:24:40Z"
+    lastTransitionTime: "2020-02-24T20:05:47Z"
+    message: kubelet has sufficient memory available
+    reason: KubeletHasSufficientMemory
+    status: "False"
+    type: MemoryPressure
+  - lastHeartbeatTime: "2020-03-18T17:24:40Z"
+    lastTransitionTime: "2020-02-24T20:05:47Z"
+    message: kubelet has no disk pressure
+    reason: KubeletHasNoDiskPressure
+    status: "False"
+    type: DiskPressure
+  - lastHeartbeatTime: "2020-03-18T17:24:40Z"
+    lastTransitionTime: "2020-02-24T20:05:47Z"
+    message: kubelet has sufficient PID available
+    reason: KubeletHasSufficientPID
+    status: "False"
+    type: PIDPressure
+  - lastHeartbeatTime: "2020-03-18T17:24:40Z"
+    lastTransitionTime: "2020-02-24T20:06:06Z"
+    message: kubelet is posting ready status
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+  - lastHeartbeatTime: "2020-03-18T17:24:40Z"
+    lastTransitionTime: "2020-02-24T20:05:47Z"
+    status: "False"
+    type: ""
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
+  images:
+  - names:
+    - kennethreitz/httpbin@sha256:599fe5e5073102dbb0ee3dbb65f049dab44fa9fc251f6835c9990f8fb196a72b
+    - kennethreitz/httpbin:latest
+    sizeBytes: 533675008
+  - names:
+    - k8s.gcr.io/etcd:3.4.3-0
+    sizeBytes: 288426917
+  - names:
+    - k8s.gcr.io/kube-apiserver:v1.17.3
+    sizeBytes: 170986003
+  - names:
+    - k8s.gcr.io/kube-controller-manager:v1.17.3
+    sizeBytes: 160918035
+  - names:
+    - k8s.gcr.io/kube-proxy:v1.17.3
+    sizeBytes: 115964919
+  - names:
+    - k8s.gcr.io/nginx-slim@sha256:8b4501fe0fe221df663c22e16539f399e89594552f400408303c42f3dd8d0e52
+    - k8s.gcr.io/nginx-slim:0.8
+    sizeBytes: 110487599
+  - names:
+    - k8s.gcr.io/kube-scheduler:v1.17.3
+    sizeBytes: 94435859
+  - names:
+    - kubernetesui/dashboard:v2.0.0-beta8
+    sizeBytes: 90835427
+  - names:
+    - gcr.io/k8s-minikube/storage-provisioner:v1.8.1
+    sizeBytes: 80815640
+  - names:
+    - k8s.gcr.io/coredns:1.6.5
+    sizeBytes: 41578211
+  - names:
+    - kubernetesui/metrics-scraper:v1.0.2
+    sizeBytes: 40101552
+  - names:
+    - busybox@sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135
+    - busybox:latest
+    sizeBytes: 1219590
+  - names:
+    - k8s.gcr.io/pause:3.1
+    sizeBytes: 742472
+  nodeInfo:
+    architecture: amd64
+    bootID: ec3cbcb4-67a8-406e-88f3-8baaa046f2bd
+    containerRuntimeVersion: docker://19.3.6
+    kernelVersion: 4.19.94
+    kubeProxyVersion: v1.17.3
+    kubeletVersion: v1.17.3
+    machineID: bf994b721cbb401db323f6d994cbe3c7
+    operatingSystem: linux
+    osImage: Buildroot 2019.02.9
+    systemUUID: b1d82a2f-42a0-417d-a2b2-017d5c21e14c

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -1,1 +1,1 @@
-Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned, node Ready:False, node MemoryPressure:True, untolerated node taint
+Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned & Ready:False & MemoryPressure:True, untolerated node taint

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -1,1 +1,9 @@
-Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned & Ready:False & MemoryPressure:True, untolerated node taint
+\A
+ReplicaSet/bad-rs -n e2e-bad-node-rs, created 1m ago, gen:1
+  InProgress: Available: 0/1
+    Reconciling: LessAvailable, Available: 0/1
+  Selector: app=kubectl-status-test-bad-rs
+    Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned & Ready:False & MemoryPressure:True, untolerated node taint
+  Not matched by any Service
+  Outage: ReplicaSet has no Ready replicas\.
+\z


### PR DESCRIPTION
## Problem

#768 skipped conditions carrying neither a type nor a status. But the placeholder entries real clusters actually leave on Nodes *do* carry a status:

```yaml
  - lastHeartbeatTime: "2026-07-27T20:56:37Z"
    lastTransitionTime: "2026-07-23T10:34:38Z"
    status: "False"
    type: ""
```

so they kept rendering as `<empty condition type!>`, and worse, they leaked into both node-problem paths — making *every* Pod on such a Node look like it was sitting on a broken one:

```
Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned, node Ready:False, node MemoryPressure:True, node :False, untolerated node taint
```

## Fix

- **`conditions_summary`** — a bare status says nothing without a type to attach it to; what makes a typeless entry worth warning about is a `reason` or a `message`, which would otherwise be lost. The skip is now based on that. A missing `type` key and an explicit `""` are equally content-free, and both are skipped.
- **`pod_node_problem_flags`** (reached via `pod_health_summary`, one line per Pod under a Job/ReplicaSet/PDB/...) — skips typeless entries, so no more phantom `node :False`.
- **`pod_node_problems`** in `Pod.tmpl` (the Pod's own Node block) — same skip.

## Also: grouped node flags

`pod_node_problem_flags` now groups everything read off the Node behind a single `node ` prefix instead of repeating it per flag, which read like several separate findings:

```
Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned & Ready:False & MemoryPressure:True, untolerated node taint
```

Untolerated taints stay a separate comma-separated flag — that's a Pod/Node *pairing* problem, not something the Node reports about itself.

## Coverage

- The fabricated e2e Node (`createBadNode`) now carries a placeholder condition, so the existing bad-node subtests exercise this, with inline absence assertions (a `.regex` fixture can't express absence — `assert.Regexp` only says what output must contain). The cluster's own Node is left untouched; no test has ever mutated it.
- `tests/artifacts/node-empty-condition.{yaml,out}` — static fixture reproducing the reported Node.
- Unit tests over `conditions_summary`, `pod_node_problem_flags` and `pod_health_summary`, the latter two with an unhealthy-node control case so they can't pass just because the Node lookup returned nothing.

Every new assertion was verified to fail with the guards reverted, and the e2e subtests were run against a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)