### PR TITLE
Add generic Gatekeeper Constraint template (K8sRequiredLabels)

### DIFF
--- a/pkg/plugin/templates/K8sRequiredLabels.tmpl
+++ b/pkg/plugin/templates/K8sRequiredLabels.tmpl
@@ -1,0 +1,34 @@
+{{- define "K8sRequiredLabels" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* GVK: constraints.gatekeeper.sh/v1beta1, Kind=K8sRequiredLabels */ -}}
+    {{- /* kstatus_summary omitted: constraints carry no status.conditions, so it only ever
+           reports a generic "Resource is current" that duplicates nothing useful -- the
+           audit/violations/sync lines below are the actual health signal. */ -}}
+    {{- template "status_summary_line" . }}
+    {{- template "finalizer_details_on_termination" . }}
+    {{- template "observed_generation_summary" . }}
+    {{- template "application_details" . }}
+    {{- template "gatekeeper_constraint_match_and_enforcement" . }}
+    {{- with .Spec.parameters }}
+        {{- with .labels }}
+            {{- if eq (len .) 1 }}
+                {{- with index . 0 }}
+                    {{- "Required labels" | bold | nindent 2 }}: {{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                {{- end }}
+            {{- else }}
+                {{- "Required labels" | bold | nindent 2 }}:
+                {{- range . }}
+                    {{- "" | nindent 4 }}{{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- with .message }}
+            {{- "Message" | bold | nindent 2 }}: {{ . }}
+        {{- end }}
+    {{- end }}
+    {{- template "gatekeeper_constraint_audit_status" . }}
+    {{- template "conditions_summary" . }}
+    {{- template "recent_updates" . }}
+    {{- template "events" . }}
+    {{- template "owners" . }}
+{{- end }}

--- a/pkg/plugin/templates/K8sRequiredLabels.tmpl
+++ b/pkg/plugin/templates/K8sRequiredLabels.tmpl
@@ -11,14 +11,29 @@
     {{- template "gatekeeper_constraint_match_and_enforcement" . }}
     {{- with .Spec.parameters }}
         {{- with .labels }}
+            {{- /* This template is matched purely by the Kind name "K8sRequiredLabels", with no
+                   group/schema check (see findTemplateName) -- so it renders for ANY
+                   ConstraintTemplate that happens to use that name, not just the
+                   gatekeeper-library one it was written against. Gatekeeper's own quickstart
+                   demo, for instance, declares "labels" as a plain list of strings rather than
+                   {key, allowedRegex} objects. Rendering .key on a plain string errors out, so
+                   each item's shape is checked before assuming it's a map. */ -}}
             {{- if eq (len .) 1 }}
                 {{- with index . 0 }}
-                    {{- "Required labels" | bold | nindent 2 }}: {{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                    {{- if kindIs "map" . }}
+                        {{- "Required labels" | bold | nindent 2 }}: {{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                    {{- else }}
+                        {{- "Required labels" | bold | nindent 2 }}: {{ . | toString | cyan }}
+                    {{- end }}
                 {{- end }}
             {{- else }}
                 {{- "Required labels" | bold | nindent 2 }}:
                 {{- range . }}
-                    {{- "" | nindent 4 }}{{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                    {{- if kindIs "map" . }}
+                        {{- "" | nindent 4 }}{{ .key | cyan }}{{ with .allowedRegex }} matching {{ . | cyan }}{{ end }}
+                    {{- else }}
+                        {{- "" | nindent 4 }}{{ . | toString | cyan }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -1,0 +1,78 @@
+{{- define "gatekeeper_constraint_match_and_enforcement" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Shared by all Gatekeeper constraint kinds (constraints.gatekeeper.sh/*, one dynamic Kind
+           per installed ConstraintTemplate -- K8sRequiredLabels, K8sAllowedRepos, etc. -- all with
+           an identical spec.match/spec.enforcementAction and status.violations/byPod shape).
+           Renders spec.match (which objects this constraint evaluates) and the enforcement mode. */ -}}
+    {{- with .Spec.match }}
+        {{- if eq (len .kinds) 1 }}
+            {{- with index .kinds 0 }}
+                {{- "Match" | bold | nindent 2 }}: {{ .apiGroups | join "," | default "core" }}/{{ .kinds | join "," | cyan }}
+            {{- end }}
+        {{- else }}
+            {{- "Match" | bold | nindent 2 }}:
+            {{- range .kinds }}
+                {{- "" | nindent 4 }}{{ .apiGroups | join "," | default "core" }}/{{ .kinds | join "," | cyan }}
+            {{- end }}
+        {{- end }}
+        {{- with .scope }}{{ if ne . "*" }}, scope:{{ . | cyan }}{{ end }}{{ end }}
+        {{- with .name }}, name:{{ . | cyan }}{{ end }}
+        {{- with .namespaces }}, namespaces:{{ join "," . | cyan }}{{ end }}
+        {{- with .excludedNamespaces }}, excludedNamespaces:{{ join "," . | cyan }}{{ end }}
+        {{- with .labelSelector }}
+            {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}
+                {{- "labelSelector" | bold | nindent 4 }}: {{ . | labelSelector | cyan }}
+            {{- end }}
+        {{- end }}
+        {{- with .namespaceSelector }}
+            {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}
+                {{- "namespaceSelector" | bold | nindent 4 }}: {{ . | labelSelector | cyan }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $enforcementAction := .Spec.enforcementAction | default "deny" }}
+    {{- "enforcementAction" | bold | nindent 2 }}: {{ if eq $enforcementAction "deny" }}{{ $enforcementAction | cyan }}{{ else }}{{ $enforcementAction | yellow | bold }} (violations are not blocked){{ end }}
+    {{- with .Spec.scopedEnforcementActions }}
+        {{- range . }}
+            {{- $action := .action | default "deny" }}
+            {{- $points := list }}
+            {{- range .enforcementPoints }}{{ $points = append $points .name }}{{ end }}
+            {{- "" | nindent 4 }}{{ $action | redBoldIf (ne $action "deny") }} at {{ $points | join "," | cyan }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "gatekeeper_constraint_audit_status" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Shared audit/violations/replica-sync rendering, see gatekeeper_constraint_match_and_enforcement. */ -}}
+    {{- with .Status.auditTimestamp }}
+        {{- "Last audited" | bold | nindent 2 }}: {{ . | colorAgo }}{{ agoSuffix }}
+    {{- end }}
+    {{- $total := .Status.totalViolations | default 0 | int }}
+    {{- $violations := .Status.violations | default list }}
+    {{- if gt $total 0 }}
+        {{- "Violations" | red | bold | nindent 2 }}: {{ $total | toString | red | bold }}
+        {{- $cap := 10 }}
+        {{- range $i, $v := $violations }}
+            {{- if lt $i $cap }}
+                {{- "" | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" $v.kind "name" $v.name "namespace" $v.namespace) }}: {{ $v.message | red }}
+                {{- with $v.enforcementAction }}{{ if ne . "deny" }} [{{ . | yellow }}]{{ end }}{{ end }}
+            {{- end }}
+        {{- end }}
+        {{- $shown := len $violations }}
+        {{- if gt $shown $cap }}{{ $shown = $cap }}{{ end }}
+        {{- with sub $total $shown }}{{ if gt . 0 }}
+            {{- printf "… %d more" . | nindent 4 }}
+        {{- end }}{{ end }}
+    {{- else }}
+        {{- "Violations" | green | nindent 2 }}: none
+    {{- end }}
+    {{- with .Status.byPod }}
+        {{- $total := len . }}
+        {{- $enforced := 0 }}
+        {{- range . }}{{ if .enforced }}{{ $enforced = add1 $enforced }}{{ end }}{{ end }}
+        {{- if lt $enforced $total }}
+            {{- "Sync" | red | bold | nindent 2 }}: {{ printf "%d/%d" $enforced $total | red | bold }} gatekeeper replicas enforcing this constraint
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -5,20 +5,36 @@
            an identical spec.match/spec.enforcementAction and status.violations/byPod shape).
            Renders spec.match (which objects this constraint evaluates) and the enforcement mode. */ -}}
     {{- with .Spec.match }}
-        {{- if eq (len .kinds) 1 }}
+        {{- /* .kinds is optional -- matching by namespaces/namespaceSelector alone is valid, and
+               len on a genuinely absent (nil) value errors out rather than returning 0, so check
+               presence with "with" first instead of calling len directly on .kinds. */ -}}
+        {{- $numKinds := 0 }}
+        {{- with .kinds }}{{ $numKinds = len . }}{{ end }}
+        {{- if eq $numKinds 1 }}
             {{- with index .kinds 0 }}
                 {{- "Match" | bold | nindent 2 }}: {{ .apiGroups | join "," | default "core" }}/{{ .kinds | join "," | cyan }}
             {{- end }}
+            {{- with .scope }}{{ if ne . "*" }}, scope:{{ . | cyan }}{{ end }}{{ end }}
+            {{- with .name }}, name:{{ . | cyan }}{{ end }}
+            {{- with .namespaces }}, namespaces:{{ join "," . | cyan }}{{ end }}
+            {{- with .excludedNamespaces }}, excludedNamespaces:{{ join "," . | cyan }}{{ end }}
         {{- else }}
-            {{- "Match" | bold | nindent 2 }}:
-            {{- range .kinds }}
-                {{- "" | nindent 4 }}{{ .apiGroups | join "," | default "core" }}/{{ .kinds | join "," | cyan }}
+            {{- /* 0 or 2+ kinds: scope/name/namespaces/excludedNamespaces apply to the whole
+                   match, not to any one kind, so they get their own line instead of trailing
+                   after the last kind in the loop below. */ -}}
+            {{- if gt $numKinds 0 }}
+                {{- "Match" | bold | nindent 2 }}:
+                {{- range .kinds }}
+                    {{- "" | nindent 4 }}{{ .apiGroups | join "," | default "core" }}/{{ .kinds | join "," | cyan }}
+                {{- end }}
+            {{- else }}
+                {{- "Match" | bold | nindent 2 }}: any kind
             {{- end }}
+            {{- with .scope }}{{ if ne . "*" }}{{ "" | nindent 4 }}scope:{{ . | cyan }}{{ end }}{{ end }}
+            {{- with .name }}{{ "" | nindent 4 }}name:{{ . | cyan }}{{ end }}
+            {{- with .namespaces }}{{ "" | nindent 4 }}namespaces:{{ join "," . | cyan }}{{ end }}
+            {{- with .excludedNamespaces }}{{ "" | nindent 4 }}excludedNamespaces:{{ join "," . | cyan }}{{ end }}
         {{- end }}
-        {{- with .scope }}{{ if ne . "*" }}, scope:{{ . | cyan }}{{ end }}{{ end }}
-        {{- with .name }}, name:{{ . | cyan }}{{ end }}
-        {{- with .namespaces }}, namespaces:{{ join "," . | cyan }}{{ end }}
-        {{- with .excludedNamespaces }}, excludedNamespaces:{{ join "," . | cyan }}{{ end }}
         {{- with .labelSelector }}
             {{- if or (hasKey . "matchLabels") (hasKey . "matchExpressions") }}
                 {{- "labelSelector" | bold | nindent 4 }}: {{ . | labelSelector | cyan }}
@@ -31,7 +47,10 @@
         {{- end }}
     {{- end }}
     {{- $enforcementAction := .Spec.enforcementAction | default "deny" }}
-    {{- "enforcementAction" | bold | nindent 2 }}: {{ if eq $enforcementAction "deny" }}{{ $enforcementAction | cyan }}{{ else }}{{ $enforcementAction | yellow | bold }} (violations are not blocked){{ end }}
+    {{- /* "scoped" is decided per-enforcement-point by scopedEnforcementActions below, not by
+           this top-level value, so the blanket "not blocked" parenthetical is only accurate for
+           the deny/dryrun/warn cases -- it must not be printed for "scoped". */ -}}
+    {{- "enforcementAction" | bold | nindent 2 }}: {{ if eq $enforcementAction "deny" }}{{ $enforcementAction | cyan }}{{ else if eq $enforcementAction "scoped" }}{{ $enforcementAction | yellow | bold }}{{ else }}{{ $enforcementAction | yellow | bold }} (violations are not blocked){{ end }}
     {{- with .Spec.scopedEnforcementActions }}
         {{- range . }}
             {{- $action := .action | default "deny" }}
@@ -45,27 +64,57 @@
 {{- define "gatekeeper_constraint_audit_status" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* Shared audit/violations/replica-sync rendering, see gatekeeper_constraint_match_and_enforcement. */ -}}
+    {{- $auditedYet := false }}
     {{- with .Status.auditTimestamp }}
+        {{- $auditedYet = true }}
         {{- "Last audited" | bold | nindent 2 }}: {{ . | colorAgo }}{{ agoSuffix }}
     {{- end }}
     {{- $total := .Status.totalViolations | default 0 | int }}
     {{- $violations := .Status.violations | default list }}
+    {{- $topAction := .Spec.enforcementAction | default "deny" }}
     {{- if gt $total 0 }}
         {{- "Violations" | red | bold | nindent 2 }}: {{ $total | toString | red | bold }}
-        {{- $cap := 10 }}
-        {{- range $i, $v := $violations }}
-            {{- if lt $i $cap }}
-                {{- "" | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" $v.kind "name" $v.name "namespace" $v.namespace) }}: {{ $v.message | red }}
-                {{- with $v.enforcementAction }}{{ if ne . "deny" }} [{{ . | yellow }}]{{ end }}{{ end }}
+        {{- if eq (len $violations) 0 }}
+            {{- /* Clusters can run with --constraint-violations-limit=0 to keep violation
+                   targets out of status/etcd while still reporting the true count in
+                   totalViolations -- say so instead of printing "... N more" under an empty
+                   list, which reads as a rendering bug. */ -}}
+            {{- "" | nindent 4 }}{{ "(violation targets not recorded in status; see --constraint-violations-limit)" | yellow }}
+        {{- else }}
+            {{- /* Some ConstraintTemplates (e.g. the gatekeeper-library K8sRequiredLabels) emit
+                   more than one violation message per target object. Group by target so the
+                   10-line cap reflects distinct objects rather than being burned on duplicate
+                   entries for the same object. */ -}}
+            {{- $cap := 10 }}
+            {{- $order := list }}
+            {{- $byTarget := dict }}
+            {{- range $violations }}
+                {{- $key := printf "%s/%s/%s" .kind (.namespace | default "") .name }}
+                {{- if not (hasKey $byTarget $key) }}
+                    {{- $order = append $order $key }}
+                    {{- $_ := $byTarget | set $key (dict "kind" .kind "namespace" .namespace "name" .name "messages" list "actions" list) }}
+                {{- end }}
+                {{- $entry := index $byTarget $key }}
+                {{- $_ := $entry | set "messages" (append $entry.messages .message) }}
+                {{- with .enforcementAction }}{{ $_ := $entry | set "actions" (append $entry.actions .) }}{{ end }}
             {{- end }}
+            {{- $shownRaw := 0 }}
+            {{- range $i, $key := $order }}
+                {{- if lt $i $cap }}
+                    {{- $entry := index $byTarget $key }}
+                    {{- "" | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" $entry.kind "name" $entry.name "namespace" $entry.namespace) }}: {{ join "; " $entry.messages | red }}
+                    {{- range $entry.actions }}{{ if ne . $topAction }} [{{ . | yellow }}]{{ end }}{{ end }}
+                    {{- $shownRaw = add $shownRaw (len $entry.messages) }}
+                {{- end }}
+            {{- end }}
+            {{- with sub $total $shownRaw }}{{ if gt . 0 }}
+                {{- printf "… %d more" . | nindent 4 }}
+            {{- end }}{{ end }}
         {{- end }}
-        {{- $shown := len $violations }}
-        {{- if gt $shown $cap }}{{ $shown = $cap }}{{ end }}
-        {{- with sub $total $shown }}{{ if gt . 0 }}
-            {{- printf "… %d more" . | nindent 4 }}
-        {{- end }}{{ end }}
-    {{- else }}
+    {{- else if $auditedYet }}
         {{- "Violations" | green | nindent 2 }}: none
+    {{- else }}
+        {{- "Violations" | yellow | nindent 2 }}: not yet audited
     {{- end }}
     {{- with .Status.byPod }}
         {{- $total := len . }}

--- a/tests/artifacts/constraint-clean.out
+++ b/tests/artifacts/constraint-clean.out
@@ -1,0 +1,7 @@
+
+K8sRequiredLabels/always-satisfied, created 1m ago, gen:1
+  Match: core/Namespace
+  enforcementAction: deny
+  Required labels: kubernetes.io/metadata.name
+  Last audited: 1m ago
+  Violations: none

--- a/tests/artifacts/constraint-clean.yaml
+++ b/tests/artifacts/constraint-clean.yaml
@@ -1,0 +1,60 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sRequiredLabels","metadata":{"annotations":{},"name":"always-satisfied"},"spec":{"match":{"kinds":[{"apiGroups":[""],"kinds":["Namespace"]}]},"parameters":{"labels":[{"key":"kubernetes.io/metadata.name"}]}}}
+  creationTimestamp: "2026-07-28T10:45:17Z"
+  generation: 1
+  name: always-satisfied
+  resourceVersion: "24018"
+  uid: db454f41-770b-4da3-bd48-3c409ede6fd7
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Namespace
+  parameters:
+    labels:
+    - key: kubernetes.io/metadata.name
+status:
+  auditTimestamp: "2026-07-28T13:33:23Z"
+  byPod:
+  - constraintUID: db454f41-770b-4da3-bd48-3c409ede6fd7
+    enforced: true
+    enforcementPointsStatus:
+    - enforcementPoint: vap.k8s.io
+      observedGeneration: 1
+      state: generated
+    id: gatekeeper-audit-5cc96fbf64-8rlsb
+    observedGeneration: 1
+    operations:
+    - audit
+    - generate
+    - mutation-status
+    - status
+  - constraintUID: db454f41-770b-4da3-bd48-3c409ede6fd7
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-9vpj8
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: db454f41-770b-4da3-bd48-3c409ede6fd7
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-jkc4d
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: db454f41-770b-4da3-bd48-3c409ede6fd7
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-pfnjr
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  totalViolations: 0

--- a/tests/artifacts/constraint-deny-violations.out
+++ b/tests/artifacts/constraint-deny-violations.out
@@ -1,0 +1,19 @@
+
+K8sRequiredLabels/all-must-have-owner, created 1m ago, gen:5
+  Match: core/Namespace
+  enforcementAction: deny
+  Required labels: owner matching ^[a-zA-Z]+.agilebank.demo$
+  Message: All namespaces must have an `owner` label that points to your company username
+  Last audited: 1m ago
+  Violations: 22
+    Namespace/test-violation-5: regex mismatch
+    Namespace/test-violation-5: missing required label, requires all of: owner
+    Namespace/test-violation-4: regex mismatch
+    Namespace/test-violation-4: missing required label, requires all of: owner
+    Namespace/test-violation-3: regex mismatch
+    Namespace/test-violation-3: missing required label, requires all of: owner
+    Namespace/test-violation-2: regex mismatch
+    Namespace/test-violation-2: missing required label, requires all of: owner
+    Namespace/test-violation-1: regex mismatch
+    Namespace/test-violation-1: missing required label, requires all of: owner
+    … 12 more

--- a/tests/artifacts/constraint-deny-violations.out
+++ b/tests/artifacts/constraint-deny-violations.out
@@ -6,14 +6,14 @@ K8sRequiredLabels/all-must-have-owner, created 1m ago, gen:5
   Message: All namespaces must have an `owner` label that points to your company username
   Last audited: 1m ago
   Violations: 22
-    Namespace/test-violation-5: regex mismatch
-    Namespace/test-violation-5: missing required label, requires all of: owner
-    Namespace/test-violation-4: regex mismatch
-    Namespace/test-violation-4: missing required label, requires all of: owner
-    Namespace/test-violation-3: regex mismatch
-    Namespace/test-violation-3: missing required label, requires all of: owner
-    Namespace/test-violation-2: regex mismatch
-    Namespace/test-violation-2: missing required label, requires all of: owner
-    Namespace/test-violation-1: regex mismatch
-    Namespace/test-violation-1: missing required label, requires all of: owner
-    … 12 more
+    Namespace/test-violation-5: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-4: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-3: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-2: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-1: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-system: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-public: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-node-lease: regex mismatch; missing required label, requires all of: owner
+    Namespace/gatekeeper-system: regex mismatch; missing required label, requires all of: owner
+    Namespace/default: regex mismatch; missing required label, requires all of: owner
+    … 2 more

--- a/tests/artifacts/constraint-deny-violations.yaml
+++ b/tests/artifacts/constraint-deny-violations.yaml
@@ -1,0 +1,184 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sRequiredLabels","metadata":{"annotations":{},"name":"all-must-have-owner"},"spec":{"match":{"kinds":[{"apiGroups":[""],"kinds":["Namespace"]}]},"parameters":{"labels":[{"allowedRegex":"^[a-zA-Z]+.agilebank.demo$","key":"owner"}],"message":"All namespaces must have an `owner` label that points to your company username"}}}
+  creationTimestamp: "2026-07-27T10:22:03Z"
+  generation: 5
+  name: all-must-have-owner
+  resourceVersion: "24017"
+  uid: 3c866d2e-289f-46e0-a61a-96487fd03395
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Namespace
+  parameters:
+    labels:
+    - allowedRegex: ^[a-zA-Z]+.agilebank.demo$
+      key: owner
+    message: All namespaces must have an `owner` label that points to your company
+      username
+status:
+  auditTimestamp: "2026-07-28T13:33:23Z"
+  byPod:
+  - constraintUID: 3c866d2e-289f-46e0-a61a-96487fd03395
+    enforced: true
+    enforcementPointsStatus:
+    - enforcementPoint: vap.k8s.io
+      observedGeneration: 5
+      state: generated
+    id: gatekeeper-audit-5cc96fbf64-8rlsb
+    observedGeneration: 5
+    operations:
+    - audit
+    - generate
+    - mutation-status
+    - status
+  - constraintUID: 3c866d2e-289f-46e0-a61a-96487fd03395
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-9vpj8
+    observedGeneration: 5
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: 3c866d2e-289f-46e0-a61a-96487fd03395
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-jkc4d
+    observedGeneration: 5
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: 3c866d2e-289f-46e0-a61a-96487fd03395
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-pfnjr
+    observedGeneration: 5
+    operations:
+    - mutation-webhook
+    - webhook
+  totalViolations: 22
+  violations:
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-5
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-5
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-4
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-4
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-3
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-3
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-2
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-2
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-1
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-1
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-system
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-system
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-public
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-public
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-node-lease
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-node-lease
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: gatekeeper-system
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: gatekeeper-system
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: default
+    version: v1
+  - enforcementAction: deny
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: default
+    version: v1

--- a/tests/artifacts/constraint-dryrun-truncated.out
+++ b/tests/artifacts/constraint-dryrun-truncated.out
@@ -5,14 +5,14 @@ K8sRequiredLabels/dryrun-check, created 1m ago, gen:1
   Required labels: owner
   Last audited: 1m ago
   Violations: 22
-    Namespace/test-violation-5: regex mismatch [dryrun]
-    Namespace/test-violation-5: missing required label, requires all of: owner [dryrun]
-    Namespace/test-violation-4: regex mismatch [dryrun]
-    Namespace/test-violation-4: missing required label, requires all of: owner [dryrun]
-    Namespace/test-violation-3: regex mismatch [dryrun]
-    Namespace/test-violation-3: missing required label, requires all of: owner [dryrun]
-    Namespace/test-violation-2: regex mismatch [dryrun]
-    Namespace/test-violation-2: missing required label, requires all of: owner [dryrun]
-    Namespace/test-violation-1: regex mismatch [dryrun]
-    Namespace/test-violation-1: missing required label, requires all of: owner [dryrun]
-    … 12 more
+    Namespace/test-violation-5: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-4: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-3: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-2: regex mismatch; missing required label, requires all of: owner
+    Namespace/test-violation-1: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-system: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-public: regex mismatch; missing required label, requires all of: owner
+    Namespace/kube-node-lease: regex mismatch; missing required label, requires all of: owner
+    Namespace/gatekeeper-system: regex mismatch; missing required label, requires all of: owner
+    Namespace/default: regex mismatch; missing required label, requires all of: owner
+    … 2 more

--- a/tests/artifacts/constraint-dryrun-truncated.out
+++ b/tests/artifacts/constraint-dryrun-truncated.out
@@ -1,0 +1,18 @@
+
+K8sRequiredLabels/dryrun-check, created 1m ago, gen:1
+  Match: core/Namespace
+  enforcementAction: dryrun (violations are not blocked)
+  Required labels: owner
+  Last audited: 1m ago
+  Violations: 22
+    Namespace/test-violation-5: regex mismatch [dryrun]
+    Namespace/test-violation-5: missing required label, requires all of: owner [dryrun]
+    Namespace/test-violation-4: regex mismatch [dryrun]
+    Namespace/test-violation-4: missing required label, requires all of: owner [dryrun]
+    Namespace/test-violation-3: regex mismatch [dryrun]
+    Namespace/test-violation-3: missing required label, requires all of: owner [dryrun]
+    Namespace/test-violation-2: regex mismatch [dryrun]
+    Namespace/test-violation-2: missing required label, requires all of: owner [dryrun]
+    Namespace/test-violation-1: regex mismatch [dryrun]
+    Namespace/test-violation-1: missing required label, requires all of: owner [dryrun]
+    … 12 more

--- a/tests/artifacts/constraint-dryrun-truncated.yaml
+++ b/tests/artifacts/constraint-dryrun-truncated.yaml
@@ -1,0 +1,181 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sRequiredLabels","metadata":{"annotations":{},"name":"dryrun-check"},"spec":{"enforcementAction":"dryrun","match":{"kinds":[{"apiGroups":[""],"kinds":["Namespace"]}]},"parameters":{"labels":[{"key":"owner"}]}}}
+  creationTimestamp: "2026-07-28T10:45:10Z"
+  generation: 1
+  name: dryrun-check
+  resourceVersion: "24019"
+  uid: 6466f129-f196-48e5-97e3-68718e778736
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Namespace
+  parameters:
+    labels:
+    - key: owner
+status:
+  auditTimestamp: "2026-07-28T13:33:23Z"
+  byPod:
+  - constraintUID: 6466f129-f196-48e5-97e3-68718e778736
+    enforced: true
+    enforcementPointsStatus:
+    - enforcementPoint: vap.k8s.io
+      observedGeneration: 1
+      state: generated
+    id: gatekeeper-audit-5cc96fbf64-8rlsb
+    observedGeneration: 1
+    operations:
+    - audit
+    - generate
+    - mutation-status
+    - status
+  - constraintUID: 6466f129-f196-48e5-97e3-68718e778736
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-9vpj8
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: 6466f129-f196-48e5-97e3-68718e778736
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-jkc4d
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  - constraintUID: 6466f129-f196-48e5-97e3-68718e778736
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-pfnjr
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  totalViolations: 22
+  violations:
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-5
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-5
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-4
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-4
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-3
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-3
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-2
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-2
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: test-violation-1
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: test-violation-1
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-system
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-system
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-public
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-public
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: kube-node-lease
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: kube-node-lease
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: gatekeeper-system
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: gatekeeper-system
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: regex mismatch
+    name: default
+    version: v1
+  - enforcementAction: dryrun
+    group: ""
+    kind: Namespace
+    message: 'missing required label, requires all of: owner'
+    name: default
+    version: v1


### PR DESCRIPTION
Closes #666

Adds a generic gatekeeper_constraint_match_and_enforcement/gatekeeper_constraint_audit_status sub-template (constraints.gatekeeper.sh/*, keyed off spec.match, spec.enforcementAction, status.violations/status.totalViolations) plus a thin K8sRequiredLabels.tmpl wrapper as the Kind.

Namespace.tmpl detection hint (mentioned in the issue) intentionally left out of scope for this PR.
--deep doesn't inline violation targets as the list is unbounded (Gatekeeper's own audit can report far more than fit compactly), which seemed to outweigh the reference-field convention here. I can add it as well if need be.
No TestE2EDynamicManifests case due to the same as above.
Have reviewed and manually tested against a live cluster (deny/violations, dryrun, zero-violations, and over-the-cap-truncation cases) before submitting.