### PR TITLE
Fix wildcard hostname handling in the Gateway/Ingress TLS checks

### DIFF
--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -167,6 +167,12 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				assert.NotContains(t, stdout, problem)
 			}
 		})
+		t.Run("httproute with a wildcard hostname covering the cert shows no cert flags", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-wildcard-host", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-httproute-wildcard-host.regex")
+			assert.NotContains(t, stdout, "hostname mismatch")
+		})
 		t.Run("httproute attached to a mismatched-hostname listener flags hostname mismatch", func(t *testing.T) {
 			cmdTest{
 				args:            []string{"httproute/e2e-tls-httproute-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},

--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -150,6 +150,16 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				stdoutRegexPath: "e2e-artifacts/tls-validation-tlsroute-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
+		t.Run("tlsroute unpinned to a section ignores listeners it doesn't attach to", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-multi-listener", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			// The Gateway's other TLS listener terminates a different hostname with a self-signed
+			// CA certificate; it never serves this route, so neither flag belongs here.
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-tlsroute-multi-listener.regex")
+			for _, problem := range []string{", self-signed", ", hostname mismatch"} {
+				assert.NotContains(t, stdout, problem)
+			}
+		})
 		t.Run("tlsroute attached to a Passthrough listener shows no cert flags", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-passthrough", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
 			require.NoError(t, err)
@@ -166,6 +176,15 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 			for _, problem := range []string{"doesn't exist", "wrong type:", "missing keys:", "parse error:", "self-signed", "hostname mismatch"} {
 				assert.NotContains(t, stdout, problem)
 			}
+		})
+		t.Run("httproute unpinned to a section checks the wildcard listener it attaches to", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-wildcard-listener", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			// The cert line's presence is the point: the wildcard listener used to be dropped as
+			// non-matching, leaving its certificate unchecked.
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-httproute-wildcard-listener.regex")
+			assert.Contains(t, stdout, "cert:Secret/e2e-tls-leaf-tls")
+			assert.NotContains(t, stdout, "hostname mismatch")
 		})
 		t.Run("httproute with a wildcard hostname covering the cert shows no cert flags", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-wildcard-host", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)

--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -108,6 +108,18 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				stdoutRegexPath: "e2e-artifacts/tls-validation-gateway-mismatch.regex",
 			}.assert(t, nil, opts...)
 		})
+		t.Run("gateway with wildcard hostname covering the cert shows no cert flags", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"gateway/e2e-tls-gw-wildcard-host", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-gateway-wildcard-host.regex")
+			assert.NotContains(t, stdout, ", hostname mismatch")
+		})
+		t.Run("gateway with wildcard hostname outside the cert flags hostname mismatch", func(t *testing.T) {
+			cmdTest{
+				args:            []string{"gateway/e2e-tls-gw-wildcard-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+				stdoutRegexPath: "e2e-artifacts/tls-validation-gateway-wildcard-mismatch.regex",
+			}.assert(t, nil, opts...)
+		})
 		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-grpcroute.yaml", ns)
 		t.Run("grpcroute attached to healthy gateway listener shows no cert flags", func(t *testing.T) {
 			stdout, _, err := executeCMD(t, []string{"grpcroute/e2e-tls-grpcroute-healthy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -1658,9 +1658,10 @@ func stringifyLabels(labels map[string]interface{}) map[string]string {
 
 // parseTLSSecretCertificate inspects a Secret expected to be type kubernetes.io/tls and
 // returns both full certificate detail (for Secret.tmpl's own display) and consistency
-// flags against an optional expected hostname (for Ingress/Gateway callers). hostname == ""
-// skips the hostname-match check and is used by Secret.tmpl, which has no "expected host" of
-// its own.
+// flags against an optional expected hostname (for Ingress/Gateway callers). The expected
+// hostname may itself be a wildcard pattern such as "*.example.com" -- see certServesHostname.
+// hostname == "" skips the hostname-match check and is used by Secret.tmpl, which has no
+// "expected host" of its own.
 func (cfg *RenderConfig) parseTLSSecretCertificate(secret RenderableObject, hostname string) map[string]interface{} {
 	result := map[string]interface{}{
 		"Exists":          false,
@@ -1763,10 +1764,97 @@ func (cfg *RenderConfig) parseTLSSecretCertificate(secret RenderableObject, host
 	if hostname == "" {
 		result["MatchesHostname"] = true
 	} else {
-		result["MatchesHostname"] = cert.VerifyHostname(hostname) == nil
+		result["MatchesHostname"] = certServesHostname(cert, hostname)
 	}
 
 	return result
+}
+
+// certServesHostname reports whether cert can serve the hostname a caller expects it to serve.
+//
+// The expectation comes from an Ingress rule host, a Gateway listener hostname or a route
+// hostname, every one of which may itself be a wildcard pattern such as "*.example.com" rather
+// than a concrete server name. x509.VerifyHostname is only defined for concrete names: it
+// refuses to treat a "*" in its argument as a wildcard and degrades to a byte comparison
+// against the SANs, so a "*.example.com" listener fronting a "foo.example.com" (or
+// "*.apps.example.com") certificate gets reported as a mismatch even though every name that
+// listener accepts routing for is one the certificate covers. For a wildcard expectation we
+// therefore ask the weaker, correct question: does the certificate cover *any* hostname this
+// caller would accept?
+func certServesHostname(cert *x509.Certificate, hostname string) bool {
+	certNames := cert.DNSNames
+	hasSAN := len(certNames) > 0 || len(cert.IPAddresses) > 0
+	if !hasSAN {
+		// Pre-RFC-6125 certificates name the server only in the subject CN. Go and browsers
+		// ignore it, but OpenSSL-based proxies still honour it, and reporting a hostname
+		// mismatch for a certificate whose CN is exactly the expected host misdiagnoses the
+		// real problem (the missing SAN) as the wrong one.
+		if cn := cert.Subject.CommonName; cn != "" {
+			certNames = []string{cn}
+		}
+	}
+
+	if suffix, isWildcard := wildcardSuffix(hostname); isWildcard {
+		for _, certName := range certNames {
+			if certNameIntersectsWildcard(certName, suffix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if hasSAN {
+		return cert.VerifyHostname(hostname) == nil
+	}
+	for _, certName := range certNames {
+		if certNameCoversHost(certName, hostname) {
+			return true
+		}
+	}
+	return false
+}
+
+// wildcardSuffix splits a "*.example.com" pattern into the "example.com" it is a wildcard for.
+func wildcardSuffix(pattern string) (suffix string, isWildcard bool) {
+	if !strings.HasPrefix(pattern, "*.") || len(pattern) == len("*.") {
+		return "", false
+	}
+	return pattern[len("*."):], true
+}
+
+// certNameIntersectsWildcard reports whether a certificate DNS name covers at least one hostname
+// under the "*."+suffix wildcard an Ingress/Gateway/route expects. Both sides can be patterns, so
+// this is a set-intersection test rather than a match: a certificate wildcard covers one label
+// (RFC 6125), while the expected wildcard covers any depth of subdomain but never the bare
+// suffix itself -- "*.example.com" accepts "a.example.com" and "b.a.example.com" but not
+// "example.com", per the Gateway API hostname spec and Ingress' wildcard host rules.
+func certNameIntersectsWildcard(certName, suffix string) bool {
+	base, certIsWildcard := wildcardSuffix(certName)
+	if !certIsWildcard {
+		base = certName
+	}
+	if base == "" {
+		return false
+	}
+	// A certificate wildcard "*."+base contributes names one label below base, so it reaches
+	// into the expected space as soon as base is the suffix itself. A concrete certificate name
+	// has to sit strictly below the suffix.
+	if certIsWildcard && strings.EqualFold(base, suffix) {
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(base), "."+strings.ToLower(suffix))
+}
+
+// certNameCoversHost applies RFC 6125 matching -- exact, or a leading wildcard standing for
+// exactly one label -- of a single certificate name against a concrete hostname. Only used for
+// the legacy CN fallback; SAN matching goes through x509.VerifyHostname.
+func certNameCoversHost(certName, host string) bool {
+	suffix, isWildcard := wildcardSuffix(certName)
+	if !isWildcard {
+		return strings.EqualFold(certName, host)
+	}
+	label, ok := strings.CutSuffix(strings.ToLower(host), "."+strings.ToLower(suffix))
+	return ok && label != "" && !strings.Contains(label, ".")
 }
 
 // parseDockerConfigSecret inspects a Secret expected to be type kubernetes.io/dockerconfigjson

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -150,6 +150,7 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"cronNextTime":                    cfg.cronNextTime,
 		"withinLastHour":                  cfg.withinLastHour,
 		"parseTLSSecretCertificate":       cfg.parseTLSSecretCertificate,
+		"hostnameIntersections":           hostnameIntersections,
 		"certificatesInSecret":            cfg.certificatesInSecret,
 		"certificatesInConfigMap":         cfg.certificatesInConfigMap,
 		"certificateInCSR":                cfg.certificateInCSR,
@@ -1658,11 +1659,13 @@ func stringifyLabels(labels map[string]interface{}) map[string]string {
 
 // parseTLSSecretCertificate inspects a Secret expected to be type kubernetes.io/tls and
 // returns both full certificate detail (for Secret.tmpl's own display) and consistency
-// flags against an optional expected hostname (for Ingress/Gateway callers). The expected
-// hostname may itself be a wildcard pattern such as "*.example.com" -- see certServesHostname.
-// hostname == "" skips the hostname-match check and is used by Secret.tmpl, which has no
-// "expected host" of its own.
-func (cfg *RenderConfig) parseTLSSecretCertificate(secret RenderableObject, hostname string) map[string]interface{} {
+// flags against the expected hostname(s) (for Ingress/Gateway callers). hostnames takes either a
+// single hostname or a list of them, each of which may be a wildcard pattern such as
+// "*.example.com" -- see certServesHostname. A list is satisfied when the certificate serves at
+// least one of its entries, since a route with several hostnames only needs the listener's
+// certificate to cover the ones it actually terminates. Passing "" (or an empty list) skips the
+// hostname-match check and is used by Secret.tmpl, which has no "expected host" of its own.
+func (cfg *RenderConfig) parseTLSSecretCertificate(secret RenderableObject, hostnames interface{}) map[string]interface{} {
 	result := map[string]interface{}{
 		"Exists":          false,
 		"WrongType":       false,
@@ -1761,13 +1764,109 @@ func (cfg *RenderConfig) parseTLSSecretCertificate(secret RenderableObject, host
 	result["SelfSigned"] = bytes.Equal(cert.RawIssuer, cert.RawSubject)
 	result["Expired"] = cert.NotAfter.Before(cfg.Now())
 
-	if hostname == "" {
-		result["MatchesHostname"] = true
-	} else {
-		result["MatchesHostname"] = certServesHostname(cert, hostname)
+	// Nothing expected to match against (Secret.tmpl, or an unset listener/route hostname) is
+	// not a mismatch.
+	expected := expectedHostnames(hostnames)
+	matchesHostname := len(expected) == 0
+	for _, hostname := range expected {
+		if certServesHostname(cert, hostname) {
+			matchesHostname = true
+			break
+		}
 	}
+	result["MatchesHostname"] = matchesHostname
 
 	return result
+}
+
+// expectedHostnames normalises a hostnames argument that templates pass either as a single
+// hostname or as a list, dropping the empty entries an unset Gateway listener or route hostname
+// produces.
+func expectedHostnames(hostnames interface{}) []string {
+	var raw []string
+	switch v := hostnames.(type) {
+	case nil:
+	case string:
+		// Not cast.ToStringSlice: that splits a plain string on whitespace.
+		raw = []string{v}
+	default:
+		raw = cast.ToStringSlice(v)
+	}
+	var out []string
+	for _, hostname := range raw {
+		if hostname != "" {
+			out = append(out, hostname)
+		}
+	}
+	return out
+}
+
+// hostnameIntersections narrows a Gateway listener's hostname against a route's hostnames the
+// way the Gateway API attaches routes to listeners, returning the hostnames the pair actually
+// serves together -- which is what a listener's certificate has to cover.
+//
+// Templates previously compared the two sides as exact strings, which is wrong on both counts a
+// Gateway API hostname can be a wildcard: a "*.example.com" listener does serve a
+// "foo.example.com" route (so the listener's certificate should be checked, not skipped), and
+// the pair's effective hostname is the narrower of the two, not the wildcard. Wildcards here are
+// suffix matches of any depth, per the Gateway API hostname spec -- unlike a certificate
+// wildcard, which spans exactly one label.
+//
+// An empty listener hostname means the listener serves every hostname, so the route's own
+// hostnames stand unnarrowed. Empty route hostnames mean the route accepts whatever the listener
+// serves, which the listener's own certificate check already covers, so nothing is returned. An
+// empty result for two non-empty sides means they are disjoint: the route does not attach here.
+func hostnameIntersections(listenerHostname string, routeHostnames interface{}) []string {
+	hostnames := expectedHostnames(routeHostnames)
+	if len(hostnames) == 0 {
+		return nil
+	}
+	if listenerHostname == "" {
+		return hostnames
+	}
+	var intersections []string
+	for _, routeHostname := range hostnames {
+		if narrowed := narrowerHostname(listenerHostname, routeHostname); narrowed != "" {
+			intersections = append(intersections, narrowed)
+		}
+	}
+	return intersections
+}
+
+// narrowerHostname returns the more specific of two Gateway API hostname patterns, or "" when
+// they share no hostname at all.
+func narrowerHostname(a, b string) string {
+	aSuffix, aIsWildcard := wildcardSuffix(a)
+	bSuffix, bIsWildcard := wildcardSuffix(b)
+	switch {
+	case !aIsWildcard && !bIsWildcard:
+		if strings.EqualFold(a, b) {
+			return a
+		}
+	case aIsWildcard && !bIsWildcard:
+		// A wildcard covers subdomains of its suffix at any depth, but never the suffix itself.
+		if hostnameUnder(b, aSuffix) {
+			return b
+		}
+	case !aIsWildcard && bIsWildcard:
+		if hostnameUnder(a, bSuffix) {
+			return a
+		}
+	default:
+		// Two wildcards overlap when one suffix contains the other; the deeper one wins.
+		if strings.EqualFold(aSuffix, bSuffix) || hostnameUnder(aSuffix, bSuffix) {
+			return a
+		}
+		if hostnameUnder(bSuffix, aSuffix) {
+			return b
+		}
+	}
+	return ""
+}
+
+// hostnameUnder reports whether host is a strict subdomain of suffix.
+func hostnameUnder(host, suffix string) bool {
+	return strings.HasSuffix(strings.ToLower(host), "."+strings.ToLower(suffix))
 }
 
 // certServesHostname reports whether cert can serve the hostname a caller expects it to serve.

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -1591,6 +1591,25 @@ func TestParseTLSSecretCertificate(t *testing.T) {
 		selfSigned: true,
 	})
 
+	// A wildcard certificate as cert-manager issues one, and an apex-only one, to exercise
+	// wildcard expected hostnames (Gateway listener/route hostnames and Ingress hosts) on both
+	// sides of the comparison.
+	wildcardPEM, _, wildcardKey := generateTestCert(t, genCertOptions{
+		subjectCN:  "*.example.com",
+		dnsNames:   []string{"*.example.com"},
+		selfSigned: true,
+	})
+	apexPEM, _, apexKey := generateTestCert(t, genCertOptions{
+		subjectCN:  "example.com",
+		dnsNames:   []string{"example.com"},
+		selfSigned: true,
+	})
+	// Pre-RFC-6125 certificate naming the server only in its subject CN, with no SAN extension.
+	cnOnlyPEM, _, cnOnlyKey := generateTestCert(t, genCertOptions{
+		subjectCN:  "*.cn-only.example.com",
+		selfSigned: true,
+	})
+
 	tests := []struct {
 		name          string
 		secret        RenderableObject
@@ -1732,6 +1751,123 @@ func TestParseTLSSecretCertificate(t *testing.T) {
 			hostname: "foo.wild.example.com",
 			want: map[string]interface{}{
 				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			// A "*.example.com" listener only ever routes names the certificate covers, so
+			// flagging this is a false alarm -- x509.VerifyHostname can't tell, since it treats
+			// its argument as a concrete server name.
+			name:     "wildcard expected hostname is served by a concrete SAN below it",
+			secret:   tlsSecret("kubernetes.io/tls", leafPEM, keyPEMBytes(leafKey)),
+			hostname: "*.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "wildcard expected hostname is served by an identical wildcard SAN",
+			secret:   tlsSecret("kubernetes.io/tls", wildcardPEM, keyPEMBytes(wildcardKey)),
+			hostname: "*.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "wildcard expected hostname is served by a deeper wildcard SAN",
+			secret:   tlsSecret("kubernetes.io/tls", leafPEM, keyPEMBytes(leafKey)),
+			hostname: "*.wild.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "wildcard expected hostname mismatch on a sibling subdomain",
+			secret:   tlsSecret("kubernetes.io/tls", leafPEM, keyPEMBytes(leafKey)),
+			hostname: "*.other.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "wildcard expected hostname mismatch on an unrelated domain",
+			secret:   tlsSecret("kubernetes.io/tls", wildcardPEM, keyPEMBytes(wildcardKey)),
+			hostname: "*.example.org",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			// "*.example.com" never routes the apex, so an apex-only certificate serves nothing
+			// the listener accepts.
+			name:     "wildcard expected hostname is not served by the bare suffix",
+			secret:   tlsSecret("kubernetes.io/tls", apexPEM, keyPEMBytes(apexKey)),
+			hostname: "*.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			// A certificate wildcard stands for exactly one label (RFC 6125), so "*.example.com"
+			// covers no name under "foo.example.com".
+			name:     "shallower wildcard SAN doesn't serve a deeper wildcard expected hostname",
+			secret:   tlsSecret("kubernetes.io/tls", wildcardPEM, keyPEMBytes(wildcardKey)),
+			hostname: "*.foo.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "CN-only certificate matches via its CommonName wildcard",
+			secret:   tlsSecret("kubernetes.io/tls", cnOnlyPEM, keyPEMBytes(cnOnlyKey)),
+			hostname: "foo.cn-only.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "CN-only certificate matches a wildcard expected hostname",
+			secret:   tlsSecret("kubernetes.io/tls", cnOnlyPEM, keyPEMBytes(cnOnlyKey)),
+			hostname: "*.cn-only.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": true,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "CN-only certificate wildcard spans a single label only",
+			secret:   tlsSecret("kubernetes.io/tls", cnOnlyPEM, keyPEMBytes(cnOnlyKey)),
+			hostname: "foo.bar.cn-only.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			name:     "CN-only certificate mismatch",
+			secret:   tlsSecret("kubernetes.io/tls", cnOnlyPEM, keyPEMBytes(cnOnlyKey)),
+			hostname: "foo.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
+			},
+			checkKeysOnly: []string{"MatchesHostname"},
+		},
+		{
+			// The SAN extension is authoritative when present: a certificate with SANs is not
+			// rescued by a CommonName that happens to match.
+			name:     "CommonName is ignored when the certificate has SANs",
+			secret:   tlsSecret("kubernetes.io/tls", cnNotFirstPEM, keyPEMBytes(cnNotFirstKey)),
+			hostname: "other.example.com",
+			want: map[string]interface{}{
+				"MatchesHostname": false,
 			},
 			checkKeysOnly: []string{"MatchesHostname"},
 		},

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -1918,6 +1918,145 @@ func TestParseTLSSecretCertificate(t *testing.T) {
 	}
 }
 
+// Routes carry a list of hostnames, so the templates hand parseTLSSecretCertificate every
+// hostname a listener serves for the route rather than only the single-hostname case they used to
+// restrict themselves to.
+func TestParseTLSSecretCertificateHostnameLists(t *testing.T) {
+	cfg := NewRenderConfig(viper.New())
+	leafPEM, _, leafKey := generateTestCert(t, genCertOptions{
+		subjectCN:  "leaf.example.com",
+		dnsNames:   []string{"leaf.example.com", "*.wild.example.com"},
+		selfSigned: true,
+	})
+	secret := tlsSecret("kubernetes.io/tls", leafPEM, keyPEMBytes(leafKey))
+
+	tests := []struct {
+		name      string
+		hostnames interface{}
+		want      bool
+	}{
+		{"empty list expects nothing", []string{}, true},
+		{"nil expects nothing", nil, true},
+		{"list of empty strings expects nothing", []string{"", ""}, true},
+		{"single-entry list matches", []string{"leaf.example.com"}, true},
+		{"one served hostname among several is enough", []string{"nope.example.com", "leaf.example.com"}, true},
+		{"no served hostname in the list", []string{"nope.example.com", "other.example.com"}, false},
+		{"wildcard entry in the list", []string{"*.wild.example.com"}, true},
+		// Templates range over unstructured data, so lists reach here as []interface{}.
+		{"untyped list from unstructured data", []interface{}{"leaf.example.com"}, true},
+		{"plain string is still accepted", "leaf.example.com", true},
+		// A hostname with a space in it can't match anything, but must not be split into two
+		// hostnames either (which is what cast.ToStringSlice would do to a bare string).
+		{"string is not split on whitespace", "nope.example.com leaf.example.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cfg.parseTLSSecretCertificate(secret, tt.hostnames)["MatchesHostname"]
+			if got != tt.want {
+				t.Errorf("parseTLSSecretCertificate(secret, %#v)[MatchesHostname] = %v, want %v", tt.hostnames, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostnameIntersections(t *testing.T) {
+	tests := []struct {
+		name             string
+		listenerHostname string
+		routeHostnames   interface{}
+		want             []string
+	}{
+		{
+			name:             "route pins no hostname, so nothing narrows the listener",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []string{},
+			want:             nil,
+		},
+		{
+			name:             "listener serves every hostname, so the route's stand unnarrowed",
+			listenerHostname: "",
+			routeHostnames:   []string{"a.example.com", "*.b.example.com"},
+			want:             []string{"a.example.com", "*.b.example.com"},
+		},
+		{
+			name:             "identical concrete hostnames",
+			listenerHostname: "a.example.com",
+			routeHostnames:   []string{"a.example.com"},
+			want:             []string{"a.example.com"},
+		},
+		{
+			name:             "different concrete hostnames are disjoint",
+			listenerHostname: "a.example.com",
+			routeHostnames:   []string{"b.example.com"},
+			want:             nil,
+		},
+		{
+			// The listener attaches the route, and the pair only ever serves the route's
+			// concrete hostname -- so that, not the wildcard, is what the cert must cover.
+			name:             "wildcard listener narrows to the route's concrete hostname",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []string{"a.example.com", "deep.a.example.com", "other.org"},
+			want:             []string{"a.example.com", "deep.a.example.com"},
+		},
+		{
+			name:             "concrete listener narrows a wildcard route to itself",
+			listenerHostname: "a.example.com",
+			routeHostnames:   []string{"*.example.com"},
+			want:             []string{"a.example.com"},
+		},
+		{
+			name:             "a wildcard never covers its own suffix",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []string{"example.com"},
+			want:             nil,
+		},
+		{
+			name:             "two wildcards keep the deeper one",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []string{"*.apps.example.com"},
+			want:             []string{"*.apps.example.com"},
+		},
+		{
+			name:             "two wildcards keep the deeper one, listener side",
+			listenerHostname: "*.apps.example.com",
+			routeHostnames:   []string{"*.example.com"},
+			want:             []string{"*.apps.example.com"},
+		},
+		{
+			name:             "identical wildcards",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []string{"*.example.com"},
+			want:             []string{"*.example.com"},
+		},
+		{
+			name:             "sibling wildcards are disjoint",
+			listenerHostname: "*.a.example.com",
+			routeHostnames:   []string{"*.b.example.com"},
+			want:             nil,
+		},
+		{
+			name:             "matching is case-insensitive",
+			listenerHostname: "*.EXAMPLE.com",
+			routeHostnames:   []string{"A.example.COM"},
+			want:             []string{"A.example.COM"},
+		},
+		{
+			name:             "untyped list from unstructured data",
+			listenerHostname: "*.example.com",
+			routeHostnames:   []interface{}{"a.example.com"},
+			want:             []string{"a.example.com"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostnameIntersections(tt.listenerHostname, tt.routeHostnames)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("hostnameIntersections(%q, %#v) = %#v, want %#v", tt.listenerHostname, tt.routeHostnames, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCertificatesInSecret(t *testing.T) {
 	cfg := NewRenderConfig(viper.New())
 	caPEM, caCert, caKey := generateTestCert(t, genCertOptions{

--- a/pkg/plugin/templates/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/GRPCRoute.tmpl
@@ -25,20 +25,16 @@
                         {{- $gwNs := coalesce .namespace $.Namespace }}
                         {{- $gw := $.KubeGetFirst $gwNs "Gateway" .name }}
                         {{- if $gw.Object }}
-                            {{- /* if the route has exactly one hostname, use it for hostname-match checks; skip strictness otherwise */}}
                             {{- $routeHostnames := $.Spec.hostnames | default (list) }}
-                            {{- $routeHostname := "" }}
-                            {{- if eq (len $routeHostnames) 1 }}{{ $routeHostname = index $routeHostnames 0 }}{{ end }}
                             {{- range $gw.Spec.listeners }}
+                                {{- /* See the HTTPRoute template for what this intersection means. */ -}}
+                                {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
                                 {{- $isMatch := false }}
                                 {{- if $parentRef.sectionName }}
                                     {{- if eq .name $parentRef.sectionName }}{{ $isMatch = true }}{{ end }}
+                                    {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
                                 {{- else if eq .protocol "HTTPS" }}
-                                    {{- $hostOk := true }}
-                                    {{- with .hostname }}
-                                        {{- if and (gt (len $routeHostnames) 0) (not (has . $routeHostnames)) }}{{ $hostOk = false }}{{ end }}
-                                    {{- end }}
-                                    {{- if $hostOk }}{{ $isMatch = true }}{{ end }}
+                                    {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $isMatch = true }}{{ end }}
                                 {{- end }}
                                 {{- if $isMatch }}
                                     {{- with .tls }}
@@ -51,7 +47,7 @@
                                                 {{- if not $secret.Object }}
                                                     {{- " doesn't exist" | red | bold }}
                                                 {{- else }}
-                                                    {{- $cert := parseTLSSecretCertificate $secret $routeHostname }}
+                                                    {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
                                                     {{- if $cert.WrongType }}
                                                         {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
                                                     {{- else if $cert.MissingKeys }}

--- a/pkg/plugin/templates/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/HTTPRoute.tmpl
@@ -17,8 +17,6 @@
         {{- end }}
     {{- end }}
     {{- $routeHostnames := .Spec.hostnames | default (list) }}
-    {{- $routeHostname := "" }}
-    {{- if eq (len $routeHostnames) 1 }}{{ $routeHostname = index $routeHostnames 0 }}{{ end }}
     {{- with .Spec.parentRefs }}
         {{- "Parents" | bold | nindent 2 }}:
         {{- range . }}
@@ -42,15 +40,23 @@
                     {{- if $gw.Object }}
                         {{- $sectionName := .sectionName }}
                         {{- range $gw.Spec.listeners }}
+                            {{- /* The hostnames this listener and this route serve together, which
+                                   are the ones the listener's certificate has to cover -- either
+                                   side may be a wildcard, so this is an intersection rather than
+                                   an equality test. Empty means the route pins no hostname (or,
+                                   for a listener that isn't pinned by sectionName below, that the
+                                   two are disjoint and the route doesn't attach here). */ -}}
+                            {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
                             {{- $matches := false }}
                             {{- if $sectionName }}
                                 {{- if eq .name $sectionName }}{{ $matches = true }}{{ end }}
+                                {{- /* sectionName attaches the route to this listener whatever its
+                                       hostname, so a disjoint pair is a real problem: fall back to
+                                       the route's hostnames to report it rather than staying
+                                       silent. */ -}}
+                                {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
                             {{- else if eq .protocol "HTTPS" }}
-                                {{- $hostnameOk := true }}
-                                {{- with .hostname }}
-                                    {{- if and $routeHostnames (not (has . $routeHostnames)) }}{{ $hostnameOk = false }}{{ end }}
-                                {{- end }}
-                                {{- if $hostnameOk }}{{ $matches = true }}{{ end }}
+                                {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $matches = true }}{{ end }}
                             {{- end }}
                             {{- if $matches }}
                                 {{- with .tls }}
@@ -63,7 +69,7 @@
                                             {{- if not $secret.Object }}
                                                 {{- " doesn't exist" | red | bold }}
                                             {{- else }}
-                                                {{- $cert := parseTLSSecretCertificate $secret $routeHostname }}
+                                                {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
                                                 {{- if $cert.WrongType }}
                                                     {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
                                                 {{- else if $cert.MissingKeys }}

--- a/pkg/plugin/templates/TLSRoute.tmpl
+++ b/pkg/plugin/templates/TLSRoute.tmpl
@@ -10,10 +10,7 @@
         {{- "Hostnames" | bold | nindent 2 }}: {{ join ", " . | cyan }}
     {{- end }}
     {{- with .Spec.parentRefs }}
-        {{- $routeHostname := "" }}
-        {{- with $.Spec.hostnames }}
-            {{- if eq (len .) 1 }}{{ $routeHostname = index . 0 }}{{ end }}
-        {{- end }}
+        {{- $routeHostnames := $.Spec.hostnames | default (list) }}
         {{- "Parents" | bold | nindent 2 }}:
         {{- range . }}
             {{- if $.Config.GetBool "deep" }}
@@ -29,11 +26,17 @@
                     {{- $gw := $.KubeGetFirst $gwNs (coalesce $parentRef.kind "Gateway") $parentRef.name }}
                     {{- if $gw.Object }}
                         {{- range $gw.Spec.listeners }}
+                            {{- /* See the HTTPRoute template for what this intersection means. Without
+                                   it an unpinned route reported every TLS listener on the Gateway,
+                                   flagging certificates on listeners whose own hostname means they
+                                   never serve this route. */ -}}
+                            {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
                             {{- $listenerMatches := false }}
                             {{- if $parentRef.sectionName }}
                                 {{- if eq .name $parentRef.sectionName }}{{ $listenerMatches = true }}{{ end }}
+                                {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
                             {{- else if eq .protocol "TLS" }}
-                                {{- $listenerMatches = true }}
+                                {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $listenerMatches = true }}{{ end }}
                             {{- end }}
                             {{- if $listenerMatches }}
                                 {{- with .tls }}
@@ -44,7 +47,7 @@
                                                 {{- $refNs := coalesce .namespace $gwNs }}
                                                 {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
                                                 {{- if $secret.Object }}
-                                                    {{- $cert := parseTLSSecretCertificate $secret $routeHostname }}
+                                                    {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
                                                     {{- if $cert.WrongType }}
                                                         {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
                                                     {{- else if $cert.MissingKeys }}

--- a/tests/e2e-artifacts/tls-validation-gateway-wildcard-host.regex
+++ b/tests/e2e-artifacts/tls-validation-gateway-wildcard-host.regex
@@ -1,0 +1,10 @@
+\A
+Gateway/e2e-tls-gw-wildcard-host -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Class: e2e-tls-unused-gwc
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
+  Listeners:
+    https: port=443/HTTPS, host=\*\.example\.com, namespaces=Same
+      TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls
+\z

--- a/tests/e2e-artifacts/tls-validation-gateway-wildcard-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-gateway-wildcard-mismatch.regex
@@ -1,0 +1,10 @@
+\A
+Gateway/e2e-tls-gw-wildcard-mismatch -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Class: e2e-tls-unused-gwc
+  Accepted:Unknown Pending, Waiting for controller for 1m
+  Programmed:Unknown Pending, Waiting for controller for 1m
+  Listeners:
+    https: port=443/HTTPS, host=\*\.wrong\.example\.com, namespaces=Same
+      TLS mode:Terminate, cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+\z

--- a/tests/e2e-artifacts/tls-validation-httproute-wildcard-host.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-wildcard-host.regex
@@ -1,0 +1,11 @@
+\A
+HTTPRoute/e2e-tls-httproute-wildcard-host -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: \*\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-healthy \[https\]
+      , cert:Secret/e2e-tls-leaf-tls
+  Rules:
+    PathPrefix /
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-httproute-wildcard-listener.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-wildcard-listener.regex
@@ -1,0 +1,11 @@
+\A
+HTTPRoute/e2e-tls-httproute-wildcard-listener -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-wildcard-host
+      , cert:Secret/e2e-tls-leaf-tls
+  Rules:
+    PathPrefix /
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-httproute.yaml
+++ b/tests/e2e-artifacts/tls-validation-httproute.yaml
@@ -19,6 +19,31 @@ spec:
         type: PathPrefix
         value: /
 ---
+# A wildcard route hostname is as legal as a wildcard listener hostname, and the
+# leaf certificate covers e2e-tls.example.com, which sits under it -- so this
+# must not be flagged as a hostname mismatch either. sectionName pins the
+# listener, bypassing the parentRef hostname filtering.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: e2e-tls-httproute-wildcard-host
+spec:
+  hostnames:
+  - "*.example.com"
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: e2e-tls-gw-healthy
+    sectionName: https
+  rules:
+  - backendRefs:
+    - name: e2e-tls-svc
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/tests/e2e-artifacts/tls-validation-httproute.yaml
+++ b/tests/e2e-artifacts/tls-validation-httproute.yaml
@@ -64,3 +64,26 @@ spec:
     - path:
         type: PathPrefix
         value: /
+---
+# No sectionName, so the listener is picked by hostname: the Gateway's
+# "*.example.com" listener does serve this route, and its certificate must be
+# checked rather than the listener being skipped as non-matching.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: e2e-tls-httproute-wildcard-listener
+spec:
+  hostnames:
+  - e2e-tls.example.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: e2e-tls-gw-wildcard-host
+  rules:
+  - backendRefs:
+    - name: e2e-tls-svc
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/tests/e2e-artifacts/tls-validation-leaf.yaml
+++ b/tests/e2e-artifacts/tls-validation-leaf.yaml
@@ -120,3 +120,41 @@ spec:
       certificateRefs:
       - kind: Secret
         name: e2e-tls-leaf-tls
+---
+# A wildcard listener only routes names the leaf certificate covers
+# (e2e-tls.example.com), so this must not be flagged as a hostname mismatch.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-tls-gw-wildcard-host
+spec:
+  gatewayClassName: e2e-tls-unused-gwc
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: "*.example.com"
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-leaf-tls
+---
+# The leaf certificate covers nothing under wrong.example.com, so a wildcard
+# listener for it is still a genuine mismatch.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-tls-gw-wildcard-mismatch
+spec:
+  gatewayClassName: e2e-tls-unused-gwc
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: "*.wrong.example.com"
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-leaf-tls

--- a/tests/e2e-artifacts/tls-validation-tlsroute-multi-listener.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-multi-listener.regex
@@ -1,0 +1,9 @@
+\A
+TLSRoute/e2e-tlsroute-multi-listener -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-tlsroute-multi
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-tlsroute.yaml
+++ b/tests/e2e-artifacts/tls-validation-tlsroute.yaml
@@ -63,3 +63,46 @@ spec:
   - backendRefs:
     - name: e2e-tls-svc
       port: 80
+---
+# Two Terminate listeners with different hostnames and certificates: the route
+# below attaches only to tls-a, so tls-b's non-covering certificate must not be
+# reported against it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-tls-gw-tlsroute-multi
+spec:
+  gatewayClassName: e2e-tls-unused-gwc
+  listeners:
+  - name: tls-a
+    port: 443
+    protocol: TLS
+    hostname: e2e-tls.example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-leaf-tls
+  - name: tls-b
+    port: 444
+    protocol: TLS
+    hostname: other.example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-root-ca-secret
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: e2e-tlsroute-multi-listener
+spec:
+  hostnames:
+  - e2e-tls.example.com
+  parentRefs:
+  - name: e2e-tls-gw-tlsroute-multi
+  rules:
+  - backendRefs:
+    - name: e2e-tls-svc
+      port: 80


### PR DESCRIPTION
## Problem

A Gateway listener with a wildcard hostname was reported as having a certificate mismatch even when the certificate was fine:

```
  Listeners:
    https: port=443/HTTPS, host=*.example.com, namespaces=Selector, accepts=HTTPRoute/GRPCRoute, routes=0
      TLS mode:Terminate, cert:Secret/ingress-tls, hostname mismatch
```

Chasing that turned up three more wildcard blind spots in the same area, all from comparing hostname *patterns* as if they were concrete names.

## 1. Certificate check fed a wildcard to `x509.VerifyHostname`

The expected hostname is a pattern — a Gateway listener hostname, a route hostname or an Ingress host, commonly `*.example.com` — while `VerifyHostname` is only defined for concrete server names: it deliberately refuses to read a `*` in its argument as a wildcard and degrades to a byte comparison against the SANs. So a `*.example.com` listener only passed when a SAN was literally that string, and a `foo.example.com` or `*.apps.example.com` certificate — which covers every name that listener can route — got flagged.

For a wildcard expectation we now ask the correct, weaker question: does the certificate cover *any* hostname this listener accepts? Both sides can be patterns, so it's a set intersection — a certificate wildcard spans exactly one label (RFC 6125), while a Gateway API/Ingress host wildcard spans any subdomain depth but never the bare apex. Still flagged as genuine mismatches: apex-only certificate under a wildcard host, sibling subdomain, unrelated domain, and a certificate wildcard shallower than the expected one. Concrete hostnames keep going through `VerifyHostname` unchanged.

## 2. Certificates with no SAN extension at all

A hand-rolled `CN=*.example.com` certificate with no `subjectAltName` produced the same misleading message, since Go ignores the subject CN. Calling that a hostname mismatch misdiagnoses the real problem, so it now falls back to matching the CN.

## 3. Route ↔ listener matching compared hostnames as exact strings

- `HTTPRoute`/`GRPCRoute` picked listeners with `has . $routeHostnames`, so a `*.example.com` listener fronting a `foo.example.com` route counted as non-matching and **its certificate was never checked at all** — a silently missing check rather than a wrong message.
- `TLSRoute` never filtered by hostname, so an unpinned route reported *every* TLS listener on the Gateway, flagging `hostname mismatch` (and `self-signed`) against listeners whose own hostname means they never serve that route. That's the same false positive as #1, without needing a wildcard.
- All three only checked anything when the route had exactly one hostname.

New `hostnameIntersections` narrows a listener hostname against the route's hostnames the way the Gateway API attaches routes, and the pair serves the *narrower* of the two — which is what the listener's certificate has to cover. Templates use it both to pick listeners and to derive what to check the certificate against, so multi-hostname routes are now checked too (`parseTLSSecretCertificate` takes a list, satisfied when the certificate serves at least one entry). A listener pinned by `sectionName` still reports a disjoint hostname rather than going quiet, since the route attaches there regardless.

All five callers — Gateway, HTTPRoute, GRPCRoute, TLSRoute, Ingress — share `parseTLSSecretCertificate`, so the certificate-side fixes apply everywhere.

## Tests

- `TestParseTLSSecretCertificate`: 13 new cases — patterns on both sides, apex-only, depth mismatches, unrelated domains, and the CN-only fallback (including that a CN is ignored when SANs exist).
- `TestParseTLSSecretCertificateHostnameLists` and `TestHostnameIntersections`: list handling and the intersection rules (wildcard/concrete in both directions, two wildcards, siblings, case-insensitivity, `[]interface{}` from unstructured data).
- Four new e2e scenarios against a live cluster: wildcard Gateway listener covering / not covering the cert, a wildcard HTTPRoute hostname, an HTTPRoute unpinned to a section behind a wildcard listener, and an unpinned TLSRoute on a two-listener Gateway. Re-running each with the relevant change reverted reproduces the old output, so all four fail without this PR.
- `go vet ./...` and `go test ./...` clean. The full e2e suite passes apart from `TestE2EDynamicManifests/VerticalPodAutoscaler...`, which is unrelated (it waits ~7min for a VPA recommendation on this box). (`make staticcheck` also fails locally for a pre-existing reason: staticcheck v0.6.1 ships built with go1.25.12, the module's toolchain wants >= go1.26.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)