### PR TITLE
Add gitleaks and govulncheck security scanning

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,10 +22,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: make test
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
-        with:
-          go-version-file: 'go.mod'
       - name: Start minikube
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -5,6 +5,15 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  # Both checks can start failing without anyone touching the repo -- govulncheck reads a
+  # vulnerability DB that gains entries for already-released dependencies, and gitleaks ships
+  # new detection rules that can match content already in history. A daily run on master
+  # surfaces that within a day instead of whenever someone next happens to open a PR.
+  schedule:
+    - cron: '17 6 * * *'
+  # So the same scan can be re-run on demand (e.g. right after bumping a dependency) without
+  # waiting for the nightly slot.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,41 @@
+name: security-checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+  # gitleaks-action reads the PR's commit list via the API to scope its scan -- it hard-fails
+  # without a token on pull_request events, even with comments disabled below.
+  pull-requests: read
+
+jobs:
+  security-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # gitleaks-action resolves `<base-commit>^` to diff against on push/pull_request
+          # events, which fails on a shallow clone.
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pinned so the action skips its own version-lookup API call. Keep in sync with
+          # GITLEAKS_MODULE in the Makefile.
+          GITLEAKS_VERSION: "8.30.1"
+          # PR review comments need pull-requests: write, which this job intentionally
+          # doesn't have; findings still show up in the job summary/logs/sarif artifact.
+          GITLEAKS_ENABLE_COMMENTS: "false"
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-file: 'go.mod'
+          # Already checked out above (with fetch-depth: 0 for gitleaks); skip this
+          # action's own default checkout.
+          repo-checkout: false

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,65 @@
+# Known test fixtures under tests/artifacts and tests/e2e-artifacts: synthetic
+# TLS keys/tokens generated from a disposable minikube cluster for kubectl-status
+# test coverage, not real credentials. Regenerate via:
+#   go run github.com/zricethezav/gitleaks/v8@v8.30.1 git --redact -r /tmp/report.json .
+# then extract .[].Fingerprint
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-basic-auth-healthy.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-expired.yaml:generic-api-key:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-expired.yaml:generic-api-key:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-expired.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-expired.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-healthy.yaml:generic-api-key:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-healthy.yaml:generic-api-key:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-healthy.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-bootstrap-token-healthy.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-opaque-malformed-cert.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-service-account-token-healthy.yaml:generic-api-key:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-service-account-token-healthy.yaml:jwt-base64:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-service-account-token-healthy.yaml:jwt:5
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-ssh-auth-healthy.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-ssh-auth-healthy.yaml:private-key:3
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-ssh-auth-malformed.yaml:generic-api-key:3
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-ssh-auth-malformed.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-tls-malformed-cert.yaml:generic-api-key:4
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-tls-malformed-cert.yaml:kubernetes-secret-yaml:2
+010ee98d7b86e683ad863769eea258f91d6f9902:tests/artifacts/secret-tls-malformed-cert.yaml:kubernetes-secret-yaml:2
+137fba623a32e82eb7ac710fdfdf2e638f4bf04f:tests/artifacts/secret-dockerconfig-healthy.yaml:generic-api-key:3
+137fba623a32e82eb7ac710fdfdf2e638f4bf04f:tests/artifacts/secret-dockerconfig-healthy.yaml:generic-api-key:3
+137fba623a32e82eb7ac710fdfdf2e638f4bf04f:tests/artifacts/secret-dockerconfig-healthy.yaml:kubernetes-secret-yaml:2
+137fba623a32e82eb7ac710fdfdf2e638f4bf04f:tests/artifacts/secret-tls-expired.yaml:private-key:4
+167a5019d218e9e5e033d6dbd4d43389db5284da:tests/e2e-artifacts/pod-image-pull-secrets.yaml:kubernetes-secret-yaml:11
+9f2119fb9c70949b3b9db7839a9b9664552cdb48:tests/artifacts/secret-cert-manager-managed.yaml:private-key:5
+9f2119fb9c70949b3b9db7839a9b9664552cdb48:tests/artifacts/secret-opaque-cert-manager-ca.yaml:private-key:5
+bbb1ad9e7392bcc50f03f141dcbdab7716dd1689:tests/artifacts/secret-helm-release-deployed.yaml:kubernetes-secret-yaml:2
+bbb1ad9e7392bcc50f03f141dcbdab7716dd1689:tests/artifacts/secret-helm-release-deployed.yaml:kubernetes-secret-yaml:2
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-healthy.yaml:kubernetes-secret-yaml:48
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-healthy.yaml:private-key:58
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-problems.yaml:kubernetes-secret-yaml:137
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-problems.yaml:kubernetes-secret-yaml:149
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-problems.yaml:kubernetes-secret-yaml:162
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-problems.yaml:private-key:159
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/gateway-tls-problems.yaml:private-key:172
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/grpcroute-tls-healthy.yaml:kubernetes-secret-yaml:81
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/grpcroute-tls-healthy.yaml:private-key:91
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/grpcroute-tls-problems.yaml:kubernetes-secret-yaml:75
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-healthy.yaml:kubernetes-secret-yaml:48
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-healthy.yaml:private-key:58
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-problems.yaml:kubernetes-secret-yaml:85
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-problems.yaml:kubernetes-secret-yaml:98
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-problems.yaml:private-key:108
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/httproute-tls-problems.yaml:private-key:95
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-healthy.yaml:kubernetes-secret-yaml:40
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-healthy.yaml:private-key:50
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-problems.yaml:kubernetes-secret-yaml:65
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-problems.yaml:kubernetes-secret-yaml:76
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-problems.yaml:kubernetes-secret-yaml:88
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/ingress-tls-problems.yaml:private-key:98
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/secret-tls-healthy.yaml:kubernetes-secret-yaml:2
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/secret-tls-healthy.yaml:private-key:12
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/secret-tls-self-signed.yaml:kubernetes-secret-yaml:2
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/secret-tls-self-signed.yaml:private-key:12
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/tlsroute-tls-healthy.yaml:kubernetes-secret-yaml:78
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/tlsroute-tls-healthy.yaml:private-key:88
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/tlsroute-tls-problems.yaml:kubernetes-secret-yaml:121
+d733fbe312eac7d3f1ca427ff20fc053c885548a:tests/artifacts/tlsroute-tls-problems.yaml:private-key:131
+d87d2d366f3bd633c9713299911c53dc5b968dca:tests/artifacts/ingress-tls-problems.yaml:private-key:88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,15 +20,14 @@ repos:
 -   repo: local
     hooks:
 
-    # install-pre-push-hook and make-test-e2e are commented out: they got too
-    # heavyweight for a local pre-push hook. Delegating to CI for now until
-    # their runtime is sorted out.
-    # -   id: install-pre-push-hook
-    #     name: install-pre-push-hook
-    #     entry: pre-commit install -t pre-push
-    #     language: system
-    #     always_run: true
-    #     pass_filenames: false
+    # Usual pre-commit install only installs the pre-commit hook, trying to get
+    # them installed through this hook.
+    -   id: install-pre-push-hook
+        name: install-pre-push-hook
+        entry: pre-commit install -t pre-push
+        language: system
+        always_run: true
+        pass_filenames: false
 
     -   id: make-test
         name: make test
@@ -37,6 +36,22 @@ repos:
         always_run: true
         pass_filenames: false
 
+    # Pre-push rather than pre-commit: both checks scan the whole repo (full git
+    # history for gitleaks, the whole module graph for govulncheck) rather than
+    # just the change in front of you, so they're too slow to pay for on every
+    # commit and there's nothing new to learn from rerunning them per commit in
+    # a branch. This mirrors what security-checks.yml runs, so a failure shows
+    # up before the push rather than in CI afterwards.
+    -   id: make-security-check
+        name: make security-check
+        stages: [pre-push]
+        entry: make security-check
+        language: system
+        always_run: true
+        pass_filenames: false
+
+    # make-test-e2e is commented out: it got too heavyweight for a local pre-push
+    # hook. Delegating to CI for now until its runtime is sorted out.
     # -   id: make-test-e2e
     #     name: make test-e2e
     #     stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,32 @@ Before submitting a PR, ensure tests pass:
 make test
 ```
 
+### Security Checks
+
+`make security-check` runs the two repo-wide security scans:
+
+```bash
+make security-check   # gitleaks (full git history) + govulncheck (module graph)
+```
+
+- **gitleaks** scans the whole git history for committed secrets. The synthetic secrets in
+  `tests/artifacts/` are allowlisted by fingerprint in the committed `.gitleaksignore`, so only
+  genuinely new findings fail the scan. When you add a fixture that trips a rule, run
+  `make gitleaks-allow` to append its fingerprint(s) (fingerprints only — no secret content or
+  commit metadata) and review the resulting `.gitleaksignore` diff before committing; that same
+  command would silence a real leak, so don't run it reflexively on a red scan.
+- **govulncheck** reports known vulnerabilities that are actually reachable from this module's
+  code, so a finding usually means bumping the dependency in `go.mod`.
+
+These are deliberately **not** part of `make test`/the pre-commit hook: both scan the repo as a
+whole rather than the change in front of you, so per-commit runs cost time without telling you
+anything new. They run at pre-push instead (the `make-security-check` hook in
+`.pre-commit-config.yaml`, installed by the `install-pre-push-hook` hook the first time
+pre-commit runs), so you find out before the push rather than from CI afterwards. CI runs the
+same pair in `.github/workflows/security-checks.yml` — on every PR and push to `master`, plus
+daily, since both checks can start failing without anyone touching the repo (a new entry in the
+vulnerability DB, a new gitleaks rule matching something already in history).
+
 ### Claude Code Integration
 
 The project ships a [Claude Code](https://claude.ai/code) skill and project-level settings under `.claude/`.

--- a/Makefile
+++ b/Makefile
@@ -32,20 +32,35 @@ fmt:
 vet:
 	go vet ./...
 
+# `go run <mod>@<version>` builds the tool with the *oldest* toolchain that module's own go.mod
+# allows (go1.25 for both staticcheck v0.6.1 and x/vuln v1.6.0), however new the local Go is. A
+# tool that type-checks this module's packages then rejects every one of them with "package
+# requires newer Go version go1.26 (application built with go1.25)". Pinning to `go env GOVERSION`
+# -- go.mod's version, once GOTOOLCHAIN=auto has resolved it -- keeps the analyzer at least as new
+# as the code it analyzes. Only bites where the machine's base Go predates go.mod's (CI's base Go
+# is installed from go.mod, so there's nothing for it to downgrade to and it never trips this).
+TOOL_GOVERSION = $(shell go env GOVERSION)
+
 .PHONY: staticcheck
 staticcheck:
-	go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
+	GOTOOLCHAIN=$(TOOL_GOVERSION) go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
+
+#--------------------------
+# Security
+#--------------------------
+# Deliberately not wired into `test` (i.e. not into the pre-commit hook or ci-test.yml):
+# both checks are about the repo as a whole rather than the change in front of you, and
+# both are already covered in CI by .github/workflows/security-checks.yml -- running them
+# from `test` too would just duplicate that job on every push. Locally they're a pre-push
+# concern instead, see the make-security-check hook in .pre-commit-config.yaml.
+.PHONY: security-check
+security-check: gitleaks govulncheck
 
 GITLEAKS_MODULE := github.com/zricethezav/gitleaks/v8@v8.30.1
 
 .PHONY: gitleaks
 gitleaks:
 	go run $(GITLEAKS_MODULE) git --redact --no-banner --verbose --log-level warn
-
-# Fast path for pre-commit: scans only staged content instead of full history.
-.PHONY: gitleaks-staged
-gitleaks-staged:
-	go run $(GITLEAKS_MODULE) git --staged --redact --no-banner --verbose --log-level warn
 
 # Appends fingerprints for current findings (e.g. a newly added test fixture)
 # to .gitleaksignore, skipping ones already listed. Findings are matched by
@@ -72,17 +87,17 @@ gitleaks-allow:
 
 GOVULNCHECK_MODULE := golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
+# GOTOOLCHAIN: govulncheck type-checks the packages it scans, so it needs the same treatment as
+# staticcheck -- see the TOOL_GOVERSION comment above.
 .PHONY: govulncheck
 govulncheck:
-	go run $(GOVULNCHECK_MODULE) ./...
+	GOTOOLCHAIN=$(TOOL_GOVERSION) go run $(GOVULNCHECK_MODULE) ./...
 
 #--------------------------
 # Test
 #--------------------------
 .PHONY: test
-# gitleaks-staged (not the full-history gitleaks) so this stays cheap enough to run on every
-# commit; the full-history scan still runs in CI via .github/workflows/security-checks.yml.
-test: vet staticcheck gitleaks-staged govulncheck
+test: vet staticcheck
 	go test ./...
 
 #--------------------------

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,53 @@ vet:
 staticcheck:
 	go run honnef.co/go/tools/cmd/staticcheck@v0.6.1 ./...
 
+GITLEAKS_MODULE := github.com/zricethezav/gitleaks/v8@v8.30.1
+
+.PHONY: gitleaks
+gitleaks:
+	go run $(GITLEAKS_MODULE) git --redact --no-banner --verbose --log-level warn
+
+# Fast path for pre-commit: scans only staged content instead of full history.
+.PHONY: gitleaks-staged
+gitleaks-staged:
+	go run $(GITLEAKS_MODULE) git --staged --redact --no-banner --verbose --log-level warn
+
+# Appends fingerprints for current findings (e.g. a newly added test fixture)
+# to .gitleaksignore, skipping ones already listed. Findings are matched by
+# fingerprint only (commit:file:rule-id:line), so nothing here embeds secret
+# content or commit metadata. Review the diff before committing -- this is
+# also the command that would silence a genuine leak if one slipped in.
+.PHONY: gitleaks-allow
+gitleaks-allow:
+	@tmp=$$(mktemp); \
+	go run $(GITLEAKS_MODULE) git --redact --no-banner --log-level warn -f json -r "$$tmp" >/dev/null 2>&1; \
+	added=0; \
+	for fp in $$(jq -r '.[].Fingerprint' "$$tmp" | sort -u); do \
+		if ! grep -qxF "$$fp" .gitleaksignore 2>/dev/null; then \
+			echo "$$fp" >> .gitleaksignore; \
+			added=$$((added+1)); \
+		fi; \
+	done; \
+	rm -f "$$tmp"; \
+	echo "Added $$added new fingerprint(s) to .gitleaksignore."; \
+	if [ "$$added" -gt 0 ]; then \
+		echo "Review before committing:"; \
+		git --no-pager diff -- .gitleaksignore; \
+	fi
+
+GOVULNCHECK_MODULE := golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+.PHONY: govulncheck
+govulncheck:
+	go run $(GOVULNCHECK_MODULE) ./...
+
 #--------------------------
 # Test
 #--------------------------
 .PHONY: test
-test: vet staticcheck
+# gitleaks-staged (not the full-history gitleaks) so this stays cheap enough to run on every
+# commit; the full-history scan still runs in CI via .github/workflows/security-checks.yml.
+test: vet staticcheck gitleaks-staged govulncheck
 	go test ./...
 
 #--------------------------
@@ -62,6 +104,7 @@ E2E_PROFILE := kstat-e2e-shared
 E2E_HOME := $(HOME)/.kstat-e2e
 E2E_KUBECONFIG := $(E2E_HOME)/shared.kubeconfig
 E2E_LOCKFILE := $(E2E_HOME)/shared.lock
+GOTESTSUM_MODULE := gotest.tools/gotestsum@v1.13.0
 
 # CI (and anyone else who already has a suitable cluster configured) sets
 # ASSUME_MINIKUBE_IS_CONFIGURED=true, in which case we deliberately fall back to the
@@ -159,7 +202,7 @@ test-e2e: vet staticcheck install-e2e-deps
 	# CI runner $(E2E_LOCKFILE)'s parent dir wouldn't otherwise exist and flock would
 	# fail outright.
 	@mkdir -p $(E2E_HOME)
-	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
+	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
 else
 test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# The cluster (profile: $(E2E_PROFILE)) is shared across every worktree/branch/session on
@@ -170,7 +213,7 @@ test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# using count to prevent caching; see the timeout note in the ASSUME_MINIKUBE_IS_CONFIGURED
 	# branch above.
 	# See the gotestsum note, and the -parallel=4 note above the other branch's go test invocation.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
 endif
 
 .PHONY: test-e2e-quick
@@ -195,7 +238,7 @@ test-e2e-quick:
 	# sized for the e2e-minikube-up VM (see that target's comment), not worth changing for a
 	# narrower -run since it's still the same cluster taking the load. flock $(E2E_LOCKFILE):
 	# see the comment on the shared-cluster branch of test-e2e above.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run gotest.tools/gotestsum@v1.13.0 -- ./... -count=1 -timeout=10m -parallel=4 -run '$(RUN)'
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=10m -parallel=4 -run '$(RUN)'
 
 #--------------------------
 # Test Artifacts


### PR DESCRIPTION
## Summary
- Moves secret/vuln scanning out of `ci-test.yml` into a dedicated `security-checks.yml` workflow with minimally-scoped permissions (`contents: read`, `pull-requests: read`), so `ci-test.yml` stays focused on build/test.
- Uses the official `gitleaks/gitleaks-action@v3` (pinned by SHA) instead of a bare `go run`, plus `govulncheck-action`. The workflow runs on PRs, pushes to `master`, **daily**, and on demand (`workflow_dispatch`) — both checks can start failing with no commit involved (a new vulnerability DB entry, a new gitleaks rule matching content already in history).
- Adds a committed `.gitleaksignore` (fingerprint-only — no secret content or commit metadata) allowlisting the known synthetic secrets in `tests/artifacts/`, so only genuinely new findings trip the scan.
- Adds a `make security-check` target (`gitleaks` + `govulncheck`), plus `make gitleaks-allow` for allowlisting a new fixture's fingerprints. It is deliberately **not** part of `make test`: both checks scan the repo as a whole rather than the change in front of you, and CI already covers them in `security-checks.yml`, so running them from `test` would just duplicate that job in `ci-test`.
- Locally these run at **pre-push**, via a new `make-security-check` hook in `.pre-commit-config.yaml`; `install-pre-push-hook` is uncommented again so the pre-push hook actually gets installed (`make-test-e2e` stays commented out — it's what made pre-push too heavyweight).
- `CONTRIBUTING.md` gains a "Security Checks" section: what each check does, how to allowlist a new fixture, and where each one runs (pre-push locally, CI per-PR + nightly).
- Centralizes repeated `go run <module>@version` pins into Makefile variables (`GITLEAKS_MODULE`, `GOTESTSUM_MODULE`) so each tool's version has one source of truth.
- Fixes a latent local-only breakage this makes load-bearing: `go run <mod>@<version>` builds a tool with the *oldest* toolchain its own `go.mod` allows (go1.25 for both staticcheck v0.6.1 and x/vuln v1.6.0), and a go1.25 analyzer rejects every package in this go1.26 module. `make staticcheck` and `make govulncheck` therefore fail outright on any machine whose base Go predates `go.mod`'s; both now pin `GOTOOLCHAIN` to `go env GOVERSION`. CI never saw it — its base Go is installed from `go.mod`.

## Test plan
- [x] `make test` (vet, staticcheck, go test) passes locally
- [x] `make security-check` passes locally (gitleaks over full history with `.gitleaksignore`, govulncheck clean)
- [x] `make gitleaks-allow` verified against the full repo history (60 known fixtures suppressed, new findings still caught)
- [ ] CI: `ci-test` and `security-checks` both green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)