### PR TITLE
Reorder the Node resource-usage lines and trim its version line

### DIFF
--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -2,7 +2,10 @@
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject */ -}}
     {{- template "status_summary_line" . }}
     {{- template "application_details" . }}
-    {{- .Status.nodeInfo.operatingSystem | bold | nindent 2 }} {{ .Status.nodeInfo.osImage }} ({{ .Status.nodeInfo.architecture }}), kernel {{ .Status.nodeInfo.kernelVersion }}, kubelet {{ .Status.nodeInfo.kubeletVersion }}, kube-proxy {{ .Status.nodeInfo.kubeProxyVersion }}, runtime {{ .Status.nodeInfo.containerRuntimeVersion }}
+    {{- .Status.nodeInfo.operatingSystem | bold | nindent 2 }} {{ .Status.nodeInfo.osImage }} ({{ .Status.nodeInfo.architecture }}), kernel {{ .Status.nodeInfo.kernelVersion }}, kubelet {{ .Status.nodeInfo.kubeletVersion }}
+    {{- /* kubeProxyVersion is deprecated and left unset from k8s 1.31 on, so the whole clause goes
+           rather than leaving a bare label behind on newer clusters. */ -}}
+    {{- with .Status.nodeInfo.kubeProxyVersion }}, kube-proxy {{ . }}{{ end }}, {{ .Status.nodeInfo.containerRuntimeVersion }}
     {{- if or (index .Labels "node.kubernetes.io/instance") (index .Labels "topology.kubernetes.io/region") (index .Labels "failure-domain.beta.kubernetes.io/region") (index .Labels "topology.kubernetes.io/zone") (index .Labels "failure-domain.beta.kubernetes.io/region") }}
         {{- "cloudprovider" | bold | nindent 2 }}
         {{- with index .Labels "topology.kubernetes.io/region" | default (index .Labels "failure-domain.beta.kubernetes.io/region") }} {{ . }}{{ end }}
@@ -220,33 +223,6 @@
                 {{- $podsNeedingAttention = append $podsNeedingAttention (dict "key" (printf "%s/%s" $pod.Namespace $pod.Name) "pod" $pod) }}
             {{- end }}
         {{- end }}
-        {{- with $podsNeedingAttention }}
-            {{- /* Not all entries here are unhealthy right now: a Running/Ready pod with a past
-                   restart is included too, since restart count is itself a signal worth a node
-                   operator's attention (see #178), just a milder one than being stuck
-                   Pending/NotReady. */ -}}
-            {{- "pods needing attention" | bold | nindent 2 }}:
-            {{- range . | sortMapListByKeysValue "key" }}
-                {{- "" | nindent 4 }}{{ template "pod_health_summary" (dict "pod" .pod) }}
-            {{- end }}
-        {{- end }}
-        {{- $inferredBurstableMemLimit := $allocMem | subFloat64 $podsTotalMemRequestsGuaranteed }}
-        {{- $inferredBestEffortMemLimit := $inferredBurstableMemLimit | subFloat64 $podsTotalMemRequestsBurstable }}
-        {{- "Inferred memory limits" | nindent 2 }} for BestEffort: {{ $inferredBestEffortMemLimit | humanizeSI "B" }}, for Burstable: {{ $inferredBurstableMemLimit | humanizeSI "B" }}
-    {{- end }}
-    {{- /* Pod slots and pid slots are the same question -- how many more things can this node still
-           run -- so the kubelet's rlimit counters share the pods line instead of sitting in a
-           separate stats block. */ -}}
-    {{- if or $detailed $stats.rlimit }}
-        {{- "pods" | bold | nindent 2 }}:
-        {{- if $detailed }} usage/allocatable:{{ $podCount }}/{{ $allocPods | printf "%g" }}({{ percent ($podCount | float64) $allocPods | colorPercent "%.0f%%" }}){{ end }}
-        {{- with $stats.rlimit }}
-            {{- if $detailed }},{{ end }} processes {{ .curproc | float64 | humanizeSI "" }}/{{ .maxpid | float64 | humanizeSI "" }} ({{ percent (.curproc | float64) (.maxpid | float64) | colorPercent "%.0f%%" }}, rlimit)
-            {{- template "node_eviction_annotation" (dict "threshold" (index $evictionHard "pid.available") "current" (subFloat64 (.curproc | float64) (.maxpid | float64)) "total" (.maxpid | float64) "unit" "") }}
-        {{- end }}
-        {{- if and $detailed (eq ($podCount | float64) $allocPods) }}
-            {{- "Reached Max Pods Limit" | red | bold | nindent 4 }}: Number of Pods that can run on this Kubelet (`--max-pods`) limit is reached. No more pods will be scheduled to this Node even if there is free resource (E.g. cpu/mem).
-        {{- end }}
     {{- end }}
     {{- if $nodeUsage }}
         {{- "cpu" | bold | nindent 2 }}: usage/allocatable:{{ $nodeUsage.cpu | quantityToFloat64 | printf "%g" }}/
@@ -288,6 +264,14 @@
         {{- template "node_stats_resources" (dict "data" $stats "full" (not $nodeUsage)
             "memAvailThreshold" (index $evictionHard "memory.available") "memAvailTotal" $allocMem) }}
     {{- end }}
+    {{- /* How much memory a not-yet-scheduled BestEffort/Burstable pod could actually get: derived
+           from the same allocatable and per-QoS request totals the mem: line above is built from, so
+           it hangs under that line rather than standing on its own. */ -}}
+    {{- if $detailed }}
+        {{- $inferredBurstableMemLimit := $allocMem | subFloat64 $podsTotalMemRequestsGuaranteed }}
+        {{- $inferredBestEffortMemLimit := $inferredBurstableMemLimit | subFloat64 $podsTotalMemRequestsBurstable }}
+        {{- "Inferred memory limits" | nindent 4 }} for BestEffort: {{ $inferredBestEffortMemLimit | humanizeSI "B" }}, for Burstable: {{ $inferredBurstableMemLimit | humanizeSI "B" }}
+    {{- end }}
     {{- if and $nodeUsage $detailed (ge $podsTotalMemLimits $allocMem) }}
         {{- "Memory overcommitted" | red | bold | nindent 4 }}: Application may be OOMKilled. Expect BestEffort and then Burstable pods to have OOMKill due to overcommitted memory on the node.
     {{- end }}
@@ -312,6 +296,30 @@
     {{- end }}
     {{- with $podsStats }}
         {{- "pods" | bold | nindent 2 }}: {{ template "node_stats_resources" (dict "data" . "full" true "allocCpu" $allocCpu "allocMem" $allocMem) }}
+    {{- end }}
+    {{- /* Pod slots and pid slots are the same question -- how many more things can this node still
+           run -- so the kubelet's rlimit counters share the pods line instead of sitting in a
+           separate stats block. */ -}}
+    {{- if or $detailed $stats.rlimit }}
+        {{- "pods" | bold | nindent 2 }}:
+        {{- if $detailed }} usage/allocatable:{{ $podCount }}/{{ $allocPods | printf "%g" }}({{ percent ($podCount | float64) $allocPods | colorPercent "%.0f%%" }}){{ end }}
+        {{- with $stats.rlimit }}
+            {{- if $detailed }},{{ end }} processes {{ .curproc | float64 | humanizeSI "" }}/{{ .maxpid | float64 | humanizeSI "" }} ({{ percent (.curproc | float64) (.maxpid | float64) | colorPercent "%.0f%%" }}, rlimit)
+            {{- template "node_eviction_annotation" (dict "threshold" (index $evictionHard "pid.available") "current" (subFloat64 (.curproc | float64) (.maxpid | float64)) "total" (.maxpid | float64) "unit" "") }}
+        {{- end }}
+        {{- if and $detailed (eq ($podCount | float64) $allocPods) }}
+            {{- "Reached Max Pods Limit" | red | bold | nindent 4 }}: Number of Pods that can run on this Kubelet (`--max-pods`) limit is reached. No more pods will be scheduled to this Node even if there is free resource (E.g. cpu/mem).
+        {{- end }}
+    {{- end }}
+    {{- with $podsNeedingAttention }}
+        {{- /* Not all entries here are unhealthy right now: a Running/Ready pod with a past
+               restart is included too, since restart count is itself a signal worth a node
+               operator's attention (see #178), just a milder one than being stuck
+               Pending/NotReady. */ -}}
+        {{- "pods needing attention" | bold | nindent 2 }}:
+        {{- range . | sortMapListByKeysValue "key" }}
+            {{- "" | nindent 4 }}{{ template "pod_health_summary" (dict "pod" .pod) }}
+        {{- end }}
     {{- end }}
     {{- /* Only ever non-empty when the pod loop above ran and found per-pod metrics, so this needs
            no config/metrics guard of its own. */ -}}

--- a/tests/artifacts/node-aks.out
+++ b/tests/artifacts/node-aks.out
@@ -1,6 +1,6 @@
 
 Node/aks-cpuworkers-41776494-vmss00006u, created 1m ago
-  linux Ubuntu 16.04.6 LTS (amd64), kernel 4.15.0-1066-azure, kubelet v1.15.7, kube-proxy v1.15.7, runtime docker://3.0.8
+  linux Ubuntu 16.04.6 LTS (amd64), kernel 4.15.0-1066-azure, kubelet v1.15.7, kube-proxy v1.15.7, docker://3.0.8
   cloudprovider eastus0 Standard_D8s_v3, agentpool:cpuworkers, role:agent
   images 50 volumes inuse=1/16, attached=1
   Current: Resource is Ready

--- a/tests/artifacts/node-and-service.out
+++ b/tests/artifacts/node-and-service.out
@@ -1,6 +1,6 @@
 
 Node/minikube, created 1m ago
-  linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41-1-MANJARO, kubelet v1.30.0, kube-proxy v1.30.0, runtime docker://26.1.1
+  linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41-1-MANJARO, kubelet v1.30.0, kube-proxy v1.30.0, docker://26.1.1
   images 8
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m

--- a/tests/artifacts/node-empty-condition.out
+++ b/tests/artifacts/node-empty-condition.out
@@ -1,6 +1,6 @@
 
 Node/node-with-empty-condition, created 1m ago
-  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
+  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m

--- a/tests/artifacts/node-minikube-with-metrics.out
+++ b/tests/artifacts/node-minikube-with-metrics.out
@@ -1,6 +1,6 @@
 
 Node/minikube, created 1m ago
-  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
+  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m

--- a/tests/artifacts/node-minikube.out
+++ b/tests/artifacts/node-minikube.out
@@ -1,6 +1,6 @@
 
 Node/minikube, created 1m ago
-  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, runtime docker://19.3.6
+  linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -1,6 +1,6 @@
 \A
 Node/[a-z0-9.-]+, created \d+[a-z]+ ago
-  linux .+, kernel \S+, kubelet v[\d.]+, kube-proxy ?\S*, runtime \S+
+  linux .+, kernel \S+, kubelet v[\d.]+(?:, kube-proxy \S+)?, \S+
   images \d+
   Current: Resource is Ready
   kubelet ok(?:, \S+:\S+)*, container logs: retains up to [\d.]+[A-Za-z]+ per container \(\S+ x \d+ files\)
@@ -11,19 +11,19 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
   addresses: InternalIP=[\d.]+ Hostname=[a-z0-9.-]+
     network: rx/tx [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, rx/tx errors \d+/\d+
   allocatable/capacity: pods \d+/\d+, cpu [\d.]+/[\d.]+, mem [\d.]+/[\d.]+[A-Za-z]+, ephemeral-storage [\d.]+/[\d.]+[A-Za-z]+
-(?:  pods needing attention:
-(?:    \S+/\S+(?: -n \S+)?, .+
-)+)?  Inferred memory limits for BestEffort: [\d.]+[A-Za-z]+, for Burstable: [\d.]+[A-Za-z]+
-  pods: usage/allocatable:\d+/\d+\(\d+%\), processes \S+/\S+ \(\d+%, rlimit\)(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?
   cpu: usage/allocatable:[\d.]+/\d+\(\d+%\), allocated usage:[\d.]+\(\d+% of allocatable\)/\[req:[\d.]+\(\d+% of allocatable\), lim:[\d.]+\(\d+% of allocatable\)\](?:, reserved:\S+)?
   mem: usage/allocatable:[\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+\(\d+%\), allocated usage:[\d.]+[A-Za-z]+\(\d+% of allocatable\)/\[req:[\d.]+[A-Za-z]+\(\d+% of allocatable\), lim:[\d.]+[A-Za-z]+\(\d+% of allocatable\)\](?:, reserved:\S+)?
     rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?)?, pageFaults/major \S+/\S+
+    Inferred memory limits for BestEffort: [\d.]+[A-Za-z]+, for Burstable: [\d.]+[A-Za-z]+
 (?:  [a-z-]+: cpu [\d.]+core/sec \(\d+% of node\), mem [\d.]+[A-Za-z]+ \(\d+% of node\), workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+
 )*  ephemeral-storage: [\d.]+[A-Za-z]+(?:, reserved:\S+)?
 (?:    rootfs/imagefs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+ used of [\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))*; \S+/\S+ of \S+ inode, \S+ inode still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))*|    rootfs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?; \S+/\S+ inode, \S+ inode still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?(?:
     imagefs: [\d.]+[A-Za-z]+/[\d.]+[A-Za-z]+, [\d.]+[A-Za-z]+ still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?; \S+/\S+ inode, \S+ inode still free(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?)?)
   pods: cpu [\d.]+core/sec \(\d+% of node\), mem [\d.]+[A-Za-z]+ \(\d+% of node\), workingSet [\d.]+[A-Za-z]+, rss [\d.]+[A-Za-z]+(?:, available [\d.]+[A-Za-z]+)?, pageFaults/major \S+/\S+
-  pods by usage: \(most memory first\)
+  pods: usage/allocatable:\d+/\d+\(\d+%\), processes \S+/\S+ \(\d+%, rlimit\)(?: \([^)]*(?:nearing|TRIPPED)[^)]*\))?
+(?:  pods needing attention:
+(?:    \S+/\S+(?: -n \S+)?, .+
+)+)?  pods by usage: \(most memory first\)
     pod\s+cpu use/req/lim \(%allocatable\)\s+mem use/req/lim \(%allocatable\)
 (?:    \S+/\S+(?: -n \S+)?\s+[\d.]+\(\d+%\)\s+[\d.]+\(\d+%\)\s+[\d.]+\(\d+%\)\s+[\d.]+[A-Za-z]+\(\d+%\)\s+[\d.]+[A-Za-z]+\(\d+%\)\s+[\d.]+[A-Za-z]+\(\d+%\)
 )+\z

--- a/tests/e2e-artifacts/node-query.regex
+++ b/tests/e2e-artifacts/node-query.regex
@@ -1,6 +1,6 @@
 \A
 Node/[a-z0-9-]+, created 1m ago
-  linux [^\n]+ \(amd64\), kernel [^\n,]+, kubelet v[0-9][^\n,]*, kube-proxy , runtime [a-z]+://[0-9][^\n,]*
+  linux [^\n]+ \(amd64\), kernel [^\n,]+, kubelet v[0-9][^\n,]*(?:, kube-proxy v[0-9][^\n,]*)?, [a-z]+://[0-9][^\n,]*
   images [0-9]+
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m


### PR DESCRIPTION
Presentation-only changes to `Node.tmpl` — no new data, no behaviour change beyond where things render.

### Moves

- **`Inferred memory limits`** now hangs under the `mem:` line (indent 4) instead of standing on its own at indent 2. It is allocatable minus the per-QoS request totals, which is exactly what that line already reports.
- **`pods: usage/allocatable`** moves down to sit right after the kubelet's `pods: cpu …` stats line, so both `pods:` lines are adjacent.
- **`pods needing attention`** moves down to sit right before `pods by usage`, grouping the two per-pod sections.

Resulting detailed-mode order:

```
cpu: → mem: (→ rss/pageFaults → Inferred memory limits) → systemContainers
→ ephemeral-storage: → rootfs/imagefs → pods: cpu … → pods: usage/allocatable …
→ pods needing attention: → pods by usage:
```

### Version line

- Dropped the `runtime ` label — `docker://26.1.1` / `cri-o://1.34.5` already says what it is.
- `kubeProxyVersion` is deprecated and left unset from k8s 1.31 on, which rendered a bare `, kube-proxy ,` on newer clusters. The whole clause is now dropped when it is empty.

Before / after on a 1.31+ node:

```
-  linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41, kubelet v1.31.0, kube-proxy , runtime docker://26.1.1
+  linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41, kubelet v1.31.0, docker://26.1.1
```

### Fixtures

Five `tests/artifacts/node-*.out` files updated for the dropped `runtime ` label (all have `kubeProxyVersion` set, so they keep their `, kube-proxy vX` clause), and both e2e regex fixtures that pin the version line updated for the dropped label and the now-optional kube-proxy clause: `node-metrics-multi-namespace.regex` (also for the new line order) and `node-query.regex`.

`node-query.regex` was missed in the first push and failed CI — its minikube runs 1.35, which leaves `kubeProxyVersion` unset, so the rendered line has no kube-proxy clause at all. `go test ./...` can't catch that one; it only runs under `RUN_E2E_TESTS`.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
