### PR TITLE
Add Flux HelmRelease and Kustomization templates

### DIFF
--- a/pkg/plugin/templates/HelmRelease.tmpl
+++ b/pkg/plugin/templates/HelmRelease.tmpl
@@ -1,0 +1,114 @@
+{{- define "HelmRelease" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: helm.toolkit.fluxcd.io/v2, Kind=HelmRelease */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- /* What chart, from where. spec.chart (helm-controller mirrors it into a HelmChart object,
+           which is where chart pull/version-resolution failures actually surface) and spec.chartRef
+           (v2, pointing straight at an OCIRepository or a hand-made HelmChart) are mutually
+           exclusive. */ -}}
+    {{- with .Spec.chart }}
+        {{- with .spec }}
+            {{- "Chart" | bold | nindent 2 }} {{ .chart | cyan }}
+            {{- with .version }} ({{ . | cyan }}){{ end }}
+            {{- with .sourceRef }}
+                {{- " from " }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "HelmRepository") "name" .name "namespace" (.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+            {{- end }}
+            {{- with $.Status.helmChart }}
+                {{- $chartParts := splitList "/" . }}
+                {{- if eq (len $chartParts) 2 }} · {{ $.Include "resource_ref" (dict "kind" "HelmChart" "name" (last $chartParts) "namespace" (first $chartParts) "callerNamespace" $.Namespace) }}{{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with .Spec.chartRef }}
+        {{- "Chart" | bold | nindent 2 }} from {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+    {{- end }}
+    {{- /* status.history is the Helm release ledger, newest first. Entry 0 is the last release
+           helm-controller made -- which is not necessarily the one currently serving: a failed
+           upgrade leaves a "failed" entry on top of the "deployed" one that is still installed. */ -}}
+    {{- $history := .Status.history | default list }}
+    {{- $latest := dict }}
+    {{- $deployed := dict }}
+    {{- with $history }}
+        {{- $latest = index . 0 }}
+        {{- range . }}
+            {{- if not $deployed }}{{ if eq (.status | default "") "deployed" }}{{ $deployed = . }}{{ end }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- with $latest }}
+        {{- /* The Helm release name/namespace are only worth showing when spec.releaseName or
+               spec.targetNamespace moved them away from this object's own name/namespace, which
+               the status summary line already shows. */ -}}
+        {{- $elsewhere := or (ne (.name | default $.Name) $.Name) (ne (.namespace | default $.Namespace) $.Namespace) }}
+        {{- "Helm release" | bold | nindent 2 }}
+        {{- if $elsewhere }} {{ .name | default $.Name | cyan }}
+            {{- with .namespace }}{{ if ne . $.Namespace }} -n {{ . | cyan }}{{ end }}{{ end }}
+        {{- end }}:
+        {{- with .chartVersion }} chart {{ . | cyan }}{{ end }}
+        {{- with .appVersion }} (app {{ . | cyan }}){{ end }}
+        {{- with .version }}, revision {{ . | toString | cyan }}{{ end }}
+        {{- with .status }}, {{ . | colorKeyword }}{{ with $latest.lastDeployed }} {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+        {{- else }}{{ with .lastDeployed }}, deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}{{ end }}
+        {{- with .firstDeployed }}
+            {{- if ne . $latest.lastDeployed }}, first deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- /* Revision divergence: the chart version helm-controller last tried isn't the one that
+           ended up released. Highest-signal state this object has -- it means an install/upgrade
+           is either in flight or persistently failing, and the conditions alone bury it.
+           status.lastAppliedRevision is the deprecated v2 spelling, only there as a fallback for
+           objects last written by an older helm-controller. */ -}}
+    {{- $released := $deployed.chartVersion | default .Status.lastAppliedRevision }}
+    {{- $olderStillInstalled := false }}
+    {{- with $deployed }}
+        {{- if ne (.version | toString) ($latest.version | toString) }}{{ $olderStillInstalled = true }}{{ end }}
+    {{- end }}
+    {{- with .Status.lastAttemptedRevision }}
+        {{- if ne . ($released | default "") }}
+            {{- "Last attempted" | red | bold | nindent 2 }} chart {{ . | red }} was not released
+            {{- if not $olderStillInstalled }}
+                {{- if $released }}, {{ $released | red }} is still what's installed
+                {{- else }}, this HelmRelease has never been installed{{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* The newest release failed, so an older one is what's actually still installed. */ -}}
+    {{- if $olderStillInstalled }}
+        {{- "Still installed" | bold | nindent 2 }}: chart {{ $deployed.chartVersion | cyan }}
+        {{- with $deployed.appVersion }} (app {{ . | cyan }}){{ end }}
+        {{- with $deployed.version }}, revision {{ . | toString | cyan }}{{ end }}
+        {{- with $deployed.lastDeployed }}, deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- end }}
+    {{- /* Cumulative since the last successful release of each kind, reset on success. */ -}}
+    {{- if or .Status.installFailures .Status.upgradeFailures .Status.failures }}
+        {{- "Failures" | red | bold | nindent 2 }}:
+        {{- $failureParts := list }}
+        {{- with .Status.installFailures }}{{ $failureParts = append $failureParts (printf "install:%d" (int .)) }}{{ end }}
+        {{- with .Status.upgradeFailures }}{{ $failureParts = append $failureParts (printf "upgrade:%d" (int .)) }}{{ end }}
+        {{- with .Status.failures }}{{ $failureParts = append $failureParts (printf "total:%d" (int .)) }}{{ end }}
+        {{- " " }}{{ join ", " $failureParts | red | bold }}
+    {{- end }}
+    {{- /* Remediation only matters once it deviates from the default of not retrying at all;
+           a non-zero retry count explains repeated install/upgrade attempts between intervals,
+           and the upgrade strategy decides whether a failure rolls back or uninstalls. */ -}}
+    {{- $installRetries := dig "install" "remediation" "retries" 0 (.Spec | default dict) }}
+    {{- $upgradeRetries := dig "upgrade" "remediation" "retries" 0 (.Spec | default dict) }}
+    {{- $upgradeStrategy := dig "upgrade" "remediation" "strategy" "" (.Spec | default dict) }}
+    {{- if or $installRetries $upgradeRetries $upgradeStrategy }}
+        {{- "Remediation" | bold | nindent 2 }}:
+        {{- $remediationParts := list }}
+        {{- with $installRetries }}{{ $remediationParts = append $remediationParts (printf "install retries %d" (int .)) }}{{ end }}
+        {{- with $upgradeRetries }}{{ $remediationParts = append $remediationParts (printf "upgrade retries %d" (int .)) }}{{ end }}
+        {{- with $upgradeStrategy }}{{ $remediationParts = append $remediationParts (printf "on failed upgrade: %s" .) }}{{ end }}
+        {{- " " }}{{ join ", " $remediationParts | cyan }}
+    {{- end }}
+    {{- template "flux_depends_on" . }}
+    {{- template "flux_reconciliation" . }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/Kustomization.tmpl
+++ b/pkg/plugin/templates/Kustomization.tmpl
@@ -1,0 +1,81 @@
+{{- define "Kustomization" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: kustomize.toolkit.fluxcd.io/v1, Kind=Kustomization */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "kstatus_summary" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- /* Which source, which path in it, and where the built manifests land. */ -}}
+    {{- with .Spec.sourceRef }}
+        {{- "Applies" | bold | nindent 2 }} {{ $.Spec.path | default "./" | cyan }} from {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+        {{- with $.Spec.targetNamespace }} into namespace {{ . | cyan }}{{ end }}
+    {{- end }}
+    {{- /* spec.kubeConfig means the manifests are applied to a *different* cluster than the one
+           this object lives in -- without it on screen, everything below reads as local. */ -}}
+    {{- with .Spec.kubeConfig }}
+        {{- with .secretRef }}
+            {{- "Applies to a remote cluster" | yellow | bold | nindent 2 }}: kubeconfig from {{ $.Include "resource_ref" (dict "kind" "Secret" "name" .name "namespace" $.Namespace "callerNamespace" $.Namespace) }}
+        {{- end }}
+    {{- end }}
+    {{- with .Status.lastAppliedRevision }}
+        {{- "Applied revision" | bold | nindent 2 }} {{ $.Include "flux_revision" . | cyan }}
+    {{- end }}
+    {{- /* Revision divergence: kustomize-controller got a newer revision from the source but
+           never managed to apply it (build error, dry-run/apply failure, failed health checks).
+           Highest-signal state this object has, and the conditions alone bury it. */ -}}
+    {{- with .Status.lastAttemptedRevision }}
+        {{- $applied := $.Status.lastAppliedRevision | default "" }}
+        {{- if ne . $applied }}
+            {{- "Last attempted" | red | bold | nindent 2 }} revision {{ $.Include "flux_revision" . | red }} was not applied
+            {{- if $applied }}, the cluster still runs {{ $.Include "flux_revision" $applied | red }}
+            {{- else }}, nothing has been applied from this source yet
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* status.inventory is the full list of applied objects -- hundreds of entries for a big
+           overlay, so only the shape of it is worth showing. Entry ids are
+           "<namespace>_<name>_<group>_<kind>"; none of those four parts can contain an
+           underscore, so the kind is always the last segment. */ -}}
+    {{- $entries := (.Status.inventory | default dict).entries | default list }}
+    {{- if $entries }}
+        {{- $countsByKind := dict }}
+        {{- range $entries }}
+            {{- $kind := last (splitList "_" (.id | toString)) }}
+            {{- $_ := set $countsByKind $kind (add1 (int (get $countsByKind $kind))) }}
+        {{- end }}
+        {{- $kindSummaries := list }}
+        {{- range $kind := keys $countsByKind | sortAlpha }}
+            {{- $kindSummaries = append $kindSummaries (printf "%s×%d" $kind (int (get $countsByKind $kind))) }}
+        {{- end }}
+        {{- "Manages" | bold | nindent 2 }} {{ len $entries | toString | cyan }} resources: {{ join ", " $kindSummaries | cyan }}
+    {{- else if .Status.lastAppliedRevision }}
+        {{- "Manages no resources" | yellow | bold | nindent 2 }}: the applied revision produced an empty inventory
+    {{- end }}
+    {{- /* prune:false is the common ops footgun -- usually enabled "temporarily" and forgotten,
+           after which everything deleted from the source keeps running in the cluster forever,
+           while the object stays perfectly Ready. */ -}}
+    {{- if not .Spec.prune }}
+        {{- "Prune disabled" | yellow | bold | nindent 2 }}: resources removed from the source are left running in the cluster
+    {{- end }}
+    {{- /* What Ready actually means here: with wait/healthChecks it also covers the health of the
+           applied objects, without them it only means the apply itself succeeded. */ -}}
+    {{- if .Spec.wait }}
+        {{- "Waits" | bold | nindent 2 }} for every managed resource to become healthy
+    {{- else }}
+        {{- with .Spec.healthChecks }}
+            {{- "Health-checks" | bold | nindent 2 }}
+            {{- if eq (len .) 1 }}
+                {{- $check := index . 0 }}
+                {{- " " }}{{ $.Include "resource_ref" (dict "kind" $check.kind "name" $check.name "namespace" ($check.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+            {{- else }} {{ len . | toString | cyan }} resources
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- template "flux_depends_on" . }}
+    {{- template "flux_reconciliation" . }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -1311,3 +1311,50 @@
         {{- template "generic_health_summary" (dict "obj" $obj "callerNamespace" $callerNamespace) }}
     {{- end }}
 {{- end }}
+
+{{- define "flux_reconciliation" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Every Flux toolkit CRD (HelmRelease, Kustomization, the source kinds) shares
+           spec.interval and spec.suspend, so this renders the same line for all of them.
+           suspend:true is the single most misleading state a Flux object can be in -- the
+           conditions keep reporting the last successful reconciliation, so it can read as
+           perfectly healthy while neither drift nor spec changes are being applied. */ -}}
+    {{- if .Spec.suspend }}
+        {{- "Suspended" | red | bold | nindent 2 }}: reconciliation is paused, neither spec changes nor drift are applied
+        {{- with .Spec.interval }} (would otherwise reconcile every {{ . | cyan }}){{ end }}
+    {{- else }}
+        {{- with .Spec.interval }}
+            {{- "Reconciles" | bold | nindent 2 }} every {{ . | cyan }}
+            {{- with $.Spec.retryInterval }}, retries every {{ . | cyan }} after a failure{{ end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "flux_depends_on" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Flux gates reconciliation on spec.dependsOn: while any listed object is not Ready this
+           one isn't reconciled at all, which is the usual explanation for an object that just
+           sits there with a stale revision. Entries carry only name/namespace -- they always
+           refer to the same kind as the object declaring them. */ -}}
+    {{- with .Spec.dependsOn }}
+        {{- "Depends on" | bold | nindent 2 }}
+        {{- range $index, $dep := . }}
+            {{- if $index }},{{ end }} {{ $.Include "resource_ref" (dict "kind" ($dep.kind | default $.Kind) "name" $dep.name "namespace" ($dep.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "flux_revision" }}
+    {{- /* Expects a Flux revision string. Source revisions are "<ref>@<algo>:<hex>" (e.g.
+           "refs/heads/main@sha1:1a2b3c...") since the v1 source API; older objects and Bucket
+           sources carry a bare "<algo>:<hex>", and OCI/Helm ones a plain version. Renders
+           "<ref>@<short-hex>", passing anything that doesn't match the shape through untouched.
+           Emits no color so callers can paint the whole revision cyan or red as their state
+           demands. */ -}}
+    {{- $parts := splitList "@" (. | toString) }}
+    {{- $digest := last $parts }}
+    {{- $digestParts := splitList ":" $digest }}
+    {{- if eq (len $digestParts) 2 }}{{ $digest = last $digestParts | trunc 8 }}{{ end }}
+    {{- if gt (len $parts) 1 }}{{ first $parts | trimPrefix "refs/heads/" | trimPrefix "refs/tags/" }}@{{ end }}
+    {{- $digest }}
+{{- end -}}

--- a/tests/artifacts/helmrelease-failed-upgrade.out
+++ b/tests/artifacts/helmrelease-failed-upgrade.out
@@ -1,0 +1,15 @@
+
+HelmRelease/nginx -n default, created 1m ago, gen:4
+  InProgress: Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition
+    Reconciling: UpgradeFailed, Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition
+  Chart nginx (>=18.x) from HelmRepository/bitnami -n flux-system · HelmChart/default-nginx -n flux-system
+  Helm release: chart 18.3.0 (app 1.27.2), revision 3, failed 1m ago, first deployed 1m ago
+  Last attempted chart 18.3.0 was not released
+  Still installed: chart 18.2.5 (app 1.27.1), revision 2, deployed 1m ago
+  Failures: upgrade:2, total:2
+  Remediation: install retries 3, upgrade retries 2, on failed upgrade: rollback
+  Depends on HelmRelease/redis
+  Reconciles every 10m
+  Ready:False UpgradeFailed, Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition for 1m
+  Released:False UpgradeFailed, Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition for 1m
+  Remediated:True RollbackSucceeded, Helm rollback to previous release default/nginx.v2 with chart nginx@18.2.5 succeeded for 1m

--- a/tests/artifacts/helmrelease-failed-upgrade.yaml
+++ b/tests/artifacts/helmrelease-failed-upgrade.yaml
@@ -1,0 +1,87 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  creationTimestamp: "2026-06-20T08:31:12Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 4
+  name: nginx
+  namespace: default
+  resourceVersion: "204411"
+  uid: 9e2c7a15-3b48-4c6d-8e1f-2a5b7c9d0e34
+spec:
+  chart:
+    spec:
+      chart: nginx
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+      version: '>=18.x'
+  dependsOn:
+  - name: redis
+  install:
+    remediation:
+      retries: 3
+  interval: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 2
+      strategy: rollback
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:52:44Z"
+    message: 'Helm upgrade failed for release default/nginx with chart nginx@18.3.0:
+      timed out waiting for the condition'
+    observedGeneration: 4
+    reason: UpgradeFailed
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2026-06-29T23:52:44Z"
+    message: 'Helm upgrade failed for release default/nginx with chart nginx@18.3.0:
+      timed out waiting for the condition'
+    observedGeneration: 4
+    reason: UpgradeFailed
+    status: "False"
+    type: Released
+  - lastTransitionTime: "2026-06-29T23:53:10Z"
+    message: Helm rollback to previous release default/nginx.v2 with chart nginx@18.2.5
+      succeeded
+    observedGeneration: 4
+    reason: RollbackSucceeded
+    status: "True"
+    type: Remediated
+  helmChart: flux-system/default-nginx
+  history:
+  - appVersion: 1.27.2
+    chartName: nginx
+    chartVersion: 18.3.0
+    configDigest: sha256:8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b
+    digest: sha256:2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d
+    firstDeployed: "2026-06-20T08:31:20Z"
+    lastDeployed: "2026-06-29T23:51:02Z"
+    name: nginx
+    namespace: default
+    status: failed
+    version: 3
+  - appVersion: 1.27.1
+    chartName: nginx
+    chartVersion: 18.2.5
+    configDigest: sha256:5a0f2b6c8e4d1a3f9c7b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c
+    digest: sha256:1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f
+    firstDeployed: "2026-06-20T08:31:20Z"
+    lastDeployed: "2026-06-25T14:07:33Z"
+    name: nginx
+    namespace: default
+    status: deployed
+    version: 2
+  installFailures: 0
+  lastAttemptedConfigDigest: sha256:8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b
+  lastAttemptedGeneration: 4
+  lastAttemptedReleaseAction: upgrade
+  lastAttemptedRevision: 18.3.0
+  observedGeneration: 4
+  upgradeFailures: 2
+  failures: 2

--- a/tests/artifacts/helmrelease-healthy.out
+++ b/tests/artifacts/helmrelease-healthy.out
@@ -1,0 +1,8 @@
+
+HelmRelease/nginx -n default, created 1m ago, gen:1
+  Current: Resource is Ready
+  Chart nginx (>=18.x) from HelmRepository/bitnami -n flux-system · HelmChart/default-nginx -n flux-system
+  Helm release: chart 18.2.5 (app 1.27.1), revision 1, deployed 1m ago
+  Reconciles every 10m
+  Ready:True InstallSucceeded, Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5 for 1m
+  Released:True InstallSucceeded, Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5 for 1m

--- a/tests/artifacts/helmrelease-healthy.yaml
+++ b/tests/artifacts/helmrelease-healthy.yaml
@@ -1,0 +1,55 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  creationTimestamp: "2026-06-27T09:12:04Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 1
+  name: nginx
+  namespace: default
+  resourceVersion: "18422"
+  uid: 4b1a0a4e-6f7c-4a2e-9d3a-0f0b2c9d1e77
+spec:
+  chart:
+    spec:
+      chart: nginx
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+      version: '>=18.x'
+  interval: 10m
+  releaseName: nginx
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:54:59Z"
+    message: Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5
+    observedGeneration: 1
+    reason: InstallSucceeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2026-06-29T23:54:59Z"
+    message: Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5
+    observedGeneration: 1
+    reason: InstallSucceeded
+    status: "True"
+    type: Released
+  helmChart: flux-system/default-nginx
+  history:
+  - appVersion: 1.27.1
+    chartName: nginx
+    chartVersion: 18.2.5
+    configDigest: sha256:5a0f2b6c8e4d1a3f9c7b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c
+    digest: sha256:1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f
+    firstDeployed: "2026-06-29T23:54:58Z"
+    lastDeployed: "2026-06-29T23:54:58Z"
+    name: nginx
+    namespace: default
+    status: deployed
+    version: 1
+  lastAttemptedConfigDigest: sha256:5a0f2b6c8e4d1a3f9c7b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c
+  lastAttemptedGeneration: 1
+  lastAttemptedReleaseAction: install
+  lastAttemptedRevision: 18.2.5
+  observedGeneration: 1

--- a/tests/artifacts/helmrelease-suspended-oci.out
+++ b/tests/artifacts/helmrelease-suspended-oci.out
@@ -1,0 +1,8 @@
+
+HelmRelease/podinfo -n apps, created 1m ago, gen:7
+  Current: Resource is Ready
+  Chart from OCIRepository/podinfo -n flux-system
+  Helm release: chart 6.7.1 (app 6.7.1), revision 5, deployed 1m ago, first deployed 1m ago
+  Suspended: reconciliation is paused, neither spec changes nor drift are applied (would otherwise reconcile every 30m)
+  Ready:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1 for 1m
+  Released:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1 for 1m

--- a/tests/artifacts/helmrelease-suspended-oci.yaml
+++ b/tests/artifacts/helmrelease-suspended-oci.yaml
@@ -1,0 +1,50 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  creationTimestamp: "2026-05-11T17:44:51Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 7
+  name: podinfo
+  namespace: apps
+  resourceVersion: "551903"
+  uid: 1f7d3c22-8a90-4d51-b2c6-77e4a0d9b311
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: podinfo
+    namespace: flux-system
+  interval: 30m
+  suspend: true
+  targetNamespace: apps
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-14T06:20:41Z"
+    message: Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1
+    observedGeneration: 7
+    reason: UpgradeSucceeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2026-06-14T06:20:41Z"
+    message: Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1
+    observedGeneration: 7
+    reason: UpgradeSucceeded
+    status: "True"
+    type: Released
+  history:
+  - appVersion: 6.7.1
+    chartName: podinfo
+    chartVersion: 6.7.1
+    configDigest: sha256:3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a
+    digest: sha256:7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a9c2f5b8e1d4a7c0f
+    firstDeployed: "2026-05-11T17:45:03Z"
+    lastDeployed: "2026-06-14T06:20:39Z"
+    name: podinfo
+    namespace: apps
+    status: deployed
+    version: 5
+  lastAttemptedConfigDigest: sha256:3d6a9c2f5b8e1d4a7c0f3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a
+  lastAttemptedGeneration: 7
+  lastAttemptedReleaseAction: upgrade
+  lastAttemptedRevision: 6.7.1
+  observedGeneration: 7

--- a/tests/artifacts/kustomization-build-failed.out
+++ b/tests/artifacts/kustomization-build-failed.out
@@ -1,0 +1,14 @@
+
+Kustomization/apps -n flux-system, created 1m ago, gen:11
+  Failed: kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base'
+    Stalled: BuildFailed, kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base'
+  Applies ./apps/production from GitRepository/flux-system
+  Applied revision main@2b9d4f1a
+  Last attempted revision main@c4e8b0d3 was not applied, the cluster still runs main@2b9d4f1a
+  Manages 3 resources: ConfigMap×1, Deployment×1, Service×1
+  Prune disabled: resources removed from the source are left running in the cluster
+  Health-checks Deployment/podinfo -n default
+  Depends on Kustomization/infra-controllers, Kustomization/infra-configs
+  Reconciles every 10m, retries every 1m after a failure
+  Ready:False BuildFailed, kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base': '/tmp/kustomization-1029384756/apps/base' must resolve to a file': recursed accumulation of path '/tmp/kustomization-1029384756/apps/base': must build at directory: not a valid directory: evalsymlink failure for 1m
+  Stalled:True BuildFailed, kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base' for 1m

--- a/tests/artifacts/kustomization-build-failed.yaml
+++ b/tests/artifacts/kustomization-build-failed.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  creationTimestamp: "2026-04-02T15:20:09Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 11
+  name: apps
+  namespace: flux-system
+  resourceVersion: "998341"
+  uid: 8a0e5c74-1b93-46f2-a5d8-0c7e2b4f6a91
+spec:
+  dependsOn:
+  - name: infra-controllers
+  - name: infra-configs
+  healthChecks:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: podinfo
+    namespace: default
+  interval: 10m
+  path: ./apps/production
+  prune: false
+  retryInterval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 3m
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:50:31Z"
+    message: 'kustomize build failed: accumulating resources: accumulation err=''accumulating
+      resources from ''../base'': ''/tmp/kustomization-1029384756/apps/base'' must
+      resolve to a file'': recursed accumulation of path ''/tmp/kustomization-1029384756/apps/base'':
+      must build at directory: not a valid directory: evalsymlink failure'
+    observedGeneration: 11
+    reason: BuildFailed
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2026-06-29T23:50:31Z"
+    message: 'kustomize build failed: accumulating resources: accumulation err=''accumulating
+      resources from ''../base'''
+    observedGeneration: 11
+    reason: BuildFailed
+    status: "True"
+    type: Stalled
+  inventory:
+    entries:
+    - id: default_podinfo__Service
+      v: v1
+    - id: default_podinfo_apps_Deployment
+      v: v1
+    - id: default_podinfo__ConfigMap
+      v: v1
+  lastAppliedRevision: refs/heads/main@sha1:2b9d4f1a6c8e0357b1d9f2a4c6e8b0d3f5a7c9e1
+  lastAttemptedRevision: refs/heads/main@sha1:c4e8b0d3f5a7c9e12b9d4f1a6c8e0357b1d9f2a4
+  observedGeneration: 11

--- a/tests/artifacts/kustomization-healthy.out
+++ b/tests/artifacts/kustomization-healthy.out
@@ -1,0 +1,9 @@
+
+Kustomization/podinfo -n flux-system, created 1m ago, gen:2
+  Current: Resource is Ready
+  Applies ./kustomize from GitRepository/flux-system into namespace default
+  Applied revision main@7f3c1a9e
+  Manages 9 resources: ConfigMap×1, Deployment×3, HorizontalPodAutoscaler×1, Service×3, ServiceAccount×1
+  Waits for every managed resource to become healthy
+  Reconciles every 5m
+  Ready:True ReconciliationSucceeded, Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1 for 1m

--- a/tests/artifacts/kustomization-healthy.yaml
+++ b/tests/artifacts/kustomization-healthy.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  creationTimestamp: "2026-06-14T11:02:37Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 2
+  name: podinfo
+  namespace: flux-system
+  resourceVersion: "77120"
+  uid: 6d2f8b31-4c5a-4e7d-9b0a-3e1c5f7a9d20
+spec:
+  force: false
+  interval: 5m
+  path: ./kustomize
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: default
+  timeout: 2m
+  wait: true
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:55:12Z"
+    message: 'Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1'
+    observedGeneration: 2
+    reason: ReconciliationSucceeded
+    status: "True"
+    type: Ready
+  inventory:
+    entries:
+    - id: default_podinfo__Service
+      v: v1
+    - id: default_podinfo__ServiceAccount
+      v: v1
+    - id: default_podinfo_apps_Deployment
+      v: v1
+    - id: default_podinfo_autoscaling_HorizontalPodAutoscaler
+      v: v2
+    - id: default_podinfo-frontend__Service
+      v: v1
+    - id: default_podinfo-frontend_apps_Deployment
+      v: v1
+    - id: default_podinfo-backend__Service
+      v: v1
+    - id: default_podinfo-backend_apps_Deployment
+      v: v1
+    - id: default_podinfo-config__ConfigMap
+      v: v1
+  lastAppliedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  lastAttemptedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  observedGeneration: 2

--- a/tests/artifacts/kustomization-source-not-found.out
+++ b/tests/artifacts/kustomization-source-not-found.out
@@ -1,0 +1,9 @@
+
+Kustomization/tenant-staging -n flux-system, created 1m ago, gen:1
+  InProgress: Source artifact not found, retrying in 30s: GitRepository.source.toolkit.fluxcd.io "tenant-repo" not found
+    Reconciling: ArtifactFailed, Source artifact not found, retrying in 30s: GitRepository.source.toolkit.fluxcd.io "tenant-repo" not found
+  Applies ./tenants/staging from GitRepository/tenant-repo -n tenants
+  Applies to a remote cluster: kubeconfig from Secret/staging-cluster-kubeconfig
+  Last attempted revision staging@0d3f5a7c was not applied, nothing has been applied from this source yet
+  Reconciles every 5m
+  Ready:False ArtifactFailed, Source artifact not found, retrying in 30s: GitRepository.source.toolkit.fluxcd.io "tenant-repo" not found for 1m

--- a/tests/artifacts/kustomization-source-not-found.yaml
+++ b/tests/artifacts/kustomization-source-not-found.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  creationTimestamp: "2026-06-29T23:40:18Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 1
+  name: tenant-staging
+  namespace: flux-system
+  resourceVersion: "991002"
+  uid: 3c5b9d17-2e64-4a80-91f3-6b8d0e2a4c57
+spec:
+  interval: 5m
+  kubeConfig:
+    secretRef:
+      key: value
+      name: staging-cluster-kubeconfig
+  path: ./tenants/staging
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: tenant-repo
+    namespace: tenants
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:40:19Z"
+    message: 'Source artifact not found, retrying in 30s: GitRepository.source.toolkit.fluxcd.io
+      "tenant-repo" not found'
+    observedGeneration: 1
+    reason: ArtifactFailed
+    status: "False"
+    type: Ready
+  lastAttemptedRevision: refs/heads/staging@sha1:0d3f5a7c9e12b9d4f1a6c8e0357b1d9f2a4c6e8b
+  observedGeneration: 1


### PR DESCRIPTION
Closes #660.

> [!NOTE]
> **This PR is fully AI-generated.** Every template line, fixture and golden file here was written by Claude Code from the issue description plus `CONVENTIONS.md`/`CONTRIBUTING.md`; a human has not hand-edited any of it. The fixtures are hand-written approximations of real Flux objects, **not** captured from a live cluster — please review the assumed `.status` shapes with that in mind.

Both kinds fell back to `DefaultResource`, which shows only owners, conditions and recent updates — nothing about what chart or revision is actually running. Flux has no built-in UI, so the CLI is the primary place this state gets checked.

## HelmRelease (`helm.toolkit.fluxcd.io/v2`)

```
HelmRelease/nginx -n default, created 3d ago, gen:4
  InProgress: Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition
  Chart nginx (>=18.x) from HelmRepository/bitnami -n flux-system · HelmChart/default-nginx -n flux-system
  Helm release: chart 18.3.0 (app 1.27.2), revision 3, failed 4m ago, first deployed 9d ago
  Last attempted chart 18.3.0 was not released
  Still installed: chart 18.2.5 (app 1.27.1), revision 2, deployed 4d ago
  Failures: upgrade:2, total:2
  Remediation: install retries 3, upgrade retries 2, on failed upgrade: rollback
  Depends on HelmRelease/redis
  Reconciles every 10m
```

`status.lastAppliedRevision` is deprecated in v2, so "what is running" comes from the newest `deployed` entry in `status.history`; `lastAppliedRevision` is kept only as a fallback for objects last written by an older helm-controller. A failed upgrade leaves a `failed` entry on top of the `deployed` one that is still installed, so both are shown. `spec.chartRef` (OCIRepository) is handled alongside the classic `spec.chart`.

## Kustomization (`kustomize.toolkit.fluxcd.io/v1`)

```
Kustomization/apps -n flux-system, created 88d ago, gen:11
  Failed: kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base'
  Applies ./apps/production from GitRepository/flux-system
  Applied revision main@2b9d4f1a
  Last attempted revision main@c4e8b0d3 was not applied, the cluster still runs main@2b9d4f1a
  Manages 3 resources: ConfigMap×1, Deployment×1, Service×1
  Prune disabled: resources removed from the source are left running in the cluster
  Health-checks Deployment/podinfo -n default
  Depends on Kustomization/infra-controllers, Kustomization/infra-configs
  Reconciles every 10m, retries every 1m after a failure
```

`status.inventory` is summarised as counts per kind — a big overlay has hundreds of entries and only the shape of it is worth showing. Entry ids are `<namespace>_<name>_<group>_<kind>` and none of those four parts can contain an underscore, so the kind is always the last segment.

Revision divergence gets its own line in both kinds: `lastAttemptedRevision` not matching what is released/applied is the single highest-signal state either has, and the conditions alone bury it.

## Shared helpers in `common.tmpl`

Three additions, used by both kinds (and by the source kinds, if those follow). All are new `define`s, so no existing golden file changed:

- `flux_reconciliation` — interval, plus a callout for `suspend: true`, which keeps reporting the last successful reconciliation while neither drift nor spec changes are applied.
- `flux_depends_on` — `spec.dependsOn`, the usual explanation for an object stuck at a stale revision.
- `flux_revision` — `refs/heads/main@sha1:7f3c1a9e...` → `main@7f3c1a9e`, passing bare-digest and plain-version forms through untouched.

## Beyond the issue's scope

Three fields were added on judgement, all because they change what a healthy-looking object actually means: `spec.suspend` (both kinds), `spec.dependsOn` (both kinds), and Kustomization's `spec.kubeConfig` — manifests landing in a *different cluster* otherwise reads as local. Happy to drop any of them.

## Testing

Neither template makes a live query, so per the two-tier model in `CONTRIBUTING.md` static artifacts cover the full render path — no e2e subtest added:

- HelmRelease: healthy, failed-upgrade (divergence + failure counters + remediation + dependsOn), suspended + `chartRef`
- Kustomization: healthy (wait, inventory, targetNamespace), build-failed (divergence, `prune: false`, single healthCheck, retryInterval), source-not-found (nothing applied yet, remote cluster)

`go test ./...` passes. Edge cases were also rendered ad hoc and not committed: no `status`, empty `spec`, never-installed, malformed inventory id, bare-digest revision — no panics, all branches degrade cleanly.

Note `make test` fails before reaching the tests on `staticcheck` in my environment (`module requires at least go1.26.0, but Staticcheck was built with go1.25.12`) — a toolchain mismatch unrelated to this change; `go vet ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)