### PR TITLE
Require every e2e regex fixture to pin the whole rendered output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,9 +213,14 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 
 ### Running e2e Tests Locally
 
-`make test-e2e` runs the `TestE2E*` suite against a real cluster (see `cmd/main_test.go`). It
-manages one **shared** minikube cluster/profile (`kstat-e2e-shared`), reused across every
-worktree, branch, and session on your machine — not one per branch/session. Run
+`make test-e2e` runs the `TestE2E*` suite against a real cluster. That suite has two top-level
+entry points — `TestE2EParallel` (`cmd/main_test.go`), which calls one topical `runXSubtests`
+function per `cmd/e2e_*_test.go` file, and `TestE2EDynamicManifests` (`cmd/e2e_dynamic_test.go`) —
+sharing the harness in `cmd/e2e_helpers_test.go` (`cmdTest`, `applyManifest`/`waitFor`, the
+`ensureX` dependency installers). `cmd/local_test.go` holds the tests that need no cluster and so
+run under plain `make test` instead. `make test-e2e` manages one **shared** minikube
+cluster/profile (`kstat-e2e-shared`), reused across every worktree, branch, and session on your
+machine — not one per branch/session. Run
 `make print-e2e-profile` to see the profile name and kubeconfig path (`~/.kstat-e2e/shared.kubeconfig`)
 it uses. `install-e2e-deps` (cert-manager, Gateway API CRDs) runs against that same cluster right
 after it's created, so deps always land on the cluster the tests actually use. The cluster is left
@@ -279,15 +284,16 @@ check should use, not the full suite.
 
 When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.Include`,
 or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`
-(`cmd/main_test.go`) plus matching manifests/regex fixtures under `tests/e2e-artifacts/`. The
+(`cmd/e2e_dynamic_test.go`) plus matching manifests/regex fixtures under `tests/e2e-artifacts/`. The
 offline golden-file tests (`TestAllArtifactsLocal*`) run with `--shallow` (alongside `--local`,
 since there's no live cluster to query either way), which makes `KubeGetFirst` a no-op — they
 can't exercise the "found the related object" or `--deep` include branches, so the live e2e suite
 is the only place that covers them.
 
-Prefer a whole-output `.regex` fixture (`stdoutRegexPath`) over ad hoc `assert.Contains`/
-`assert.Regexp` calls scattered through the subtest, unless you're only asserting on a couple of
-one-off lines. A single regex covering the full rendered output, matched with `\A`...`\z` anchors
+Assert on stdout with a whole-output `.regex` fixture (`stdoutRegexPath`, or
+`assertStdoutMatchesRegexFixture` when the subtest also needs to assert something the fixture can't
+express) rather than ad hoc `assert.Contains`/`assert.Regexp` calls scattered through the subtest.
+A single regex covering the full rendered output, matched with `\A`...`\z` anchors
 (see the existing `tests/e2e-artifacts/*.regex` files for the pattern), lets a reviewer diff the
 expected output like a golden `.out` file and catches regressions anywhere in the render, not just
 in the specific substrings an inline assertion happens to check. Use `[0-9.]+[A-Za-z]+` and similar
@@ -300,17 +306,16 @@ text. One gotcha: the regex file must not have a trailing newline after the fina
 asserts absolute end-of-text, so a trailing newline in the fixture file makes the pattern
 impossible to satisfy.
 
-A fixture is either a whole-output match, anchored at both ends with `\A`...`\z`, or a deliberately
-partial one-off-lines match, anchored at neither end — never just one of the two anchors. A lone
-`\A` (or a lone `\z`) almost always means the fixture was meant to be a whole-output match but lost
-its other anchor while being edited, silently stopped verifying whatever now falls outside the
-anchored end, and started rendering the file misleading to read as "full output" when it isn't.
-`TestE2ERegexFixturesAreAnchored` in `cmd/main_test.go` enforces this pairing across every fixture
-under `tests/e2e-artifacts/`; it doesn't need a live cluster, so it also runs in `make test`/CI.
-If some part of an object's output is noisy or not worth pinning, don't drop to a partial fixture
-to dodge it — trim that section from the render instead with the relevant `--include-*` flag
-(`--include-events=false`, `--include-managed-fields=false`, etc.) and keep the fixture anchored
-and whole.
+Every fixture is a whole-output match, anchored at both ends with `\A`...`\z` — partial fixtures
+that pin a line or two out of the middle of the render aren't allowed. A partial fixture silently
+stops verifying everything outside what it happens to match, and reads to the next person like
+"this is the full output" when it isn't. `TestE2ERegexFixturesAreAnchored` in `cmd/local_test.go`
+enforces both anchors across every fixture under `tests/e2e-artifacts/`; it doesn't need a live
+cluster, so it also runs in `make test`/CI. If some part of an object's output is noisy or not
+worth pinning, don't drop to a partial fixture to dodge it — trim that section from the render
+instead with the relevant `--include-*` flag (`--include-events=false`,
+`--include-managed-fields=false`, etc.), or match it with a tolerant pattern, and keep the fixture
+anchored and whole.
 
 Pass `--include-events=false --include-managed-fields=false` on every e2e `cmdTest` unless the
 subtest is specifically exercising events or managed fields. Both sections list real cluster data

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ test-e2e: vet staticcheck install-e2e-deps
 	# gotestsum runs go test with -v under the hood (so full per-subtest logs are still
 	# captured) but only prints them for failing tests, collapsing a green run to one line
 	# per package (default --format=pkgname) -- the ~60 fixture/scenario subtests in
-	# cmd/main_test.go otherwise flood the terminal with "=== RUN"/"--- PASS" and t.Logf
+	# cmd/e2e_*_test.go otherwise flood the terminal with "=== RUN"/"--- PASS" and t.Logf
 	# noise on every green run.
 	# -parallel=4: bounds how many TestE2EParallel subtests hit the cluster at once. Go's
 	# default (GOMAXPROCS, i.e. host core count) can far exceed what the e2e-minikube-up VM

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -27,6 +27,26 @@ import (
 	"github.com/bergerx/kubectl-status/pkg/plugin"
 )
 
+// neverSchedulingGate is a spec.schedulingGates entry nothing ever removes, which parks a Pod in
+// Pending indefinitely: PodScheduled:False SchedulingGated, no container statuses, no node. A
+// subtest that only cares about a spec-driven section (the ServiceAccount/PriorityClass/
+// RuntimeClass lookups) gates its Pod so the whole-output fixture isn't racing the scheduler and
+// kubelet through Scheduled -> ContainerCreating -> Running -> the exit/restart cycle of whatever
+// image it used. Preferred over pointing spec.nodeName at a Node that doesn't exist, which parks
+// the Pod just as well but leaves it for the pod-GC controller to reap on its own ~40s timer.
+const neverSchedulingGate = "kubectl-status.example.com/never-schedule"
+
+// gatedPodSpecWith returns a PodSpec for a Pod that stays Pending forever (see
+// neverSchedulingGate), with the field the caller's subtest is actually about set on it.
+func gatedPodSpecWith(set func(*corev1.PodSpec)) corev1.PodSpec {
+	spec := corev1.PodSpec{
+		SchedulingGates: []corev1.PodSchedulingGate{{Name: neverSchedulingGate}},
+		Containers:      []corev1.Container{{Name: "app", Image: "busybox"}},
+	}
+	set(&spec)
+	return spec
+}
+
 type cmdTest struct {
 	name            string
 	args            []string
@@ -85,11 +105,49 @@ func createBadNode(t *testing.T, clientset *kubernetes.Clientset) string {
 		return err
 	})
 	require.NoError(t, err)
+	// The node-lifecycle-controller mirrors the conditions set above into taints, and callers pin
+	// the full rendered taint list -- so wait for it to have caught up rather than racing it.
+	// node.kubernetes.io/unschedulable comes from Spec.Unschedulable and is already there.
+	wantTaints := []string{
+		"dedicated",
+		corev1.TaintNodeUnschedulable,
+		corev1.TaintNodeNotReady,
+		corev1.TaintNodeMemoryPressure,
+	}
+	require.Eventuallyf(t, func() bool {
+		latest, err := clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		have := map[string]bool{}
+		for _, taint := range latest.Spec.Taints {
+			have[taint.Key] = true
+		}
+		for _, key := range wantTaints {
+			if !have[key] {
+				return false
+			}
+		}
+		return true
+	}, time.Minute, time.Second, "Node/%s never got all of the expected taints %v", node.Name, wantTaints)
 	return node.Name
 }
 
 func nodeNameModifier(stdout string) string {
 	return string(regexp.MustCompile(`Node/[a-z0-9-]+`).ReplaceAll([]byte(stdout), []byte(`Node/minikube`)))
+}
+
+// assertStdoutMatchesRegexFixture matches stdout against the regex in tests/<fixture> (a path
+// relative to tests/, e.g. "e2e-artifacts/node-query.regex"). Fixtures are whole-output matches
+// anchored with \A...\z (see CONTRIBUTING.md), and are matched in (?ms) mode so `.` spans the
+// newlines between output lines. Subtests that assert on stdout beyond the fixture match (an
+// extra NotContains sweep, say) call this directly; the rest go through cmdTest.stdoutRegexPath.
+func assertStdoutMatchesRegexFixture(t *testing.T, stdout, fixture string) {
+	t.Helper()
+	outFile := path.Join("..", "tests", fixture)
+	regexBytes, err := os.ReadFile(outFile)
+	assert.NoErrorf(t, err, "failed to read test artifact file: %s", outFile)
+	assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
 }
 
 func (c cmdTest) assert(t *testing.T, stdoutModifier func(string) string, opts ...func(*plugin.RenderConfig)) {
@@ -108,11 +166,7 @@ func (c cmdTest) assert(t *testing.T, stdoutModifier func(string) string, opts .
 		assert.NoErrorf(t, err, "failed to read test artifact file: %s", outFile)
 		assert.Equal(t, string(out), stdout)
 	case c.stdoutRegexPath != "":
-		outFile := path.Join("..", "tests", c.stdoutRegexPath)
-		regexBytes, err := os.ReadFile(outFile)
-		assert.NoErrorf(t, err, "failed to read test artifact file: %s", outFile)
-		regex := `(?ms)` + string(regexBytes)
-		assert.Regexp(t, regex, stdout)
+		assertStdoutMatchesRegexFixture(t, stdout, c.stdoutRegexPath)
 	}
 	switch {
 	case c.stderrRegex == "" && c.stderrEqual == "":

--- a/cmd/e2e_pod_scheduling_test.go
+++ b/cmd/e2e_pod_scheduling_test.go
@@ -51,7 +51,7 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 	})
 	t.Run("pod's serviceAccountName resolves to the ServiceAccount and surfaces automount/imagePullSecrets", func(t *testing.T) {
 		t.Parallel()
-		opts := combineOpts(viperTestHackOpts())
+		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-pod-custom-sa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
@@ -90,10 +90,9 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				Name:      "pod-with-custom-sa",
 				Namespace: ns,
 			},
-			Spec: corev1.PodSpec{
-				ServiceAccountName: sa.Name,
-				Containers:         []corev1.Container{{Name: "app", Image: "busybox"}},
-			},
+			Spec: gatedPodSpecWith(func(spec *corev1.PodSpec) {
+				spec.ServiceAccountName = sa.Name
+			}),
 		}
 		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -113,7 +112,7 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		// serviceAccountName after admission, so the Pod is left referencing a name that no
 		// longer resolves, which is exactly the "doesn't exist" case being tested -- just
 		// reached via drift instead of an upfront invalid manifest.
-		opts := combineOpts(viperTestHackOpts())
+		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-pod-missing-sa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
@@ -133,10 +132,9 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				Name:      "pod-missing-service-account",
 				Namespace: ns,
 			},
-			Spec: corev1.PodSpec{
-				ServiceAccountName: sa.Name,
-				Containers:         []corev1.Container{{Name: "app", Image: "busybox"}},
-			},
+			Spec: gatedPodSpecWith(func(spec *corev1.PodSpec) {
+				spec.ServiceAccountName = sa.Name
+			}),
 		}
 		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -163,7 +161,7 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		// plugin will also copy overhead.podFixed into this Pod's own spec.overhead, but Pod.tmpl
 		// reads it from the fetched RuntimeClass object, not spec.overhead, so that duplication
 		// doesn't undermine what's being verified here.
-		opts := combineOpts(viperTestHackOpts())
+		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-pod-runtimeclass-overhead"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
@@ -193,10 +191,9 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				Name:      "pod-with-runtimeclass-overhead",
 				Namespace: ns,
 			},
-			Spec: corev1.PodSpec{
-				RuntimeClassName: &rc.Name,
-				Containers:       []corev1.Container{{Name: "app", Image: "busybox"}},
-			},
+			Spec: gatedPodSpecWith(func(spec *corev1.PodSpec) {
+				spec.RuntimeClassName = &rc.Name
+			}),
 		}
 		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -209,7 +206,7 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 	})
 	t.Run("pod's priorityClassName resolves to the PriorityClass and surfaces value/globalDefault/preemptionPolicy", func(t *testing.T) {
 		t.Parallel()
-		opts := combineOpts(viperTestHackOpts())
+		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-pod-priorityclass"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
@@ -238,10 +235,9 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				Name:      "pod-with-priorityclass",
 				Namespace: ns,
 			},
-			Spec: corev1.PodSpec{
-				PriorityClassName: pc.Name,
-				Containers:        []corev1.Container{{Name: "app", Image: "busybox"}},
-			},
+			Spec: gatedPodSpecWith(func(spec *corev1.PodSpec) {
+				spec.PriorityClassName = pc.Name
+			}),
 		}
 		_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -301,6 +297,12 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		_, err = clientset.AppsV1().ReplicaSets(ns).Create(context.TODO(), rs, metav1.CreateOptions{})
 		require.NoError(t, err)
 		defer clientset.AppsV1().ReplicaSets(ns).Delete(context.TODO(), rs.Name, metav1.DeleteOptions{})
+
+		// The status summary reports the first count that falls short, so it reads "Labelled: 0/1"
+		// until the ReplicaSet controller has counted the (already existing) matching Pod into
+		// fullyLabeledReplicas and only then settles on "Available: 0/1" -- wait for that, rather
+		// than pinning whichever of the two the render happened to catch.
+		waitForInNamespace(t, "rs/bad-rs", "jsonpath={.status.fullyLabeledReplicas}=1", ns)
 
 		cmdTest{
 			args:            []string{"rs/bad-rs", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},

--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -44,9 +42,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("secret/leaf shows full non-self-signed certificate detail", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"secret/e2e-tls-leaf-tls", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-secret-leaf.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-secret-leaf.regex")
 			// The secret also carries a ca.crt (the self-signed root CA cert), which
 			// legitimately renders its own "Self-signed:" line further down -- scope the
 			// check to the leaf cert's own block, which precedes it.
@@ -68,9 +64,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("ingress with matching hostname is healthy", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"ingress/e2e-tls-ingress-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-ingress-healthy.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-ingress-healthy.regex")
 			for _, problem := range []string{
 				"doesn't exist",
 				"wrong type:",
@@ -103,9 +97,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("gateway with matching hostname is healthy", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"gateway/e2e-tls-gw-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-gateway-healthy.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-gateway-healthy.regex")
 			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:"} {
 				assert.NotContains(t, stdout, problem)
 			}
@@ -120,9 +112,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("grpcroute attached to healthy gateway listener shows no cert flags", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"grpcroute/e2e-tls-grpcroute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-grpcroute-healthy.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-grpcroute-healthy.regex")
 			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:", "doesn't exist"} {
 				assert.NotContains(t, stdout, problem)
 			}
@@ -137,9 +127,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("tlsroute attached to Terminate listener with matching hostname is healthy", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-tlsroute-healthy.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-tlsroute-healthy.regex")
 			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:", "doesn't exist"} {
 				assert.NotContains(t, stdout, problem)
 			}
@@ -153,9 +141,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("tlsroute attached to a Passthrough listener shows no cert flags", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-passthrough", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-tlsroute-passthrough.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-tlsroute-passthrough.regex")
 			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:", "doesn't exist"} {
 				assert.NotContains(t, stdout, problem)
 			}
@@ -164,9 +150,7 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		t.Run("httproute attached to a healthy listener is healthy", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
-			regexBytes, rerr := os.ReadFile(path.Join("..", "tests", "e2e-artifacts", "tls-validation-httproute-healthy.regex"))
-			require.NoError(t, rerr)
-			assert.Regexp(t, `(?ms)`+string(regexBytes), stdout)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-httproute-healthy.regex")
 			for _, problem := range []string{"doesn't exist", "wrong type:", "missing keys:", "parse error:", "self-signed", "hostname mismatch"} {
 				assert.NotContains(t, stdout, problem)
 			}

--- a/cmd/e2e_vanilla_test.go
+++ b/cmd/e2e_vanilla_test.go
@@ -11,6 +11,7 @@ func TestE2EAgainstVanillaMinikube(t *testing.T) {
 	hackOpts := testHackOpts(t)
 	klog.InitFlags(nil)
 	t.Log("starting tests...")
+	applyManifest(t, "e2e-artifacts/pods-in-namespace.yaml")
 	tests := []cmdTest{
 		{
 			name:        "empty call should print an error and usage",
@@ -22,13 +23,23 @@ func TestE2EAgainstVanillaMinikube(t *testing.T) {
 			stderrRegex: `error: no resources found\n$`,
 		},
 		{
-			name:            "pods on kube-system ns should return storage-provisioner",
-			args:            []string{"pods", "-n", "kube-system", "--include-events=false", "--include-managed-fields=false"},
-			stdoutRegexPath: "e2e-artifacts/pods-kube-system.regex",
+			// Renders against a namespace this test owns rather than kube-system: the pods there
+			// belong to the cluster, so their images, replica-hash names, restart counts and live
+			// usage all move with the minikube/Kubernetes version and with whatever else the
+			// shared cluster has been doing, none of which a whole-output fixture can pin.
+			name:            "pods in a namespace should render every pod in it",
+			args:            []string{"pods", "-n", "e2e-pods-in-namespace", "--include-events=false", "--include-managed-fields=false"},
+			stdoutRegexPath: "e2e-artifacts/pods-in-namespace.regex",
 		},
 		{
-			name:            "node query should return at least a node",
-			args:            []string{"node", "--include-events=false", "--include-managed-fields=false"},
+			// The kubelet-api-summary and detailed-usage sections are per-pod views of whatever
+			// else happens to be running on the shared cluster (a "pods needing attention" list
+			// keyed off restart counts, a pod-by-usage table ordered by live memory), so they
+			// can't be pinned in a whole-output fixture -- turn them off rather than settle for
+			// matching only the parts of the Node render that are stable.
+			name: "node query should return at least a node",
+			args: []string{"node", "--include-events=false", "--include-managed-fields=false",
+				"--include-node-kubelet-api-summary=false", "--include-node-detailed-usage=false"},
 			stdoutRegexPath: "e2e-artifacts/node-query.regex",
 		},
 		{

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -93,12 +93,11 @@ func TestDeepRespectsExplicitIncludeFalse(t *testing.T) {
 }
 
 // TestE2ERegexFixturesAreAnchored guards the whole-output convention documented in
-// CONTRIBUTING.md: a fixture under tests/e2e-artifacts/ either pins the full rendered output,
-// anchored at both ends with `\A`...`\z`, or is a deliberately partial one-off-lines match with
-// neither anchor. A fixture with only one of the two anchors is neither -- almost always a fixture
-// that was meant to be anchored but lost its `\z` (or gained a stray `\A`) while being edited, so
-// it silently stopped verifying the parts of the output past/before the missing anchor. This
-// doesn't require a live cluster, so it runs unconditionally.
+// CONTRIBUTING.md: every fixture under tests/e2e-artifacts/ pins the full rendered output, anchored
+// at both ends with `\A`...`\z`. A fixture missing either anchor is a partial match -- it silently
+// stops verifying whatever falls outside the part it happens to match, while still reading like the
+// full output to the next person who edits it. This doesn't require a live cluster, so it runs
+// unconditionally.
 func TestE2ERegexFixturesAreAnchored(t *testing.T) {
 	fixtures, err := filepath.Glob("../tests/e2e-artifacts/*.regex")
 	require.NoError(t, err)
@@ -110,11 +109,11 @@ func TestE2ERegexFixturesAreAnchored(t *testing.T) {
 			require.NoError(t, err)
 			startsAnchored := bytes.HasPrefix(content, []byte(`\A`))
 			endsAnchored := bytes.HasSuffix(content, []byte(`\z`))
-			if startsAnchored != endsAnchored {
-				t.Errorf("%s: has `\\A` at the start=%v but `\\z` at the end=%v -- a whole-output "+
-					"fixture needs both anchors (see CONTRIBUTING.md), a partial one-off-lines "+
-					"fixture needs neither; use the --include-* flags to trim sections you don't "+
-					"want to pin instead of matching only part of the output",
+			if !startsAnchored || !endsAnchored {
+				t.Errorf("%s: starts with `\\A`=%v, ends with `\\z`=%v -- every fixture must pin "+
+					"the whole rendered output between both anchors (see CONTRIBUTING.md); use the "+
+					"--include-* flags to trim sections you don't want to pin, or a tolerant "+
+					"pattern to match them, instead of matching only part of the output",
 					fixture, startsAnchored, endsAnchored)
 			}
 		})

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -85,7 +85,7 @@ var testHackNow = time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
 // appears is otherwise a coin flip; this forces it present whenever Status.startTime is set.
 //
 // Both the "--test-hack" CLI flag (cmd/main.go, used by `make update-artifacts`/`make
-// new-artifact`) and the e2e test suite (cmd/main_test.go) call this, so the artifacts generated
+// new-artifact`) and the e2e test suite (cmd/e2e_*_test.go) call this, so the artifacts generated
 // on disk and the output the tests compare against can never drift apart.
 func ApplyTestHack(cfg *RenderConfig) {
 	cfg.Now = func() time.Time { return testHackNow }

--- a/tests/e2e-artifacts/node-query.regex
+++ b/tests/e2e-artifacts/node-query.regex
@@ -1,1 +1,14 @@
-Node/
+\A
+Node/[a-z0-9-]+, created 1m ago
+  linux [^\n]+ \(amd64\), kernel [^\n,]+, kubelet v[0-9][^\n,]*, kube-proxy , runtime [a-z]+://[0-9][^\n,]*
+  images [0-9]+
+  Current: Resource is Ready
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
+  addresses: InternalIP=[0-9.]+ Hostname=[a-z0-9-]+
+  allocatable/capacity: pods [0-9]+/[0-9]+, cpu [0-9]+/[0-9]+, mem [0-9.]+/[0-9.]+[A-Za-z]+, ephemeral-storage [0-9.]+/[0-9.]+[A-Za-z]+
+  cpu: usage/allocatable:[0-9.]+/[0-9]+\([0-9]+%\)
+  mem: usage/allocatable:[0-9.]+[A-Za-z]+/[0-9.]+[A-Za-z]+\([0-9]+%\)
+\z

--- a/tests/e2e-artifacts/pod-missing-service-account.regex
+++ b/tests/e2e-artifacts/pod-missing-service-account.regex
@@ -1,1 +1,10 @@
-ServiceAccount/will-be-deleted doesn't exist, but it's referenced as the serviceAccountName\.
+\A
+Pod/pod-missing-service-account -n e2e-pod-missing-sa, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+  ServiceAccount/will-be-deleted doesn't exist, but it's referenced as the serviceAccountName\.
+\z

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -1,1 +1,9 @@
-Pod/pod-on-bad-node-for-rs[^\n]*, node cordoned, node Ready:False, node MemoryPressure:True, untolerated node taint
+\A
+ReplicaSet/bad-rs -n e2e-bad-node-rs, created 1m ago, gen:1
+  InProgress: Available: 0/1
+    Reconciling: LessAvailable, Available: 0/1
+  Selector: app=kubectl-status-test-bad-rs
+    Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned, node Ready:False, node MemoryPressure:True, untolerated node taint
+  Not matched by any Service
+  Outage: ReplicaSet has no Ready replicas\.
+\z

--- a/tests/e2e-artifacts/pod-on-bad-node.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node.regex
@@ -1,5 +1,16 @@
-Node/kubectl-status-test-bad-node-[a-z0-9]+ cordoned \(unschedulable\)
-.*Ready:False KubeletNotReady, kubelet is not ready.*
-.*MemoryPressure:True KubeletHasInsufficientMemory, kubelet has insufficient memory available.*
-.*taint dedicated=gpu:NoSchedule \(not tolerated\)
-.*OOM / eviction risk.*Node kubectl-status-test-bad-node-[a-z0-9]+ has MemoryPressure.*Pod is BestEffort.*
+\A
+Pod/pod-on-bad-node -n e2e-bad-node-pod, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:Unknown -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+  Node/kubectl-status-test-bad-node-[a-z0-9]+ cordoned \(unschedulable\)
+    Ready:False KubeletNotReady, kubelet is not ready for 1m
+    MemoryPressure:True KubeletHasInsufficientMemory, kubelet has insufficient memory available for 1m
+    taint dedicated=gpu:NoSchedule \(not tolerated\)
+    taint node\.kubernetes\.io/unschedulable:NoSchedule \(not tolerated\)
+(?:    taint node\.kubernetes\.io/memory-pressure:NoSchedule \(not tolerated\)
+    taint node\.kubernetes\.io/not-ready:NoSchedule \(not tolerated\)|    taint node\.kubernetes\.io/not-ready:NoSchedule \(not tolerated\)
+    taint node\.kubernetes\.io/memory-pressure:NoSchedule \(not tolerated\))
+  OOM / eviction risk: Node kubectl-status-test-bad-node-[a-z0-9]+ has MemoryPressure\. Pod is BestEffort, the first kubelet eviction candidate under node memory pressure and has essentially no kernel-OOM protection\. Pod Priority affects eviction order, not OOM protection\.
+  Standalone POD\.
+\z

--- a/tests/e2e-artifacts/pod-with-custom-sa.regex
+++ b/tests/e2e-artifacts/pod-with-custom-sa.regex
@@ -1,1 +1,10 @@
-ServiceAccount/kubectl-status-test-sa, automountServiceAccountToken: false, imagePullSecrets: regcred
+\A
+Pod/pod-with-custom-sa -n e2e-pod-custom-sa, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+  ServiceAccount/kubectl-status-test-sa, automountServiceAccountToken: false, imagePullSecrets: regcred
+\z

--- a/tests/e2e-artifacts/pod-with-priorityclass.regex
+++ b/tests/e2e-artifacts/pod-with-priorityclass.regex
@@ -1,1 +1,10 @@
-Priority: PriorityClass/e2e-test-priority \(value: 1000000, global default, preemptionPolicy: Never\)
+\A
+Pod/pod-with-priorityclass -n e2e-pod-priorityclass, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+  Priority: PriorityClass/e2e-test-priority \(value: 1000000, global default, preemptionPolicy: Never\)
+\z

--- a/tests/e2e-artifacts/pod-with-runtimeclass-overhead.regex
+++ b/tests/e2e-artifacts/pod-with-runtimeclass-overhead.regex
@@ -1,1 +1,10 @@
-Overhead: RuntimeClass/e2e-test-gvisor \(cpu: [0-9.]+, memory: [0-9.]+[A-Za-z]+\)
+\A
+Pod/pod-with-runtimeclass-overhead -n e2e-pod-runtimeclass-overhead, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+  Overhead: RuntimeClass/e2e-test-gvisor \(cpu: 0\.2, memory: 67\.1MB\)
+\z

--- a/tests/e2e-artifacts/pods-in-namespace.regex
+++ b/tests/e2e-artifacts/pods-in-namespace.regex
@@ -1,0 +1,17 @@
+\A
+Pod/pods-in-namespace-first -n e2e-pods-in-namespace, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+
+Pod/pods-in-namespace-second -n e2e-pods-in-namespace, created 1m ago, gen:1 Pending BestEffort
+  InProgress: Pod is in the Pending phase
+    Reconciling: PodPending, Pod is in the Pending phase
+  PodScheduled:False -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
+    PodScheduled:False SchedulingGated, Scheduling is blocked due to non-empty scheduling gates for 1m
+    Scheduling gate: kubectl-status\.example\.com/never-schedule
+  Standalone POD\.
+\z

--- a/tests/e2e-artifacts/pods-in-namespace.yaml
+++ b/tests/e2e-artifacts/pods-in-namespace.yaml
@@ -1,0 +1,36 @@
+# Fixture for the "pods in a namespace" list query in TestE2EAgainstVanillaMinikube: a namespace
+# holding more than one Pod, so the query renders several objects in one go.
+#
+# Both Pods carry the never-removed scheduling gate from cmd/e2e_helpers_test.go
+# (neverSchedulingGate), which parks them in Pending forever. That's what makes the render
+# reproducible: an ungated busybox Pod would race the scheduler and kubelet through
+# ContainerCreating -> Running -> exited -> CrashLoopBackOff while the suite runs, and none of
+# those states can be pinned in a whole-output fixture.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-pods-in-namespace
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pods-in-namespace-first
+  namespace: e2e-pods-in-namespace
+spec:
+  schedulingGates:
+    - name: kubectl-status.example.com/never-schedule
+  containers:
+    - name: app
+      image: busybox
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pods-in-namespace-second
+  namespace: e2e-pods-in-namespace
+spec:
+  schedulingGates:
+    - name: kubectl-status.example.com/never-schedule
+  containers:
+    - name: app
+      image: busybox

--- a/tests/e2e-artifacts/pods-kube-system.regex
+++ b/tests/e2e-artifacts/pods-kube-system.regex
@@ -1,1 +1,0 @@
-Pod/[a-z0-9-]+ -n kube-system

--- a/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service-deep.regex
@@ -1,3 +1,9 @@
-Ingresses matching this Service:
+\A
+Service/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, last endpoint change was 1m ago
+  Current: Service is ready
+  Ready: Pod/sts-with-ingress-0 on Node/[a-z0-9-]+, 1\.1\.1\.1:80/TCP
+  Ingresses matching this Service:
     Ingress/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, gen:1
       Current: Resource is current
+      Service/sts-with-ingress, created 1m ago, ClusterIP, 1 ready, 80/TCP
+\z

--- a/tests/e2e-artifacts/sts-with-ingress.service.regex
+++ b/tests/e2e-artifacts/sts-with-ingress.service.regex
@@ -1,2 +1,7 @@
-Ingresses matching this Service:
-    Ingress/sts-with-ingress, created 1m ago, sts-with-ingress\.com, [^\n]*Current
+\A
+Service/sts-with-ingress -n e2e-sts-with-ingress, created 1m ago, last endpoint change was 1m ago
+  Current: Service is ready
+  Ready: Pod/sts-with-ingress-0 on Node/[a-z0-9-]+, 1\.1\.1\.1:80/TCP
+  Ingresses matching this Service:
+    Ingress/sts-with-ingress, created 1m ago, sts-with-ingress\.com, Pending LoadBalancer, Current
+\z

--- a/tests/e2e-artifacts/sts-with-nodeport.sts.regex
+++ b/tests/e2e-artifacts/sts-with-nodeport.sts.regex
@@ -1,4 +1,9 @@
+\A
+StatefulSet/sts-with-nodeport -n e2e-sts-nodeport, created 1m ago, gen:1
+  Current: Partition rollout complete\. updated: 1
   Selector: app=sts-with-nodeport
     Pod/sts-with-nodeport-0, created 1m ago Running, 1/1 ready
   Services: Service/sts-with-nodeport, created 1m ago, NodePort, 1 ready, http\(80/TCP\)→30081
   PodDisruptionBudgets: PodDisruptionBudget/sts-with-nodeport, created 1m ago, min available=1, evictions/drains currently blocked
+  desired:1, existing:1, ready:1, current:1, updated:1, available:1
+\z

--- a/tests/e2e-artifacts/tls-validation-gateway-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-gateway-healthy.regex
@@ -1,1 +1,10 @@
-TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls
+\A
+Gateway/e2e-tls-gw-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Class: e2e-tls-unused-gwc
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
+  Listeners:
+    https: port=443/HTTPS, host=e2e-tls\.example\.com, namespaces=Same
+      TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls
+\z

--- a/tests/e2e-artifacts/tls-validation-gateway-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-gateway-mismatch.regex
@@ -1,1 +1,10 @@
-TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+\A
+Gateway/e2e-tls-gw-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Class: e2e-tls-unused-gwc
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
+  Listeners:
+    https: port=443/HTTPS, host=wrong-host\.example\.com, namespaces=Same
+      TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+\z

--- a/tests/e2e-artifacts/tls-validation-grpcroute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-grpcroute-healthy.regex
@@ -1,1 +1,10 @@
-cert:Secret/e2e-tls-leaf-tls
+\A
+GRPCRoute/e2e-tls-grpcroute-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-healthy \[https\]
+      cert:Secret/e2e-tls-leaf-tls
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-grpcroute-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-grpcroute-mismatch.regex
@@ -1,1 +1,10 @@
-cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+\A
+GRPCRoute/e2e-tls-grpcroute-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: wrong-route-host\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-mismatch \[https\]
+      cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
@@ -1,1 +1,11 @@
-HTTPRoute/e2e-tls-httproute-healthy -n e2e-tls-validation, created .* ago, gen:1
+\A
+HTTPRoute/e2e-tls-httproute-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-healthy \[https\]
+      , cert:Secret/e2e-tls-leaf-tls
+  Rules:
+    PathPrefix /
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-httproute-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-mismatch.regex
@@ -1,1 +1,11 @@
-cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+\A
+HTTPRoute/e2e-tls-httproute-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: wrong-host\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-mismatch \[https\]
+      , cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+  Rules:
+    PathPrefix /
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-ingress-deep.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-deep.regex
@@ -1,3 +1,25 @@
-Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created .* ago, gen:1.*
-    Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created .* ago.*
+\A
+Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Service/e2e-tls-svc, created 1m ago, ClusterIP, no matching pods, http\(80/TCP\)
+    Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created 1m ago
+      Managed by
+        Certificate/e2e-tls-leaf -n e2e-tls-validation, created 1m ago, gen:1
+          Current: Resource is Ready
+          Issued by Issuer/e2e-tls-ca-issuer for "e2e-tls\.example\.com" · stored in Secret/e2e-tls-leaf-tls
+            Also valid for: e2e-tls-alt\.example\.com
+          Issued [0-9]{4}-[0-9]{2}-[0-9]{2} \(1m ago\), expires [0-9]{4}-[0-9]{2}-[0-9]{2}, auto-renews [0-9]{4}-[0-9]{2}-[0-9]{2} · rev 1
+          Ready:True Ready, Certificate is up to date and has not expired for 1m
+        Issuer/e2e-tls-ca-issuer -n e2e-tls-validation, created 1m ago, gen:1
+          Current: Resource is Ready
+          Backend: CA · signing key in Secret/e2e-tls-root-ca-secret
+          Ready:True KeyPairVerified, Signing CA verified for 1m
       Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca
+        Also valid for: e2e-tls-alt\.example\.com
+        Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+        Key: RSA · serial [0-9]+
+      Certificate \(ca\.crt\) for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
+        Self-signed: issuer and subject match, not issued by a separate CA
+        Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+        Key: RSA · serial [0-9]+
+\z

--- a/tests/e2e-artifacts/tls-validation-ingress-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-healthy.regex
@@ -1,1 +1,5 @@
-Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created .* ago, gen:1
+\A
+Ingress/e2e-tls-ingress-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Service/e2e-tls-svc, created 1m ago, ClusterIP, no matching pods, http\(80/TCP\)
+\z

--- a/tests/e2e-artifacts/tls-validation-ingress-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-mismatch.regex
@@ -1,1 +1,6 @@
-Secret/e2e-tls-leaf-tls certificate doesn't match host wrong-host\.example\.com\.
+\A
+Ingress/e2e-tls-ingress-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Service/e2e-tls-svc, created 1m ago, ClusterIP, no matching pods, http\(80/TCP\)
+  Secret/e2e-tls-leaf-tls certificate doesn't match host wrong-host\.example\.com\.
+\z

--- a/tests/e2e-artifacts/tls-validation-ingress-selfsigned.regex
+++ b/tests/e2e-artifacts/tls-validation-ingress-selfsigned.regex
@@ -1,1 +1,7 @@
-Secret/e2e-tls-root-ca-secret certificate is self-signed, used for host\(s\) \[.*\]\.
+\A
+Ingress/e2e-tls-ingress-selfsigned -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Service/e2e-tls-svc, created 1m ago, ClusterIP, no matching pods, http\(80/TCP\)
+  Secret/e2e-tls-root-ca-secret certificate is self-signed, used for host\(s\) \[e2e-tls\.example\.com\]\.
+  Secret/e2e-tls-root-ca-secret certificate doesn't match host e2e-tls\.example\.com\.
+\z

--- a/tests/e2e-artifacts/tls-validation-secret-leaf-deep.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-leaf-deep.regex
@@ -1,9 +1,22 @@
-Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created .* ago
+\A
+Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created 1m ago
   Managed by
-    Certificate/e2e-tls-leaf -n e2e-tls-validation, created .* ago, gen:1
+    Certificate/e2e-tls-leaf -n e2e-tls-validation, created 1m ago, gen:1
       Current: Resource is Ready
-      Issued by Issuer/e2e-tls-ca-issuer for "e2e-tls\.example\.com" · stored in Secret/e2e-tls-leaf-tls.*
-    Issuer/e2e-tls-ca-issuer -n e2e-tls-validation, created .* ago, gen:1
+      Issued by Issuer/e2e-tls-ca-issuer for "e2e-tls\.example\.com" · stored in Secret/e2e-tls-leaf-tls
+        Also valid for: e2e-tls-alt\.example\.com
+      Issued [0-9]{4}-[0-9]{2}-[0-9]{2} \(1m ago\), expires [0-9]{4}-[0-9]{2}-[0-9]{2}, auto-renews [0-9]{4}-[0-9]{2}-[0-9]{2} · rev 1
+      Ready:True Ready, Certificate is up to date and has not expired for 1m
+    Issuer/e2e-tls-ca-issuer -n e2e-tls-validation, created 1m ago, gen:1
       Current: Resource is Ready
-      Backend: CA · signing key in Secret/e2e-tls-root-ca-secret.*
+      Backend: CA · signing key in Secret/e2e-tls-root-ca-secret
+      Ready:True KeyPairVerified, Signing CA verified for 1m
   Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca
+    Also valid for: e2e-tls-alt\.example\.com
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+  Certificate \(ca\.crt\) for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
+    Self-signed: issuer and subject match, not issued by a separate CA
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+\z

--- a/tests/e2e-artifacts/tls-validation-secret-leaf.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-leaf.regex
@@ -1,6 +1,12 @@
-Secret/e2e-tls-leaf-tls.*
+\A
+Secret/e2e-tls-leaf-tls -n e2e-tls-validation, created 1m ago
   Managed by Certificate/e2e-tls-leaf via Issuer/e2e-tls-ca-issuer \(cert-manager\.io\)
   Certificate for CN=e2e-tls\.example\.com · issued by CN=e2e-tls-root-ca
     Also valid for: e2e-tls-alt\.example\.com
-    Valid [^,]+, expires \d{4}-\d{2}-\d{2} \(in 1m\)
-    Key: RSA .*
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+  Certificate \(ca\.crt\) for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
+    Self-signed: issuer and subject match, not issued by a separate CA
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+\z

--- a/tests/e2e-artifacts/tls-validation-secret-root.regex
+++ b/tests/e2e-artifacts/tls-validation-secret-root.regex
@@ -1,4 +1,12 @@
-Secret/e2e-tls-root-ca-secret.*
+\A
+Secret/e2e-tls-root-ca-secret -n e2e-tls-validation, created 1m ago
   Managed by Certificate/e2e-tls-root-ca via Issuer/e2e-tls-root-issuer \(cert-manager\.io\)
   Certificate for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
     Self-signed: issuer and subject match, not issued by a separate CA
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+  Certificate \(ca\.crt\) for CN=e2e-tls-root-ca · issued by CN=e2e-tls-root-ca
+    Self-signed: issuer and subject match, not issued by a separate CA
+    Valid 1m ago, expires [0-9]{4}-[0-9]{2}-[0-9]{2} \(in 1m\)
+    Key: RSA · serial [0-9]+
+\z

--- a/tests/e2e-artifacts/tls-validation-tlsroute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-healthy.regex
@@ -1,1 +1,9 @@
-Gateway/e2e-tls-gw-tlsroute \[tls-term\]
+\A
+TLSRoute/e2e-tlsroute-healthy -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-tlsroute \[tls-term\]
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-tlsroute-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-mismatch.regex
@@ -1,1 +1,9 @@
-Gateway/e2e-tls-gw-tlsroute \[tls-term\], hostname mismatch
+\A
+TLSRoute/e2e-tlsroute-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: wrong-host\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-tlsroute \[tls-term\], hostname mismatch
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-tlsroute-passthrough.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-passthrough.regex
@@ -1,1 +1,9 @@
-Gateway/e2e-tls-gw-tlsroute \[tls-passthrough\]
+\A
+TLSRoute/e2e-tlsroute-passthrough -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: passthrough\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-tlsroute \[tls-passthrough\]
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/vapbinding-orphan-policy.regex
+++ b/tests/e2e-artifacts/vapbinding-orphan-policy.regex
@@ -1,3 +1,5 @@
-ValidatingAdmissionPolicyBinding/e2e-orphan-binding, created .* ago, gen:1
+\A
+ValidatingAdmissionPolicyBinding/e2e-orphan-binding, created 1m ago, gen:1
   Policy: ValidatingAdmissionPolicy/e2e-does-not-exist \(not found\)
   Actions: Deny
+\z


### PR DESCRIPTION
## Why

`TestE2ERegexFixturesAreAnchored` only checked that a fixture's two anchors *agreed* — `\A` at the start iff `\z` at the end. A fixture with **neither** anchor passed, because CONTRIBUTING.md carved out "deliberately partial one-off-lines" matches as a legitimate second shape.

28 of the 96 fixtures under `tests/e2e-artifacts/` were that shape. Several pinned a single line out of a multi-section render and verified nothing else — `node-query.regex` was literally the two characters `Node/`.

## What

Drop the carve-out. The guard now requires both anchors on every fixture, and all 28 partial ones are rewritten as whole-output matches.

Four needed the *subtest* made deterministic first, not just a wider regex — in each case two capture runs against the shared cluster already disagreed:

| Fixture(s) | Non-determinism | Fix |
|---|---|---|
| `pod-with-custom-sa`, `pod-missing-service-account`, `pod-with-priorityclass`, `pod-with-runtimeclass-overhead` | Rendered immediately after creation, racing scheduler + kubelet through `Pending` → `ContainerCreating` → `Running` → busybox's exit/restart cycle. Runs disagreed on `created 0s ago` vs `created  ago`, and `PodScheduled` isn't reliably present yet. | Park the Pod on a scheduling gate nothing removes (`gatedPodSpecWith`), so it stays Pending for good; add `testHackOpts` to freeze durations. |
| `pod-on-bad-node` | `createBadNode` returned before node-lifecycle-controller mirrored the conditions into taints — and the two taints it adds come back **in either order** (both orderings observed). | `require.Eventuallyf` on all four taints; fixture matches both orderings via an alternation. |
| `pod-on-bad-node-for-rs` | Summary reports the first count that falls short: `Labelled: 0/1` until `fullyLabeledReplicas` catches up, `Available: 0/1` after. | `waitFor` `.status.fullyLabeledReplicas=1`. |
| `node-query` | Node render embeds a pod-by-usage table ordered by live memory and a "pods needing attention" list keyed off restart counts — i.e. whatever else the shared cluster is running. | Pass `--include-node-kubelet-api-summary=false --include-node-detailed-usage=false`. |

`pods-kube-system` is replaced by `pods-in-namespace.{yaml,regex}` — a scratch namespace with two gated Pods. Rendering all of kube-system pins objects the *cluster* owns (image tags, replica-hash names, restart counts, kubeadm's volume lists), all of which move with the minikube/Kubernetes version, and neither the Makefile nor `ci-test.yml` pins that version. The dedicated namespace keeps the list-many-Pods-in-one-query coverage without it.

Also fixes the stale `cmd/main_test.go` references left over from splitting the e2e suite into `cmd/e2e_*_test.go` — in CONTRIBUTING.md, the Makefile, and `pkg/plugin/template_functions_static.go`.

## Testing

- `go test ./...` passes, including the tightened guard.
- Full `TestE2E*` suite against the shared minikube cluster: passes. Every fixture subtest is green, including all 28 converted ones.
- Note: `staticcheck` can't build in my local environment (Go toolchain mismatch) and two `TestE2EDynamicManifests` subtests skip on missing `helm`. Both pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
