### PR TITLE
Identify a Node's cloud provider from .spec.providerID

### DIFF
--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -138,6 +138,7 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"untilClause":                     cfg.untilClause,
 		"labelSelector":                   labelSelector,
 		"taintsNotToleratedByPod":         taintsNotToleratedByPod,
+		"nodeCloudProvider":               nodeCloudProvider,
 		"formatNodeSelector":              formatNodeSelector,
 		"formatNodeSelectorTerms":         formatNodeSelectorTerms,
 		"podHardConstraintRequirements":   podHardConstraintRequirements,
@@ -1039,6 +1040,68 @@ func taintsNotToleratedByPod(nodeTaints, tolerations []interface{}) (result []in
 		}
 	}
 	return result
+}
+
+// cloudProviderNames maps the scheme of a Node's .spec.providerID -- the
+// "<provider>://<provider-specific-id>" prefix naming the infrastructure that backs the node -- to
+// a display name. providerID is the only field in the Node object meant to identify the provider,
+// but it is optional and its format is provider-defined (see
+// https://github.com/kubernetes/kubernetes/issues/124348), so an unrecognized scheme is reported
+// verbatim rather than dropped: telling the reader the node says "ibmcloud" beats saying nothing.
+var cloudProviderNames = map[string]string{
+	"alicloud":     "Alibaba Cloud",
+	"aws":          "AWS",
+	"azure":        "Azure",
+	"digitalocean": "DigitalOcean",
+	"equinixmetal": "Equinix Metal",
+	"gce":          "GCP",
+	"hcloud":       "Hetzner",
+	"ibm":          "IBM Cloud",
+	"kind":         "kind",
+	"kwok":         "kwok",
+	"metal3":       "Metal3",
+	"oci":          "OCI",
+	"openstack":    "OpenStack",
+	"vsphere":      "vSphere",
+}
+
+// cloudProviderLabelPrefixes maps label namespaces only one provider's components ever set to that
+// provider. Weaker evidence than providerID -- a node can carry these while the cloud provider
+// integration itself is absent or half-configured -- so nodeCloudProvider qualifies a match found
+// this way. A slice rather than a map so a node carrying two of these namespaces always reports
+// the same provider instead of whichever one map iteration happened to reach first.
+var cloudProviderLabelPrefixes = []struct{ prefix, name string }{
+	{"eks.amazonaws.com/", "AWS"},
+	{"karpenter.k8s.aws/", "AWS"},
+	{"cloud.google.com/", "GCP"},
+	{"topology.gke.io/", "GCP"},
+	{"kubernetes.azure.com/", "Azure"},
+	{"doks.digitalocean.com/", "DigitalOcean"},
+	{"oci.oraclecloud.com/", "OCI"},
+	{"ibm-cloud.kubernetes.io/", "IBM Cloud"},
+}
+
+// nodeCloudProvider names the infrastructure backing a Node, preferring .spec.providerID (set by
+// the cloud provider itself) over provider-specific label namespaces (circumstantial, so the
+// returned name says where it came from). Returns "" when neither offers evidence, which the Node
+// template renders as no provider at all: node names, addresses and topology values all look like
+// they identify a provider and are all installation-specific, and to a reader mid-incident a
+// confidently wrong provider is worse than none.
+func nodeCloudProvider(providerID string, labels map[string]interface{}) string {
+	if scheme, _, found := strings.Cut(providerID, "://"); found && scheme != "" {
+		if name, ok := cloudProviderNames[strings.ToLower(scheme)]; ok {
+			return name
+		}
+		return scheme
+	}
+	for _, provider := range cloudProviderLabelPrefixes {
+		for key := range labels {
+			if strings.HasPrefix(key, provider.prefix) {
+				return provider.name + " (from labels)"
+			}
+		}
+	}
+	return ""
 }
 
 // formatNodeSelector renders spec.nodeSelector, a flat key/value map, as "k=v,k2=v2" -- the same

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -1008,6 +1008,92 @@ func TestKarpenterDisqualifyingKey(t *testing.T) {
 	}
 }
 
+func TestNodeCloudProvider(t *testing.T) {
+	labels := func(keys ...string) map[string]interface{} {
+		m := map[string]interface{}{}
+		for _, k := range keys {
+			m[k] = ""
+		}
+		return m
+	}
+
+	tests := []struct {
+		name       string
+		providerID string
+		labels     map[string]interface{}
+		want       string
+	}{
+		{
+			name:       "providerID scheme wins over everything else",
+			providerID: "aws:///us-east-1a/i-0123456789abcdef0",
+			labels:     labels("kubernetes.azure.com/cluster"),
+			want:       "AWS",
+		},
+		{
+			name:       "azure's empty-authority form still parses",
+			providerID: "azure:///subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/1",
+			want:       "Azure",
+		},
+		{
+			name:       "gce is reported under the name users know it by",
+			providerID: "gce://my-project/europe-west1-b/instance-1",
+			want:       "GCP",
+		},
+		{
+			name:       "an unrecognized scheme is still reported verbatim",
+			providerID: "someprovider://opaque-id",
+			want:       "someprovider",
+		},
+		{
+			name:       "a providerID that isn't a URL at all falls through to the labels",
+			providerID: "bare-metal-box-17",
+			labels:     labels("eks.amazonaws.com/nodegroup"),
+			want:       "AWS (from labels)",
+		},
+		{
+			name:   "labels alone are reported as the weaker evidence they are",
+			labels: labels("cloud.google.com/gke-nodepool"),
+			want:   "GCP (from labels)",
+		},
+		{
+			name:   "topology and instance-type labels are provider-agnostic -- not evidence",
+			labels: labels("topology.kubernetes.io/zone", "node.kubernetes.io/instance-type"),
+			want:   "",
+		},
+		{
+			name: "no providerID and no labels -- no guess",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeCloudProvider(tt.providerID, tt.labels)
+			if got != tt.want {
+				t.Errorf("nodeCloudProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNodeCloudProviderIsDeterministicAcrossNamespaces guards the ordering of
+// cloudProviderLabelPrefixes: a node can legitimately carry two providers' label namespaces (an
+// EKS node managed by Karpenter carries both eks.amazonaws.com/ and karpenter.k8s.aws/, and a
+// migrated cluster can keep a departed provider's labels around), and map iteration order would
+// make which one gets reported differ between runs.
+func TestNodeCloudProviderIsDeterministicAcrossNamespaces(t *testing.T) {
+	multi := map[string]interface{}{
+		"kubernetes.azure.com/cluster":  "",
+		"eks.amazonaws.com/nodegroup":   "",
+		"cloud.google.com/gke-nodepool": "",
+	}
+	first := nodeCloudProvider("", multi)
+	for i := 0; i < 50; i++ {
+		if got := nodeCloudProvider("", multi); got != first {
+			t.Fatalf("nodeCloudProvider() = %q on run %d, want a stable %q", got, i, first)
+		}
+	}
+}
+
 func TestNetworkPolicySelectsPod(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -6,14 +6,28 @@
     {{- /* kubeProxyVersion is deprecated and left unset from k8s 1.31 on, so the whole clause goes
            rather than leaving a bare label behind on newer clusters. */ -}}
     {{- with .Status.nodeInfo.kubeProxyVersion }}, kube-proxy {{ . }}{{ end }}, {{ .Status.nodeInfo.containerRuntimeVersion }}
-    {{- if or (index .Labels "node.kubernetes.io/instance") (index .Labels "topology.kubernetes.io/region") (index .Labels "failure-domain.beta.kubernetes.io/region") (index .Labels "topology.kubernetes.io/zone") (index .Labels "failure-domain.beta.kubernetes.io/region") }}
+    {{- /* Which cloud this node runs on, and where. The beta.kubernetes.io/failure-domain.beta
+           forms of these labels are deprecated in favour of the topology.kubernetes.io/
+           node.kubernetes.io ones, but a node only ever carries one of each pair, so each falls
+           back to its predecessor rather than being shown twice. */ -}}
+    {{- $providerID := .Spec.providerID | default "" }}
+    {{- $region := index .Labels "topology.kubernetes.io/region" | default (index .Labels "failure-domain.beta.kubernetes.io/region") }}
+    {{- $zone := index .Labels "topology.kubernetes.io/zone" | default (index .Labels "failure-domain.beta.kubernetes.io/zone") }}
+    {{- $instanceType := index .Labels "node.kubernetes.io/instance-type" | default (index .Labels "beta.kubernetes.io/instance-type") }}
+    {{- $provider := nodeCloudProvider $providerID .Labels }}
+    {{- if or $provider $providerID $region $zone $instanceType }}
         {{- "cloudprovider" | bold | nindent 2 }}
-        {{- with index .Labels "topology.kubernetes.io/region" | default (index .Labels "failure-domain.beta.kubernetes.io/region") }} {{ . }}{{ end }}
-        {{- with index .Labels "topology.kubernetes.io/zone" | default (index .Labels "failure-domain.beta.kubernetes.io/zone") }}{{ . }}{{ end }}
-        {{- with index .Labels "node.kubernetes.io/instance" | default (index .Labels "beta.kubernetes.io/instance-type") }} {{ . }}{{ end }}
-        {{- with .Labels.agentpool }}, agentpool:{{ . }}{{ end }}
-        {{- with index .Labels "node.kubernetes.io/windows-build" }}, windows-build:{{ . }}{{ end }}
-        {{- with index .Labels "kubernetes.io/role" }}, role:{{ . }}{{ end }}
+        {{- with $provider }} {{ . | cyan }}{{ end }}
+        {{- with $region }} {{ . | cyan }}{{ end }}
+        {{- with $zone }}{{ if $region }}/{{ else }} {{ end }}{{ . | cyan }}{{ end }}
+        {{- with $instanceType }} {{ . | cyan }}{{ end }}
+        {{- with .Labels.agentpool }}, agentpool:{{ . | cyan }}{{ end }}
+        {{- with index .Labels "node.kubernetes.io/windows-build" }}, windows-build:{{ . | cyan }}{{ end }}
+        {{- with index .Labels "kubernetes.io/role" }}, role:{{ . | cyan }}{{ end }}
+        {{- /* The evidence behind the provider name above, and the only place in the Node object
+               that identifies the backing VM/instance -- worth the line it costs when you need to
+               go find that instance in a cloud console. */ -}}
+        {{- with $providerID }}{{ "providerID" | bold | nindent 4 }}: {{ . | cyan }}{{ end }}
     {{- end }}
     {{- with .Status.images }}{{ "images" | bold | nindent 2 }} {{ . | len }}{{ end }}
     {{- if .Status.volumesInUse }} {{ "volumes" | bold }} inuse={{ .Status.volumesInUse | len }}

--- a/tests/artifacts/node-aks.out
+++ b/tests/artifacts/node-aks.out
@@ -1,7 +1,8 @@
 
 Node/aks-cpuworkers-41776494-vmss00006u, created 1m ago
   linux Ubuntu 16.04.6 LTS (amd64), kernel 4.15.0-1066-azure, kubelet v1.15.7, kube-proxy v1.15.7, docker://3.0.8
-  cloudprovider eastus0 Standard_D8s_v3, agentpool:cpuworkers, role:agent
+  cloudprovider Azure eastus/0 Standard_D8s_v3, agentpool:cpuworkers, role:agent
+    providerID: azure:///subscriptions/f198f0d7-73af-486e-ad9c-f17f5c3f6664/resourceGroups/mc_cluster-nimbus_cluster-nimbus_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-cpuworkers-41776494-vmss/virtualMachines/246
   images 50 volumes inuse=1/16, attached=1
   Current: Resource is Ready
   MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m

--- a/tests/artifacts/node-eks.out
+++ b/tests/artifacts/node-eks.out
@@ -1,6 +1,6 @@
 
 Node/ip-10-0-1-23.ec2.internal, created 1m ago
-  linux Amazon Linux 2 (amd64), kernel 5.10.205-195.807.amzn2.x86_64, kubelet v1.29.0, kube-proxy v1.29.0, runtime containerd://1.7.11
+  linux Amazon Linux 2 (amd64), kernel 5.10.205-195.807.amzn2.x86_64, kubelet v1.29.0, kube-proxy v1.29.0, containerd://1.7.11
   cloudprovider AWS us-east-1/us-east-1a m5.large
     providerID: aws:///us-east-1a/i-0123456789abcdef0
   Current: Resource is Ready

--- a/tests/artifacts/node-eks.out
+++ b/tests/artifacts/node-eks.out
@@ -1,0 +1,12 @@
+
+Node/ip-10-0-1-23.ec2.internal, created 1m ago
+  linux Amazon Linux 2 (amd64), kernel 5.10.205-195.807.amzn2.x86_64, kubelet v1.29.0, kube-proxy v1.29.0, runtime containerd://1.7.11
+  cloudprovider AWS us-east-1/us-east-1a m5.large
+    providerID: aws:///us-east-1a/i-0123456789abcdef0
+  Current: Resource is Ready
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
+  DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
+  addresses: InternalIP=10.0.1.23 Hostname=ip-10-0-1-23.ec2.internal
+  allocatable/capacity: pods 29/29, cpu 1.93/2, mem 7.3/8.1GB, ephemeral-storage 76.2/85.8GB

--- a/tests/artifacts/node-eks.yaml
+++ b/tests/artifacts/node-eks.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Node
+metadata:
+  creationTimestamp: "2020-03-18T14:13:28Z"
+  labels:
+    eks.amazonaws.com/capacityType: ON_DEMAND
+    eks.amazonaws.com/nodegroup: workers
+    karpenter.sh/capacity-type: on-demand
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: ip-10-0-1-23.ec2.internal
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: m5.large
+    topology.kubernetes.io/region: us-east-1
+    topology.kubernetes.io/zone: us-east-1a
+  name: ip-10-0-1-23.ec2.internal
+  resourceVersion: "46883692"
+  uid: 4ecfbfa0-e12b-4868-9463-2bc9808d3aab
+spec:
+  providerID: aws:///us-east-1a/i-0123456789abcdef0
+status:
+  addresses:
+  - address: 10.0.1.23
+    type: InternalIP
+  - address: ip-10-0-1-23.ec2.internal
+    type: Hostname
+  allocatable:
+    cpu: 1930m
+    ephemeral-storage: "76224326324"
+    memory: 7220364Ki
+    pods: "29"
+  capacity:
+    cpu: "2"
+    ephemeral-storage: 83873772Ki
+    memory: 7938700Ki
+    pods: "29"
+  conditions:
+  - lastHeartbeatTime: "2020-03-18T17:27:09Z"
+    lastTransitionTime: "2020-03-18T14:13:28Z"
+    message: kubelet has sufficient memory available
+    reason: KubeletHasSufficientMemory
+    status: "False"
+    type: MemoryPressure
+  - lastHeartbeatTime: "2020-03-18T17:27:09Z"
+    lastTransitionTime: "2020-03-18T14:13:28Z"
+    message: kubelet has no disk pressure
+    reason: KubeletHasNoDiskPressure
+    status: "False"
+    type: DiskPressure
+  - lastHeartbeatTime: "2020-03-18T17:27:09Z"
+    lastTransitionTime: "2020-03-18T14:13:28Z"
+    message: kubelet has sufficient PID available
+    reason: KubeletHasSufficientPID
+    status: "False"
+    type: PIDPressure
+  - lastHeartbeatTime: "2020-03-18T17:27:09Z"
+    lastTransitionTime: "2020-03-18T14:13:29Z"
+    message: kubelet is posting ready status
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
+  nodeInfo:
+    architecture: amd64
+    bootID: 2df597ca-daa5-4dec-95d2-61237fafd4cf
+    containerRuntimeVersion: containerd://1.7.11
+    kernelVersion: 5.10.205-195.807.amzn2.x86_64
+    kubeProxyVersion: v1.29.0
+    kubeletVersion: v1.29.0
+    machineID: 58d2ef1eaeaa4c80b42069f2fe5bb0cd
+    operatingSystem: linux
+    osImage: Amazon Linux 2
+    systemUUID: F3DC2E84-279A-FF45-A31A-ADBBD8DD5DD3

--- a/tests/artifacts/node-without-provider-id.out
+++ b/tests/artifacts/node-without-provider-id.out
@@ -1,6 +1,6 @@
 
 Node/gke-cluster-default-pool-9f5f0e1a-abcd, created 1m ago
-  linux Container-Optimized OS from Google (amd64), kernel 5.15.133+, kubelet v1.29.0, kube-proxy v1.29.0, runtime containerd://1.7.11
+  linux Container-Optimized OS from Google (amd64), kernel 5.15.133+, kubelet v1.29.0, kube-proxy v1.29.0, containerd://1.7.11
   cloudprovider GCP (from labels) europe-west1/europe-west1-b e2-standard-2
   Current: Resource is Ready
   Ready:True KubeletReady, kubelet is posting ready status for 1m

--- a/tests/artifacts/node-without-provider-id.out
+++ b/tests/artifacts/node-without-provider-id.out
@@ -1,0 +1,8 @@
+
+Node/gke-cluster-default-pool-9f5f0e1a-abcd, created 1m ago
+  linux Container-Optimized OS from Google (amd64), kernel 5.15.133+, kubelet v1.29.0, kube-proxy v1.29.0, runtime containerd://1.7.11
+  cloudprovider GCP (from labels) europe-west1/europe-west1-b e2-standard-2
+  Current: Resource is Ready
+  Ready:True KubeletReady, kubelet is posting ready status for 1m
+  addresses: InternalIP=10.132.0.11 Hostname=gke-cluster-default-pool-9f5f0e1a-abcd
+  allocatable/capacity: pods 110/110, cpu 1.93/2, mem 6.3/8.3GB, ephemeral-storage 47/101.2GB

--- a/tests/artifacts/node-without-provider-id.yaml
+++ b/tests/artifacts/node-without-provider-id.yaml
@@ -1,0 +1,56 @@
+# A node whose cloud provider integration hasn't set .spec.providerID (yet) -- the provider can
+# still be named, but only from labels its components left behind, which is weaker evidence.
+apiVersion: v1
+kind: Node
+metadata:
+  creationTimestamp: "2020-03-18T14:13:28Z"
+  labels:
+    cloud.google.com/gke-nodepool: default-pool
+    cloud.google.com/gke-os-distribution: cos
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: gke-cluster-default-pool-9f5f0e1a-abcd
+    kubernetes.io/os: linux
+    node.kubernetes.io/instance-type: e2-standard-2
+    topology.kubernetes.io/region: europe-west1
+    topology.kubernetes.io/zone: europe-west1-b
+  name: gke-cluster-default-pool-9f5f0e1a-abcd
+  resourceVersion: "46883692"
+  uid: 5ecfbfa0-e12b-4868-9463-2bc9808d3aab
+spec: {}
+status:
+  addresses:
+  - address: 10.132.0.11
+    type: InternalIP
+  - address: gke-cluster-default-pool-9f5f0e1a-abcd
+    type: Hostname
+  allocatable:
+    cpu: 1930m
+    ephemeral-storage: "47093746742"
+    memory: 6187140Ki
+    pods: "110"
+  capacity:
+    cpu: "2"
+    ephemeral-storage: 98831908Ki
+    memory: 8145028Ki
+    pods: "110"
+  conditions:
+  - lastHeartbeatTime: "2020-03-18T17:27:09Z"
+    lastTransitionTime: "2020-03-18T14:13:29Z"
+    message: kubelet is posting ready status
+    reason: KubeletReady
+    status: "True"
+    type: Ready
+  daemonEndpoints:
+    kubeletEndpoint:
+      Port: 10250
+  nodeInfo:
+    architecture: amd64
+    bootID: 3df597ca-daa5-4dec-95d2-61237fafd4cf
+    containerRuntimeVersion: containerd://1.7.11
+    kernelVersion: 5.15.133+
+    kubeProxyVersion: v1.29.0
+    kubeletVersion: v1.29.0
+    machineID: 68d2ef1eaeaa4c80b42069f2fe5bb0cd
+    operatingSystem: linux
+    osImage: Container-Optimized OS from Google
+    systemUUID: F3DC2E84-279A-FF45-A31A-ADBBD8DD5DD4


### PR DESCRIPTION
## ⚠️ AI-generated, not verified against real-world node YAMLs

Read this first. This change was written by Claude and **has not been tested against a single real
node object from any of the providers it claims to recognise**, except the one AKS node already
committed as a fixture. The two new fixtures (`node-eks.yaml`, `node-without-provider-id.yaml`)
are hand-written from documentation and memory, not captured from a live cluster — the providerID
formats, the label namespaces, and the display names are all plausible rather than confirmed.

**To improve this we need real `kubectl get node -o yaml` output** from actual EKS / GKE / AKS /
OpenStack / vSphere / bare-metal clusters, added as fixtures. Contributions of node YAMLs are
more valuable here than more code.

Merging anyway on the judgement that it beats what's there today and degrades safely:

- the current line shows no provider at all, so anything correct is a gain;
- detection is evidence-based and never guesses — no providerID and no provider-owned labels means
  no provider is named, rather than one being inferred from the node name or IP;
- an unrecognised providerID scheme is echoed verbatim instead of being mapped to a wrong provider;
- worst case for an unrecognised provider is that the line just doesn't appear, not that it lies.

The one way this *could* mislead is if a label namespace in the fallback list is set by something
other than the provider I attributed it to. That list is the part most worth reviewing.

## What changed

The `cloudprovider` line was assembled purely from topology labels, which say *where* a node runs
but never *which provider* runs it. `.spec.providerID` is the one field in the Node object meant to
identify the backing instance, so the provider is now read from its `<provider>://` scheme, with
provider-owned label namespaces (`eks.amazonaws.com/`, `cloud.google.com/`,
`kubernetes.azure.com/`, ...) as a weaker fallback, marked `(from labels)`.

The raw providerID renders under the line it backs — it is both the evidence for the provider name
and the only pointer from the Node object to the instance in a cloud console.

```
  cloudprovider Azure eastus/0 Standard_D8s_v3, agentpool:cpuworkers, role:agent
    providerID: azure:///subscriptions/f198f0d7-.../virtualMachines/246
  cloudprovider AWS us-east-1/us-east-1a m5.large
    providerID: aws:///us-east-1a/i-0123456789abcdef0
  cloudprovider GCP (from labels) europe-west1/europe-west1-b e2-standard-2
```

## Bugs fixed on the same line

Verified against https://kubernetes.io/docs/reference/labels-annotations-taints/:

- the instance type was read from `node.kubernetes.io/instance`, which is not a label — the real
  one is `node.kubernetes.io/instance-type`, so the type only ever showed up via the deprecated
  `beta.kubernetes.io/instance-type` fallback;
- region and zone were concatenated with no separator, rendering AKS's `eastus` + `0` as `eastus0`
  (visible in the `node-aks.out` diff);
- the guard tested `failure-domain.beta.kubernetes.io/region` twice, so a node carrying only the
  beta *zone* label rendered no line at all.

## Testing

`go vet` and `go test ./...` pass. Unit tests cover the providerID/label/no-evidence paths, a
providerID that isn't a URL, and determinism when a node carries two providers' label namespaces.
e2e fixtures are untouched — minikube sets neither providerID nor any of these namespaces, so
nothing new renders there.

`make staticcheck` fails on a pre-existing toolchain mismatch (staticcheck built with go1.25,
module needs go1.26), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)