### PR TITLE
Give CI's minikube every runner CPU, and diagnose Crossplane wait timeouts

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,6 +30,17 @@ jobs:
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           addons: metrics-server
+          # minikube's own default is --cpus=2, sized for serial use, and the suite below runs
+          # with -parallel=4. The Makefile already learned this the hard way and starts its
+          # cluster with --cpus=4 (see e2e-minikube-up's note on the defaults getting
+          # overwhelmed into widespread `kubectl wait` timeouts) -- but CI runs the
+          # ASSUME_MINIKUBE_IS_CONFIGURED branch, which skips e2e-minikube-up entirely, so that
+          # sizing never applied here and CI has been running the whole suite on 2 CPUs.
+          # "max" rather than a literal 4 so this tracks the runner size instead of pinning to
+          # today's 4-vCPU ubuntu-latest.
+          cpus: max
+          # memory is deliberately left at minikube's default: unlike --cpus it auto-sizes from
+          # the host, so naming a figure here could only shrink it.
       - name: Run e2e tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -941,11 +941,37 @@ func ensureCrossplane(t *testing.T) {
 		if output, err := exec.Command("kubectl", "apply", "-f", functionsManifest).CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply %s: %w: %s", functionsManifest, err, output)
 		}
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Healthy", "--timeout=180s",
+		// 5m, matching the helm installs above rather than being the one short wait in the
+		// function: both Functions are OCI packages pulled on demand, so this is a cold pull of
+		// two images plus a Deployment rollout, racing whatever else the suite has running.
+		output, err := exec.Command("kubectl", "wait", "--for=condition=Healthy", "--timeout=300s",
 			"function.pkg.crossplane.io", "--all").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("kubectl wait crossplane functions: %w: %s", err, output)
+			return fmt.Errorf("kubectl wait crossplane functions: %w: %s%s", err, output, crossplaneDiagnostics())
 		}
 		return nil
 	})
+}
+
+// crossplaneDiagnostics dumps the state that explains why the Functions never went Healthy. On
+// timeout `kubectl wait` says only "timed out waiting for the condition on functions/...", which
+// names no cause: a package still pulling, a pull that failed outright, and a Function whose pod
+// never got scheduled are indistinguishable in CI logs after the fact. The install runs
+// unattended on a cluster the rest of the suite is loading, so whatever is collected here is the
+// only evidence anyone gets -- the failure is not reproducible by re-reading the log later.
+func crossplaneDiagnostics() string {
+	var b strings.Builder
+	for _, args := range [][]string{
+		{"get", "function.pkg.crossplane.io", "-o", "wide"},
+		{"get", "functionrevision.pkg.crossplane.io", "-o", "wide"},
+		{"get", "pods", "-n", "crossplane-system", "-o", "wide"},
+		{"get", "events", "-n", "crossplane-system", "--sort-by=.lastTimestamp"},
+	} {
+		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		fmt.Fprintf(&b, "\n--- kubectl %s ---\n%s", strings.Join(args, " "), out)
+		if err != nil {
+			fmt.Fprintf(&b, "(%v)\n", err)
+		}
+	}
+	return b.String()
 }


### PR DESCRIPTION
## What broke

master's `ci-test` went red on `TestE2EDynamicManifests/Crossplane_XR_composes_namespaced_children_and_surfaces_their_health` ([run 30409806895](https://github.com/bergerx/kubectl-status/actions/runs/30409806895)), and **both** attempts of the retry failed identically:

```
kubectl wait crossplane functions: exit status 1: timed out waiting for the condition on functions/function-auto-ready
timed out waiting for the condition on functions/function-patch-and-transform
```

## Why it isn't the code that landed

- #772, the merge it broke on, only touched `Node.tmpl` rendering and static `tests/artifacts` — nothing reachable from this test.
- Every version involved is pinned (Crossplane `2.3.3` in `hack/versions.env`, both Functions by tag in `crossplane-functions.yaml`), so there was no silent upstream bump.
- Running that exact install off-cluster, both Functions go `Healthy` in **45s** on an idle 2-CPU minikube.

The one thing CI has that a local run doesn't is the rest of the suite hitting the same node at the same time.

## Root cause

`e2e-minikube-up` already sizes its cluster past minikube's defaults and explains why in the Makefile — they're *"sized for serial usage and get overwhelmed (widespread `kubectl wait` timeouts) under that load."* That's the exact symptom here.

CI never got that fix. It builds its cluster with `setup-minikube` and then runs the `ASSUME_MINIKUBE_IS_CONFIGURED` branch, which **skips `e2e-minikube-up` entirely**. The action passes no `--cpus`, so CI has been running all 179 tests at `-parallel=4` on minikube's default **2 CPUs** — passing on margin until the suite grew enough to spend it.

That also explains why the retry didn't rescue it: the Function pods declare no resource requests, so they schedule and then *starve* rather than sit Pending, and attempt 2 inherited the same saturated node plus everything attempt 1 left behind.

## Changes

1. **`cpus: max`** for `setup-minikube`. `max` rather than a literal `4` so it tracks the runner instead of pinning to today's 4-vCPU `ubuntu-latest`. `memory` is left alone on purpose — it auto-sizes from the host, so naming a figure could only shrink it.
2. **Diagnostics on the failure path.** `kubectl wait` reports only that it timed out, which can't distinguish a package still pulling from one that failed to pull from a pod that never ran — and the cluster is gone by the time anyone reads the log. Now dumps Functions, FunctionRevisions, `crossplane-system` pods and events.
3. **Wait 180s → 5m**, matching the helm installs above it in the same function. It's a cold pull of two OCI packages plus a rollout, and was the one short timeout there.

## Verification

- Reproduced the install standalone against a live cluster: Crossplane 2.3.3 + both Functions Healthy in 45s.
- `TestE2EDynamicManifests/Crossplane` passes against a real cluster with these changes (22s).
- Forced the wait to fail to exercise the new diagnostics — output includes per-image pull timings, i.e. exactly the evidence this investigation had to gather by hand.
- `go vet ./...` clean.

Note this is an e2e-harness fix, not a product fix: the failure is environment-specific and reproduces only under CI's cluster sizing, so this PR's own CI run is the real test of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)