### PR TITLE
Flesh out the Flux HelmRelease and Kustomization templates

### DIFF
--- a/.claude/skills/generate-template/SKILL.md
+++ b/.claude/skills/generate-template/SKILL.md
@@ -38,6 +38,7 @@ Read `spec` and `status` sub-schemas **in full** — not just top-level keys. Fo
 Pay specific attention to:
 - **Timestamps** — apply the date formatting rules in CONVENTIONS.md § Dates.
 - **Booleans and enums** — never emit raw `true`/`false`; emit a meaningful label only when the value is operationally interesting.
+- **`required` lists** — note them, but do **not** treat them as a render-time guarantee. Third-party CRD schemas are looser than their docs, they change between operator versions, and `--local`/`-f` renders manifests that never passed API-server validation. See CONVENTIONS.md § Never trust a field to be present — a nil reaching a color function aborts the render of the whole object.
 
 ### 3. Sample live instances
 
@@ -57,6 +58,7 @@ Copy the `define` wrapper and bookend sections from any existing template. The G
 All design rules are in CONVENTIONS.md. Implementation pointers:
 - **Label selectors** — use `selector_with_health_summary` from `common.tmpl`; only hand-roll when custom health logic is needed.
 - **Reference fields** — `HTTPRoute.tmpl` has worked examples of both single-ref and list-of-refs forms.
+- **Nil safety** — normal `with`/`if` guards cover almost everything; don't pre-emptively wrap every field in `default`. Add it where a guard can't reach: values handed to a shared sub-template, sub-fields of an item inside a `range`, and anything reaching `toString`. Let step 5 tell you the rest.
 
 ### 5. Verify
 
@@ -65,3 +67,20 @@ kubectl status <resource> <name> -n <ns>
 ```
 
 Test at least two different instances to confirm optional fields appear and disappear correctly.
+
+Then verify against a **partial object**, which live instances never exercise:
+
+```bash
+cat > /tmp/partial.yaml <<'EOF'
+apiVersion: <group>/<version>
+kind: <Kind>
+metadata:
+  name: bare
+  namespace: default
+  creationTimestamp: "2026-06-27T09:12:04Z"
+spec: {}
+EOF
+kubectl status -f /tmp/partial.yaml --local --shallow
+```
+
+Add further documents that drop individual `required` sub-fields from each list and reference the template renders — e.g. a ref with `name` but no `kind`, a list entry with only one of its fields. Any `Failed to render:` line, or a literal `<nil>` in the output, is a bug: fix it before finishing, and re-run all three renders.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,28 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 
 3. **Include updated artifacts in PRs** - reviewers use `.out` file diffs to verify template changes.
 
+4. **Check the template survives a partial object.** Artifacts captured from a live cluster are
+   fully populated, so they never exercise the missing-field paths — and a rendering error aborts
+   the whole object, not just the offending line (see CONVENTIONS.md § Never trust a field to be
+   present). Hand-write a stripped manifest with empty/absent fields and render it:
+
+   ```bash
+   cat > /tmp/partial.yaml <<'EOF'
+   apiVersion: <group>/<version>
+   kind: <Kind>
+   metadata:
+     name: bare
+     namespace: default
+     creationTimestamp: "2026-06-27T09:12:04Z"
+   spec: {}
+   EOF
+   bin/status -f /tmp/partial.yaml --local --shallow
+   ```
+
+   Then add a second document dropping individual `required` sub-fields from the lists and refs
+   the template renders. Any `Failed to render:` line, or a literal `<nil>` in the output, is a
+   bug. Worth keeping as a `tests/artifacts/` case when the kind has many optional fields.
+
 ### Running e2e Tests Locally
 
 `make test-e2e` runs the `TestE2E*` suite against a real cluster. That suite has two top-level

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -127,6 +127,15 @@ For **label selectors**, `selector_with_health_summary` in `common.tmpl` impleme
 
 For **reference fields** (spec fields pointing to another resource by kind/name), show `Kind/name -n ns` via the `resource_ref` sub-template in the default case, and `$.IncludeRenderableObject` in deep mode. `HTTPRoute.tmpl` has worked examples of both single-ref and list-of-refs forms.
 
+Where the ref sits on a line of its own, deep mode replaces it with the inlined object (`ExternalSecret.tmpl`, `HTTPRoute.tmpl`). Where it's named mid-sentence — `Applies ./x from GitRepository/y into namespace z` — substituting a multi-line block would destroy the sentence, so pair the `resource_ref` line with `deep_render_ref`, which appends the inlined object underneath and renders nothing in the other modes:
+
+```
+{{- "Applies" | bold | nindent 2 }} from {{ $.Include "resource_ref" (dict "kind" .kind "name" .name) }}
+{{- $.Include "deep_render_ref" (dict "ctx" $ "kind" .kind "name" .name) }}
+```
+
+Either shape is fine; the requirement is that the ref itself stays on screen in all three modes. `deep_render_ref` needs no `--shallow`/`--local` check of its own — `KubeGetFirst` already returns an empty object whenever `LiveQueriesDisabled()` is true.
+
 ### Go template `and`/`or` do not short-circuit
 
 Unlike most languages, Go templates evaluate **all** arguments to `and` and `or` before applying the logic. `{{ if and .A (someFunc .A.B) }}` panics when `.A` is nil because `.A.B` is always evaluated. Use nested `with`/`if` blocks for any chained field access that could be nil:
@@ -137,6 +146,37 @@ Unlike most languages, Go templates evaluate **all** arguments to `and` and `or`
 ```
 
 Never rely on `and` to guard a nil dereference.
+
+### Never trust a field to be present, however required the schema says it is
+
+A rendering error aborts the **entire object**, not the line that caused it — `Include` propagates the error up, so you lose the conditions, events, and everything else for exactly the resource someone was trying to debug. A template must degrade one line, never the whole render.
+
+`required:` in a CRD schema is not a guarantee at render time:
+
+- `--local` / `-f file.yaml` renders hand-written manifests that never passed API-server validation.
+- CRD schemas change between operator versions; an object written by an older controller can be missing a field the current schema marks required, and a `status` block is written asynchronously — an object observed mid-reconcile has a partial one.
+- Third-party CRDs are the common case here, and their schemas are frequently looser than their docs imply.
+
+The trap is that these paths are the ones a template is *least* likely to be exercised against, so the crash surfaces in the field.
+
+Color functions are the usual detonator — `cyan` and friends reject a nil with `invalid value; expected string`:
+
+```
+{{- .kind | cyan }}                    {{- /* aborts the object's render when kind is absent */}}
+{{- .kind | default "" | cyan }}       {{- /* degrades to an empty segment */}}
+```
+
+`toString` is the other one: it turns a missing field into a literal `<nil>` on screen rather than an error, which is worse — it looks like real data.
+
+This is not a licence to wrap every field in `default`. The `with`/`if` guards the conventions already call for cover the overwhelming majority of cases, and they read better than a wall of defaulted pipelines — `{{- with .Spec.url }}url: {{ . | cyan }}{{ end }}` needs nothing further. Reach for `default` only in the three spots a guard can't reach:
+
+- **Values passed to a shared sub-template**, which can't guard on behalf of its caller. A single unguarded `cyan` in `common.tmpl` is a latent crash for all ~50 call sites, so helpers default their own inputs.
+- **Sub-fields of an item inside a `range`**, where wrapping each one in its own `with` would bury the line. When several optional fields concatenate there, track the separators rather than hardcoding them so any subset composes — `storageclass_summary` is the reference for the `$needsComma` pattern.
+- **Anything reaching `toString`**, which has no failure mode that looks like a failure.
+
+Everywhere else, let the test tell you. Render a stripped-down manifest with `--local` where optional fields are absent and the "required" ones are missing or empty, and guard what actually breaks — see CONTRIBUTING.md § Working with Test Artifacts. Guessing at it up front produces noise; the render either aborts or prints `<nil>`, and both are obvious.
+
+The same proportionality applies to parsing. `colorAgo` accepts exactly one layout and silently returns the zero time for anything else, rendering an age that is wrong by two millennia but looks plausible. For a Kubernetes-managed timestamp that's fine — the API server normalizes them. For a value a human or a CLI writes, such as the `reconcile.fluxcd.io/requestedAt` annotation, print it raw instead of inventing a guard.
 
 ### Omit spec fields at their Kubernetes default
 

--- a/pkg/plugin/templates/HelmRelease.tmpl
+++ b/pkg/plugin/templates/HelmRelease.tmpl
@@ -12,6 +12,7 @@
            exclusive. */ -}}
     {{- with .Spec.chart }}
         {{- with .spec }}
+            {{- $chartSpec := . }}
             {{- "Chart" | bold | nindent 2 }} {{ .chart | cyan }}
             {{- with .version }} ({{ . | cyan }}){{ end }}
             {{- with .sourceRef }}
@@ -21,10 +22,61 @@
                 {{- $chartParts := splitList "/" . }}
                 {{- if eq (len $chartParts) 2 }} · {{ $.Include "resource_ref" (dict "kind" "HelmChart" "name" (last $chartParts) "namespace" (first $chartParts) "callerNamespace" $.Namespace) }}{{ end }}
             {{- end }}
+            {{- /* reconcileStrategy:Revision makes the HelmChart re-package on every source
+                   revision, so upgrades happen without the chart version ever changing --
+                   without it on screen an unchanged chart version reads as "nothing moved". */ -}}
+            {{- if eq (.reconcileStrategy | default "ChartVersion") "Revision" }}
+                {{- ", repackaged on every source revision" }}
+            {{- end }}
+            {{- /* Unverifiable provenance blocks the release before it is ever attempted, so the
+                   fact that verification is demanded at all explains that failure mode. */ -}}
+            {{- with .verify }}
+                {{- ", signature verified with " }}{{ .provider | default "cosign" | cyan }}
+            {{- end }}
+            {{- /* Values files are read out of the chart source; a typo'd path fails the release
+                   outright unless ignoreMissingValuesFiles turns it into a silent no-op, which
+                   is worth calling out because the release then runs on unintended values. */ -}}
+            {{- with .valuesFiles }}
+                {{- "Chart values" | bold | nindent 2 }} from {{ join ", " . | cyan }}
+                {{- if $chartSpec.ignoreMissingValuesFiles }} ({{ "missing files are ignored" | yellow }}){{ end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- /* Deep inlines the chart's source and the mirrored HelmChart. Both are named mid-sentence
+           on the Chart line above, so they're rendered below the whole chart block rather than
+           substituted into it. The HelmChart is where chart pull and version-resolution failures
+           actually surface, which the HelmRelease's own conditions only summarize. */ -}}
+    {{- with .Spec.chart }}
+        {{- with .spec }}
+            {{- with .sourceRef }}
+                {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" (.kind | default "HelmRepository") "name" .name "namespace" (.namespace | default $.Namespace)) }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with .Status.helmChart }}
+        {{- $chartParts := splitList "/" . }}
+        {{- if eq (len $chartParts) 2 }}
+            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "HelmChart" "name" (last $chartParts) "namespace" (first $chartParts)) }}
         {{- end }}
     {{- end }}
     {{- with .Spec.chartRef }}
         {{- "Chart" | bold | nindent 2 }} from {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace)) }}
+    {{- end }}
+    {{- /* Values pulled from other objects: an edit to one of these changes what is deployed
+           without this HelmRelease ever changing, and a missing non-optional ref stalls
+           reconciliation before Helm is even invoked. */ -}}
+    {{- with .Spec.valuesFrom }}
+        {{- "Values" | bold | nindent 2 }} also from
+        {{- range $index, $ref := . }}
+            {{- if $index }},{{ end }} {{ $.Include "resource_ref" (dict "kind" $ref.kind "name" $ref.name "namespace" $.Namespace "callerNamespace" $.Namespace) }}
+            {{- with $ref.valuesKey }} key {{ . | cyan }}{{ end }}
+            {{- with $ref.targetPath }} into {{ . | cyan }}{{ end }}
+            {{- if $ref.optional }} (optional){{ end }}
+        {{- end }}
+        {{- range $ref := . }}
+            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" $ref.kind "name" $ref.name) }}
+        {{- end }}
     {{- end }}
     {{- /* status.history is the Helm release ledger, newest first. Entry 0 is the last release
            helm-controller made -- which is not necessarily the one currently serving: a failed
@@ -38,22 +90,44 @@
             {{- if not $deployed }}{{ if eq (.status | default "") "deployed" }}{{ $deployed = . }}{{ end }}{{ end }}
         {{- end }}
     {{- end }}
-    {{- with $latest }}
+    {{- /* Every revision is listed, not just the newest: the ledger is where a bad rollout shows
+           its shape -- a flapping install/rollback loop, a chart version that was released and
+           then silently superseded, or an upgrade that has been failing across several attempts
+           while the object still reports the last good release. */ -}}
+    {{- with $history }}
+        {{- $multipleRevisions := gt (len .) 1 }}
+        {{- $firstDeployed := (index . (sub (len .) 1)).firstDeployed | default "" }}
         {{- /* The Helm release name/namespace are only worth showing when spec.releaseName or
                spec.targetNamespace moved them away from this object's own name/namespace, which
                the status summary line already shows. */ -}}
-        {{- $elsewhere := or (ne (.name | default $.Name) $.Name) (ne (.namespace | default $.Namespace) $.Namespace) }}
-        {{- "Helm release" | bold | nindent 2 }}
-        {{- if $elsewhere }} {{ .name | default $.Name | cyan }}
-            {{- with .namespace }}{{ if ne . $.Namespace }} -n {{ . | cyan }}{{ end }}{{ end }}
+        {{- $elsewhere := or (ne ($latest.name | default $.Name) $.Name) (ne ($latest.namespace | default $.Namespace) $.Namespace) }}
+        {{- if $multipleRevisions }}{{ "Helm releases" | bold | nindent 2 }}{{ else }}{{ "Helm release" | bold | nindent 2 }}{{ end }}
+        {{- if $elsewhere }} {{ $latest.name | default $.Name | cyan }}
+            {{- with $latest.namespace }}{{ if ne . $.Namespace }} -n {{ . | cyan }}{{ end }}{{ end }}
+        {{- end }}
+        {{- /* firstDeployed is the same value on every entry -- it belongs to the Helm release,
+               not the revision -- so it goes on the header rather than repeated per line. When it
+               predates the oldest revision shown, Helm has already trimmed older ones. */ -}}
+        {{- if $multipleRevisions }} ({{ len . | toString | cyan }} revisions
+            {{- with $firstDeployed }}, first deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }})
         {{- end }}:
-        {{- with .chartVersion }} chart {{ . | cyan }}{{ end }}
-        {{- with .appVersion }} (app {{ . | cyan }}){{ end }}
-        {{- with .version }}, revision {{ . | toString | cyan }}{{ end }}
-        {{- with .status }}, {{ . | colorKeyword }}{{ with $latest.lastDeployed }} {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-        {{- else }}{{ with .lastDeployed }}, deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}{{ end }}
-        {{- with .firstDeployed }}
-            {{- if ne . $latest.lastDeployed }}, first deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+        {{- range . }}
+            {{- if $multipleRevisions }}{{ "" | nindent 4 }}{{ else }}{{ " " }}{{ end }}
+            {{- /* Every field here is required by the CRD schema, but a history entry rendered
+                   from a hand-written manifest with -f can be missing any of them, so the
+                   separators are tracked rather than hardcoded between the parts. */ -}}
+            {{- $needsComma := false }}
+            {{- with .version }}revision {{ . | toString | cyan }}{{ $needsComma = true }}{{ end }}
+            {{- with .chartVersion }}{{ if $needsComma }}, {{ end }}chart {{ . | cyan }}{{ $needsComma = true }}{{ end }}
+            {{- with .appVersion }} (app {{ . | cyan }}){{ end }}
+            {{- if $needsComma }}, {{ end }}
+            {{- with .status }}{{ . | colorKeyword }}{{ else }}deployed{{ end }}
+            {{- with .lastDeployed }} {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+        {{- end }}
+        {{- if not $multipleRevisions }}
+            {{- with $firstDeployed }}
+                {{- if ne . ($latest.lastDeployed | default "") }}, first deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+            {{- end }}
         {{- end }}
     {{- end }}
     {{- /* Revision divergence: the chart version helm-controller last tried isn't the one that
@@ -62,25 +136,13 @@
            status.lastAppliedRevision is the deprecated v2 spelling, only there as a fallback for
            objects last written by an older helm-controller. */ -}}
     {{- $released := $deployed.chartVersion | default .Status.lastAppliedRevision }}
-    {{- $olderStillInstalled := false }}
-    {{- with $deployed }}
-        {{- if ne (.version | toString) ($latest.version | toString) }}{{ $olderStillInstalled = true }}{{ end }}
-    {{- end }}
     {{- with .Status.lastAttemptedRevision }}
         {{- if ne . ($released | default "") }}
-            {{- "Last attempted" | red | bold | nindent 2 }} chart {{ . | red }} was not released
-            {{- if not $olderStillInstalled }}
-                {{- if $released }}, {{ $released | red }} is still what's installed
-                {{- else }}, this HelmRelease has never been installed{{ end }}
-            {{- end }}
+            {{- "Last attempted" | red | bold | nindent 2 }}
+            {{- with $.Status.lastAttemptedReleaseAction }} {{ . | red }} of{{ end }} chart {{ . | red }} was not released
+            {{- if $released }}, {{ $released | red }} is still what's installed
+            {{- else }}, this HelmRelease has never been installed{{ end }}
         {{- end }}
-    {{- end }}
-    {{- /* The newest release failed, so an older one is what's actually still installed. */ -}}
-    {{- if $olderStillInstalled }}
-        {{- "Still installed" | bold | nindent 2 }}: chart {{ $deployed.chartVersion | cyan }}
-        {{- with $deployed.appVersion }} (app {{ . | cyan }}){{ end }}
-        {{- with $deployed.version }}, revision {{ . | toString | cyan }}{{ end }}
-        {{- with $deployed.lastDeployed }}, deployed {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- end }}
     {{- /* Cumulative since the last successful release of each kind, reset on success. */ -}}
     {{- if or .Status.installFailures .Status.upgradeFailures .Status.failures }}
@@ -104,6 +166,22 @@
         {{- with $upgradeRetries }}{{ $remediationParts = append $remediationParts (printf "upgrade retries %d" (int .)) }}{{ end }}
         {{- with $upgradeStrategy }}{{ $remediationParts = append $remediationParts (printf "on failed upgrade: %s" .) }}{{ end }}
         {{- " " }}{{ join ", " $remediationParts | cyan }}
+    {{- end }}
+    {{- /* Off by default: with it on, helm-controller diffs the cluster against the last release
+           on every reconcile and (in full mode) reverts anything edited out-of-band, which is
+           the explanation for manual changes that keep disappearing. */ -}}
+    {{- with .Spec.driftDetection }}
+        {{- if ne (.mode | default "disabled") "disabled" }}
+            {{- "Drift detection" | bold | nindent 2 }} in {{ .mode | cyan }} mode
+            {{- if eq .mode "enabled" }}: out-of-band changes to released resources are reverted{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- /* Without it helm-controller acts as itself (cluster-admin in most installs); with it
+           every Helm operation is impersonated, so RBAC denials on the release come from this
+           account, not from the controller. */ -}}
+    {{- with .Spec.serviceAccountName }}
+        {{- "Impersonates" | bold | nindent 2 }} {{ $.Include "resource_ref" (dict "kind" "ServiceAccount" "name" . "namespace" $.Namespace "callerNamespace" $.Namespace) }}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ServiceAccount" "name" .) }}
     {{- end }}
     {{- template "flux_depends_on" . }}
     {{- template "flux_reconciliation" . }}

--- a/pkg/plugin/templates/Kustomization.tmpl
+++ b/pkg/plugin/templates/Kustomization.tmpl
@@ -10,12 +10,16 @@
     {{- with .Spec.sourceRef }}
         {{- "Applies" | bold | nindent 2 }} {{ $.Spec.path | default "./" | cyan }} from {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
         {{- with $.Spec.targetNamespace }} into namespace {{ . | cyan }}{{ end }}
+        {{- /* The source is where a stuck Kustomization usually fails -- a GitRepository that
+               can't authenticate or an artifact that never got fetched -- so deep inlines it. */ -}}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace)) }}
     {{- end }}
     {{- /* spec.kubeConfig means the manifests are applied to a *different* cluster than the one
            this object lives in -- without it on screen, everything below reads as local. */ -}}
     {{- with .Spec.kubeConfig }}
         {{- with .secretRef }}
             {{- "Applies to a remote cluster" | yellow | bold | nindent 2 }}: kubeconfig from {{ $.Include "resource_ref" (dict "kind" "Secret" "name" .name "namespace" $.Namespace "callerNamespace" $.Namespace) }}
+            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "Secret" "name" .name) }}
         {{- end }}
     {{- end }}
     {{- with .Status.lastAppliedRevision }}
@@ -58,6 +62,18 @@
     {{- if not .Spec.prune }}
         {{- "Prune disabled" | yellow | bold | nindent 2 }}: resources removed from the source are left running in the cluster
     {{- end }}
+    {{- /* force turns an immutable-field conflict into a delete-and-recreate of the whole object,
+           which for a Job or a Service is real disruption rather than a retry. */ -}}
+    {{- if .Spec.force }}
+        {{- "Force" | yellow | bold | nindent 2 }}: resources that can't be patched are deleted and recreated
+    {{- end }}
+    {{- /* Without it kustomize-controller applies as itself (cluster-admin in most installs); with
+           it every apply is impersonated, so RBAC denials on the managed resources come from this
+           account, not from the controller. */ -}}
+    {{- with .Spec.serviceAccountName }}
+        {{- "Impersonates" | bold | nindent 2 }} {{ $.Include "resource_ref" (dict "kind" "ServiceAccount" "name" . "namespace" $.Namespace "callerNamespace" $.Namespace) }}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ServiceAccount" "name" .) }}
+    {{- end }}
     {{- /* What Ready actually means here: with wait/healthChecks it also covers the health of the
            applied objects, without them it only means the apply itself succeeded. */ -}}
     {{- if .Spec.wait }}
@@ -68,7 +84,11 @@
             {{- if eq (len .) 1 }}
                 {{- $check := index . 0 }}
                 {{- " " }}{{ $.Include "resource_ref" (dict "kind" $check.kind "name" $check.name "namespace" ($check.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+                {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" $check.kind "name" $check.name "namespace" ($check.namespace | default $.Namespace)) }}
             {{- else }} {{ len . | toString | cyan }} resources
+                {{- range . }}
+                    {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" .kind "name" .name "namespace" (.namespace | default $.Namespace)) }}
+                {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -57,11 +57,40 @@
 {{- define "resource_ref" }}
     {{- /* Expects dict "kind" "name" "namespace" (optional) "callerNamespace" (optional -- the
            namespace of the object doing the referencing; when it matches "namespace" the
-           namespace is redundant on screen and is dropped). */ -}}
-    {{- .kind | cyan | bold }}/{{ .name | cyan }}
+           namespace is redundant on screen and is dropped).
+           kind/name go through "default" rather than straight into cyan: a ref field a CRD marks
+           required can still arrive nil from a hand-written manifest rendered with -f, and cyan
+           errors on a nil, which aborts the render of the entire object instead of degrading
+           just this one reference. */ -}}
+    {{- .kind | default "" | cyan | bold }}/{{ .name | default "" | cyan }}
     {{- with .namespace }}
         {{- if or (not $.callerNamespace) (ne . $.callerNamespace) }}
             {{- " -n " }}{{ if eq . "default" }}{{ . | red }}{{ else }}{{ . | cyan }}{{ end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "deep_render_ref" }}
+    {{- /* Expects dict "ctx" (the RenderableObject doing the referencing) "kind" "name"
+           "namespace" (optional, defaults to the caller's) "indent" (optional, defaults to 4).
+           Renders the referenced object inline under the caller's line when --deep is set, and
+           nothing at all otherwise -- so a caller pairs it with a resource_ref line, which stays
+           on screen in every mode:
+
+               {{- "Applies" | bold | nindent 2 }} from {{ $.Include "resource_ref" (dict ...) }}
+               {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" .kind "name" .name) }}
+
+           Appending rather than replacing the ref keeps prose lines intact -- "Applies ./x from
+           GitRepository/y into namespace z" would be destroyed by substituting a multi-line block
+           mid-sentence. Templates whose ref sits on a line of its own (ExternalSecret, HTTPRoute)
+           replace it instead; both are fine, the ref just has to survive in the non-deep modes.
+           Silent when the object can't be fetched, which covers --shallow and --local without
+           either needing an explicit check here. */ -}}
+    {{- $ctx := .ctx }}
+    {{- if $ctx.Config.GetBool "deep" }}
+        {{- $obj := $ctx.KubeGetFirst (.namespace | default $ctx.Namespace) .kind .name }}
+        {{- if $obj.Object }}
+            {{- $ctx.IncludeRenderableObject $obj | nindent (int (.indent | default 4)) }}
         {{- end }}
     {{- end }}
 {{- end -}}
@@ -1328,6 +1357,22 @@
             {{- with $.Spec.retryInterval }}, retries every {{ . | cyan }} after a failure{{ end }}
         {{- end }}
     {{- end }}
+    {{- /* "flux reconcile" asks for an out-of-band run by stamping this annotation; the controller
+           copies it into status.lastHandledReconcileAt once it picks the request up. While the two
+           differ the request is still outstanding, and every condition on the object continues to
+           describe the *previous* run -- so the object reads as Current while the reconcile the
+           operator is waiting on hasn't started.
+           The timestamp is printed raw rather than through colorAgo: the annotation is documented
+           as "any value that changes", the flux CLI writes RFC3339 with nanoseconds, and colorAgo
+           parses exactly one layout and silently returns the zero time otherwise -- which would
+           render a plausible-looking age that is wrong by two millennia. */ -}}
+    {{- $reconcileRequestedAt := index .Annotations "reconcile.fluxcd.io/requestedAt" | default "" }}
+    {{- if $reconcileRequestedAt }}
+        {{- if ne $reconcileRequestedAt (.Status.lastHandledReconcileAt | default "") }}
+            {{- "Reconcile pending" | yellow | bold | nindent 2 }}: requested at {{ $reconcileRequestedAt | cyan }}, not handled yet
+            {{- with .Status.lastHandledReconcileAt }} (last handled {{ . | cyan }}){{ end }}
+        {{- end }}
+    {{- end }}
 {{- end -}}
 
 {{- define "flux_depends_on" }}
@@ -1340,6 +1385,11 @@
         {{- "Depends on" | bold | nindent 2 }}
         {{- range $index, $dep := . }}
             {{- if $index }},{{ end }} {{ $.Include "resource_ref" (dict "kind" ($dep.kind | default $.Kind) "name" $dep.name "namespace" ($dep.namespace | default $.Namespace) "callerNamespace" $.Namespace) }}
+        {{- end }}
+        {{- /* Deep renders each dependency below the list rather than inline in it, so the
+               one-line "who is blocking me" summary survives in every mode. */ -}}
+        {{- range $dep := . }}
+            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" ($dep.kind | default $.Kind) "name" $dep.name "namespace" ($dep.namespace | default $.Namespace)) }}
         {{- end }}
     {{- end }}
 {{- end -}}

--- a/tests/artifacts/helmrelease-drift-detection-impersonated.out
+++ b/tests/artifacts/helmrelease-drift-detection-impersonated.out
@@ -1,0 +1,12 @@
+
+HelmRelease/podinfo -n apps, created 1m ago, gen:3
+  Current: Resource is Ready
+  Chart ./charts/podinfo from GitRepository/podinfo -n flux-system, repackaged on every source revision, signature verified with cosign
+  Chart values from ./charts/podinfo/values.yaml, ./charts/podinfo/values-prod.yaml (missing files are ignored)
+  Values also from ConfigMap/podinfo-defaults key values.yaml, Secret/podinfo-credentials key password into backend.password (optional)
+  Helm release: revision 3, chart 6.7.1 (app 6.7.1), deployed 1m ago, first deployed 1m ago
+  Drift detection in enabled mode: out-of-band changes to released resources are reverted
+  Impersonates ServiceAccount/podinfo-deployer
+  Reconciles every 10m
+  Ready:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.7.1 for 1m
+  Released:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.7.1 for 1m

--- a/tests/artifacts/helmrelease-drift-detection-impersonated.yaml
+++ b/tests/artifacts/helmrelease-drift-detection-impersonated.yaml
@@ -1,0 +1,69 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  creationTimestamp: "2026-06-27T09:12:04Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 3
+  name: podinfo
+  namespace: apps
+  resourceVersion: "44190"
+  uid: 8c3d1f6a-2b5e-4a7c-9f0d-1e4b7a2c5d80
+spec:
+  chart:
+    spec:
+      chart: ./charts/podinfo
+      ignoreMissingValuesFiles: true
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: podinfo
+        namespace: flux-system
+      valuesFiles:
+      - ./charts/podinfo/values.yaml
+      - ./charts/podinfo/values-prod.yaml
+      verify:
+        provider: cosign
+        secretRef:
+          name: cosign-pub
+  driftDetection:
+    mode: enabled
+  interval: 10m
+  serviceAccountName: podinfo-deployer
+  valuesFrom:
+  - kind: ConfigMap
+    name: podinfo-defaults
+    valuesKey: values.yaml
+  - kind: Secret
+    name: podinfo-credentials
+    optional: true
+    targetPath: backend.password
+    valuesKey: password
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:55:41Z"
+    message: Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.7.1
+    observedGeneration: 3
+    reason: UpgradeSucceeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2026-06-29T23:55:41Z"
+    message: Helm upgrade succeeded for release apps/podinfo.v3 with chart podinfo@6.7.1
+    observedGeneration: 3
+    reason: UpgradeSucceeded
+    status: "True"
+    type: Released
+  history:
+  - appVersion: 6.7.1
+    chartName: podinfo
+    chartVersion: 6.7.1
+    firstDeployed: "2026-06-29T23:50:12Z"
+    lastDeployed: "2026-06-29T23:55:41Z"
+    name: podinfo
+    namespace: apps
+    status: deployed
+    version: 3
+  lastAttemptedGeneration: 3
+  lastAttemptedReleaseAction: upgrade
+  lastAttemptedRevision: 6.7.1
+  observedGeneration: 3

--- a/tests/artifacts/helmrelease-failed-upgrade.out
+++ b/tests/artifacts/helmrelease-failed-upgrade.out
@@ -3,9 +3,10 @@ HelmRelease/nginx -n default, created 1m ago, gen:4
   InProgress: Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition
     Reconciling: UpgradeFailed, Helm upgrade failed for release default/nginx with chart nginx@18.3.0: timed out waiting for the condition
   Chart nginx (>=18.x) from HelmRepository/bitnami -n flux-system · HelmChart/default-nginx -n flux-system
-  Helm release: chart 18.3.0 (app 1.27.2), revision 3, failed 1m ago, first deployed 1m ago
-  Last attempted chart 18.3.0 was not released
-  Still installed: chart 18.2.5 (app 1.27.1), revision 2, deployed 1m ago
+  Helm releases (2 revisions, first deployed 1m ago):
+    revision 3, chart 18.3.0 (app 1.27.2), failed 1m ago
+    revision 2, chart 18.2.5 (app 1.27.1), deployed 1m ago
+  Last attempted upgrade of chart 18.3.0 was not released, 18.2.5 is still what's installed
   Failures: upgrade:2, total:2
   Remediation: install retries 3, upgrade retries 2, on failed upgrade: rollback
   Depends on HelmRelease/redis

--- a/tests/artifacts/helmrelease-flapping-history.out
+++ b/tests/artifacts/helmrelease-flapping-history.out
@@ -1,0 +1,16 @@
+
+HelmRelease/kafka -n streaming, created 1m ago, gen:9
+  InProgress: Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8: timed out waiting for the condition
+    Reconciling: UpgradeFailed, Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8: timed out waiting for the condition
+  Chart kafka (30.x) from HelmRepository/bitnami -n flux-system · HelmChart/streaming-kafka -n flux-system
+  Helm releases (4 revisions, first deployed 1m ago):
+    revision 7, chart 30.1.8 (app 3.8.0), failed 1m ago
+    revision 6, chart 30.0.4 (app 3.7.1), deployed 1m ago
+    revision 5, chart 30.1.8 (app 3.8.0), superseded 1m ago
+    revision 4, chart 30.0.4 (app 3.7.1), superseded 1m ago
+  Last attempted upgrade of chart 30.1.8 was not released, 30.0.4 is still what's installed
+  Remediation: install retries 3, upgrade retries 4, on failed upgrade: rollback
+  Reconciles every 10m
+  Ready:False UpgradeFailed, Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8: timed out waiting for the condition for 1m
+  Released:False UpgradeFailed, Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8: timed out waiting for the condition for 1m
+  Remediated:True RollbackSucceeded, Helm rollback to previous release streaming/kafka.v4 with chart kafka@30.0.4 succeeded for 1m

--- a/tests/artifacts/helmrelease-flapping-history.yaml
+++ b/tests/artifacts/helmrelease-flapping-history.yaml
@@ -1,0 +1,95 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  creationTimestamp: "2026-06-20T08:41:19Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 9
+  name: kafka
+  namespace: streaming
+  resourceVersion: "203914"
+  uid: 2e9a4b7c-1d3f-4085-a6b2-7c0e9f4d5a13
+spec:
+  chart:
+    spec:
+      chart: kafka
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+      version: 30.x
+  install:
+    remediation:
+      retries: 3
+  interval: 10m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 4
+      strategy: rollback
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:52:07Z"
+    message: 'Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8:
+      timed out waiting for the condition'
+    observedGeneration: 9
+    reason: UpgradeFailed
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2026-06-29T23:52:07Z"
+    message: 'Helm upgrade failed for release streaming/kafka with chart kafka@30.1.8:
+      timed out waiting for the condition'
+    observedGeneration: 9
+    reason: UpgradeFailed
+    status: "False"
+    type: Released
+  - lastTransitionTime: "2026-06-29T23:52:41Z"
+    message: Helm rollback to previous release streaming/kafka.v4 with chart kafka@30.0.4
+      succeeded
+    observedGeneration: 9
+    reason: RollbackSucceeded
+    status: "True"
+    type: Remediated
+  helmChart: flux-system/streaming-kafka
+  history:
+  - appVersion: 3.8.0
+    chartName: kafka
+    chartVersion: 30.1.8
+    firstDeployed: "2026-06-20T08:41:31Z"
+    lastDeployed: "2026-06-29T23:52:07Z"
+    name: kafka
+    namespace: streaming
+    status: failed
+    version: 7
+  - appVersion: 3.7.1
+    chartName: kafka
+    chartVersion: 30.0.4
+    firstDeployed: "2026-06-20T08:41:31Z"
+    lastDeployed: "2026-06-29T23:52:41Z"
+    name: kafka
+    namespace: streaming
+    status: deployed
+    version: 6
+  - appVersion: 3.8.0
+    chartName: kafka
+    chartVersion: 30.1.8
+    firstDeployed: "2026-06-20T08:41:31Z"
+    lastDeployed: "2026-06-29T23:44:52Z"
+    name: kafka
+    namespace: streaming
+    status: superseded
+    version: 5
+  - appVersion: 3.7.1
+    chartName: kafka
+    chartVersion: 30.0.4
+    firstDeployed: "2026-06-20T08:41:31Z"
+    lastDeployed: "2026-06-29T23:45:18Z"
+    name: kafka
+    namespace: streaming
+    status: superseded
+    version: 4
+  lastAttemptedConfigDigest: sha256:9f2e5c8b1a4d7f0c3b6e9d2a5c8f1b4e7d0a3c6f9b2e5d8a1c4f7b0e3d6a9c2f
+  lastAttemptedGeneration: 9
+  lastAttemptedReleaseAction: upgrade
+  lastAttemptedRevision: 30.1.8
+  observedGeneration: 9

--- a/tests/artifacts/helmrelease-healthy.out
+++ b/tests/artifacts/helmrelease-healthy.out
@@ -2,7 +2,7 @@
 HelmRelease/nginx -n default, created 1m ago, gen:1
   Current: Resource is Ready
   Chart nginx (>=18.x) from HelmRepository/bitnami -n flux-system · HelmChart/default-nginx -n flux-system
-  Helm release: chart 18.2.5 (app 1.27.1), revision 1, deployed 1m ago
+  Helm release: revision 1, chart 18.2.5 (app 1.27.1), deployed 1m ago
   Reconciles every 10m
   Ready:True InstallSucceeded, Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5 for 1m
   Released:True InstallSucceeded, Helm install succeeded for release default/nginx.v1 with chart nginx@18.2.5 for 1m

--- a/tests/artifacts/helmrelease-suspended-oci.out
+++ b/tests/artifacts/helmrelease-suspended-oci.out
@@ -2,7 +2,7 @@
 HelmRelease/podinfo -n apps, created 1m ago, gen:7
   Current: Resource is Ready
   Chart from OCIRepository/podinfo -n flux-system
-  Helm release: chart 6.7.1 (app 6.7.1), revision 5, deployed 1m ago, first deployed 1m ago
+  Helm release: revision 5, chart 6.7.1 (app 6.7.1), deployed 1m ago, first deployed 1m ago
   Suspended: reconciliation is paused, neither spec changes nor drift are applied (would otherwise reconcile every 30m)
   Ready:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1 for 1m
   Released:True UpgradeSucceeded, Helm upgrade succeeded for release apps/podinfo.v5 with chart podinfo@6.7.1 for 1m

--- a/tests/artifacts/kustomization-force-impersonated.out
+++ b/tests/artifacts/kustomization-force-impersonated.out
@@ -1,0 +1,11 @@
+
+Kustomization/tenant-apps -n flux-system, created 1m ago, gen:4
+  Current: Resource is Ready
+  Applies ./tenants/production from GitRepository/flux-system
+  Applied revision main@7f3c1a9e
+  Manages 2 resources: Deployment×1, ServiceAccount×1
+  Prune disabled: resources removed from the source are left running in the cluster
+  Force: resources that can't be patched are deleted and recreated
+  Impersonates ServiceAccount/tenant-reconciler
+  Reconciles every 5m
+  Ready:True ReconciliationSucceeded, Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1 for 1m

--- a/tests/artifacts/kustomization-force-impersonated.yaml
+++ b/tests/artifacts/kustomization-force-impersonated.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  creationTimestamp: "2026-06-14T11:02:37Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 4
+  name: tenant-apps
+  namespace: flux-system
+  resourceVersion: "88431"
+  uid: 1f7b3c95-8d2a-4e60-b1c7-9a0d5e3f2b41
+spec:
+  force: true
+  interval: 5m
+  path: ./tenants/production
+  prune: false
+  serviceAccountName: tenant-reconciler
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:55:12Z"
+    message: 'Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1'
+    observedGeneration: 4
+    reason: ReconciliationSucceeded
+    status: "True"
+    type: Ready
+  inventory:
+    entries:
+    - id: production_tenant-apps__ServiceAccount
+      v: v1
+    - id: production_tenant-apps_apps_Deployment
+      v: v1
+  lastAppliedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  lastAttemptedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  observedGeneration: 4

--- a/tests/artifacts/kustomization-reconcile-pending.out
+++ b/tests/artifacts/kustomization-reconcile-pending.out
@@ -1,0 +1,9 @@
+
+Kustomization/podinfo -n flux-system, created 1m ago, gen:3
+  Current: Resource is Ready
+  Applies ./kustomize from GitRepository/flux-system
+  Applied revision main@7f3c1a9e
+  Manages 2 resources: Deployment×1, Service×1
+  Reconciles every 5m
+  Reconcile pending: requested at 2026-06-29T23:59:00.482913746Z, not handled yet (last handled 2026-06-29T22:14:03.118204553Z)
+  Ready:True ReconciliationSucceeded, Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1 for 1m

--- a/tests/artifacts/kustomization-reconcile-pending.yaml
+++ b/tests/artifacts/kustomization-reconcile-pending.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  annotations:
+    reconcile.fluxcd.io/requestedAt: "2026-06-29T23:59:00.482913746Z"
+  creationTimestamp: "2026-06-14T11:02:37Z"
+  finalizers:
+  - finalizers.fluxcd.io
+  generation: 3
+  name: podinfo
+  namespace: flux-system
+  resourceVersion: "91004"
+  uid: 4a8e2c17-6b93-4f05-8d2e-b17c0a5f9e34
+spec:
+  interval: 5m
+  path: ./kustomize
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-29T23:55:12Z"
+    message: 'Applied revision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1'
+    observedGeneration: 3
+    reason: ReconciliationSucceeded
+    status: "True"
+    type: Ready
+  inventory:
+    entries:
+    - id: default_podinfo__Service
+      v: v1
+    - id: default_podinfo_apps_Deployment
+      v: v1
+  lastAppliedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  lastAttemptedRevision: refs/heads/main@sha1:7f3c1a9e4b2d8c60f5a3e1b7d9c2f480a6e5b3d1
+  lastHandledReconcileAt: "2026-06-29T22:14:03.118204553Z"
+  observedGeneration: 3


### PR DESCRIPTION
## What

Rounds out the two Flux templates: adds the spec fields that change *what* gets deployed or *who* deploys it, renders the full Helm release ledger, surfaces outstanding manual reconciles, and brings both templates in line with the `--shallow`/`--deep`/`--local` conventions.

## Fields added

**HelmRelease** — chart provenance `verify`, `valuesFiles` + `ignoreMissingValuesFiles`, `reconcileStrategy: Revision`, `valuesFrom`, `driftDetection.mode`, `serviceAccountName` impersonation, and `status.lastAttemptedReleaseAction` (which now names the action in the divergence line: `Last attempted upgrade of chart 18.3.0 was not released`).

**Kustomization** — `force` and `serviceAccountName`.

All are gated on deviating from their default, per CONVENTIONS.md.

## Full release history

`status.history` was rendered newest-entry-only. The ledger is where a bad rollout shows its shape — this is a chart version that was released and rolled back twice, previously indistinguishable from a first-time failure:

```
  Helm releases (4 revisions, first deployed 1m ago):
    revision 7, chart 30.1.8 (app 3.8.0), failed 1m ago
    revision 6, chart 30.0.4 (app 3.7.1), deployed 1m ago
    revision 5, chart 30.1.8 (app 3.8.0), superseded 1m ago
    revision 4, chart 30.0.4 (app 3.7.1), superseded 1m ago
  Last attempted upgrade of chart 30.1.8 was not released, 30.0.4 is still what's installed
```

A single revision still collapses onto the header line. `firstDeployed` moves to the header — it belongs to the release, not the revision, and it flags trimmed history when it predates the oldest revision shown (as above, where the ledger starts at 4). The old `Still installed:` line became a verbatim repeat of a listed row, so its meaning folded into `Last attempted`.

## Pending manual reconciles

`reconcile.fluxcd.io/requestedAt` is now compared against `status.lastHandledReconcileAt` in the shared `flux_reconciliation` helper. While they differ, a `flux reconcile` is outstanding and every condition still describes the *previous* run — so the object reads as `Current` when the run someone is waiting on hasn't started:

```
  Reconcile pending: requested at 2026-06-29T23:59:00.482913746Z, not handled yet (last handled 2026-06-29T22:14:03.118204553Z)
```

The timestamp prints raw rather than through `colorAgo`: the annotation is documented as "any value that changes", the flux CLI writes RFC3339 with nanoseconds, and `colorAgo` parses exactly one layout and silently returns the zero time otherwise — which would render a plausible-looking age wrong by two millennia.

## Rendering depth

Neither template honoured `--deep` for any of its references. Adds `deep_render_ref` to `common.tmpl` and wires it into every ref in both: chart source, mirrored HelmChart, `chartRef`, `valuesFrom`, `serviceAccountName`, Kustomization's source, `kubeConfig` secret, `healthChecks`, and `dependsOn`.

It *appends* the inlined object under a `resource_ref` line rather than replacing it, because these refs are named mid-sentence (`Applies ./x from GitRepository/y into namespace z`) and substituting a multi-line block would destroy the sentence. Templates whose ref sits on its own line keep replacing it; the requirement is only that the ref survives in all three modes. No `--shallow`/`--local` check is needed — `KubeGetFirst` already no-ops when `LiveQueriesDisabled()`.

## Bug fix in `resource_ref`

`.kind`/`.name` went straight into `cyan`, which errors on a nil and — because the error propagates through `Include` — aborts the render of the **entire object**, losing conditions and events for exactly the resource being debugged. A `valuesFrom` entry missing its `kind` was enough to trigger it. Now defaulted, so it degrades one segment. This hazard applied to all ~50 call sites, not just the new ones.

## Docs

- **CONVENTIONS.md** — new section on not trusting `required:` in CRD schemas at render time (`--local`/`-f` manifests never passed API-server validation, schemas drift between operator versions, `status` is written asynchronously). Deliberately scoped: `with`/`if` guards cover almost everything, and `default` is reserved for the three spots a guard can't reach. Also documents the `deep_render_ref` shape.
- **CONTRIBUTING.md** — recipe for rendering a partial object, since artifacts captured from a live cluster are fully populated and never exercise those paths.
- **generate-template skill** — same, as a required verification step.

## Testing

756 unit tests pass. Four new fixtures cover the new fields, the multi-revision ledger, and the pending reconcile.

Verified by hand beyond the fixtures:
- Degenerate manifests (`spec: {}`, refs missing required sub-fields, history entries missing fields) — this is what surfaced the `resource_ref` crash and a `revision <nil>`, both fixed.
- All three rendering modes. `--deep` inlining was verified against the live cluster with a temporary probe on `ConfigMap.tmpl` (since this cluster has no Flux CRDs), confirming the object inlines at the correct indent in deep mode and not at all otherwise; the probe was reverted.

## Not included

Flux's per-object annotations (`kustomize.toolkit.fluxcd.io/prune|force|ssa|reconcile`, `helm.toolkit.fluxcd.io/driftDetection`) land on *any* Kind, so they need a generic `common.tmpl` section added to every template's bookends rather than anything in these two files. Same for the `kustomize.toolkit.fluxcd.io/name`+`namespace` labels, which would let any Flux-managed object name its owning Kustomization. Happy to do those as a follow-up.

Several *defaults* are also operationally significant and currently silent — `upgrade.crds: Create` silently skips CRD upgrades, `wait: false` makes `Ready` mean far less than it appears, and an unset `serviceAccountName` means the controller's own (usually cluster-admin) identity. These need their defaults confirmed against the CRD schemas first; this cluster has no Flux installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)