### PR TITLE
Name the certificate's namespace on cross-namespace certificateRefs

### DIFF
--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -14,6 +14,30 @@ import (
 	"github.com/bergerx/kubectl-status/pkg/plugin"
 )
 
+// copyLeafSecretToNamespace clones the cert-manager-issued leaf TLS secret into a second
+// namespace, so a certificateRef can point across namespaces at genuine certificate content.
+// Copying beats issuing a second Certificate there: the CA Issuer is namespaced to srcNS, so
+// reaching it from another namespace would mean promoting it to a ClusterIssuer for every other
+// subtest too. Creating dstNS is part of the same job: it has to exist before
+// tls-validation-crossns-grant.yaml, which is applied into it, lands.
+func copyLeafSecretToNamespace(t *testing.T, clientset *kubernetes.Clientset, srcNS, dstNS string) {
+	t.Helper()
+	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dstNS}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		clientset.CoreV1().Namespaces().Delete(context.TODO(), dstNS, metav1.DeleteOptions{})
+	})
+	src, err := clientset.CoreV1().Secrets(srcNS).Get(context.TODO(), "e2e-tls-leaf-tls", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = clientset.CoreV1().Secrets(dstNS).Create(context.TODO(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: src.Name, Namespace: dstNS},
+		Type:       src.Type,
+		Data:       src.Data,
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
 func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
 	ensureCertManager(t)
 	ensureGatewayAPICRDs(t)
@@ -197,6 +221,30 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 				args:            []string{"httproute/e2e-tls-httproute-mismatch", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 				stdoutRegexPath: "e2e-artifacts/tls-validation-httproute-mismatch.regex",
 			}.assert(t, nil, opts...)
+		})
+		certsNS := ns + "-certs"
+		copyLeafSecretToNamespace(t, clientset, ns, certsNS)
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-crossns-grant.yaml", certsNS)
+		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-crossns.yaml", ns)
+		t.Run("httproute whose listener certificate lives in another namespace names that namespace", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"httproute/e2e-tls-httproute-crossns", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-crossns-httproute.regex")
+			// The namespace is the whole point: a bare "cert:Secret/e2e-tls-leaf-tls" would
+			// point at a Secret that doesn't exist in the route's own namespace.
+			assert.Contains(t, stdout, "cert:Secret/e2e-tls-leaf-tls -n "+certsNS)
+			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:", "doesn't exist"} {
+				assert.NotContains(t, stdout, problem)
+			}
+		})
+		t.Run("tlsroute whose listener certificate lives in another namespace names that namespace", func(t *testing.T) {
+			stdout, _, err := executeCMD(t, []string{"tlsroute/e2e-tlsroute-crossns", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"}, opts...)
+			require.NoError(t, err)
+			assertStdoutMatchesRegexFixture(t, stdout, "e2e-artifacts/tls-validation-crossns-tlsroute.regex")
+			assert.Contains(t, stdout, "cert:Secret/e2e-tls-leaf-tls -n "+certsNS)
+			for _, problem := range []string{", self-signed", ", hostname mismatch", "wrong type:", "missing keys:", "parse error:", "doesn't exist"} {
+				assert.NotContains(t, stdout, problem)
+			}
 		})
 	})
 }

--- a/pkg/plugin/templates/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/GRPCRoute.tmpl
@@ -43,7 +43,7 @@
                                             {{- if eq $refKind "Secret" }}
                                                 {{- $refNs := coalesce .namespace $gwNs }}
                                                 {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
-                                                {{- printf "cert:%s/%s" $refKind .name | cyan | nindent 6 }}
+                                                {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
                                                 {{- if not $secret.Object }}
                                                     {{- " doesn't exist" | red | bold }}
                                                 {{- else }}

--- a/pkg/plugin/templates/Gateway.tmpl
+++ b/pkg/plugin/templates/Gateway.tmpl
@@ -33,9 +33,9 @@
                 {{- with .certificateRefs }}
                     {{- range . }}
                         {{- $refKind := .kind | default "Secret" }}
-                        {{- printf ", cert:%s/%s" $refKind .name | cyan }}
+                        {{- $refNs := coalesce .namespace $.Namespace }}
+                        {{- ", cert:" }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
                         {{- if and (eq $refKind "Secret") (not ($.LiveQueriesDisabled)) }}
-                            {{- $refNs := coalesce .namespace $.Namespace }}
                             {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
                             {{- if not $secret.Object }}
                                 {{- " doesn't exist" | red | bold }}

--- a/pkg/plugin/templates/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/HTTPRoute.tmpl
@@ -63,8 +63,8 @@
                                     {{- range .certificateRefs }}
                                         {{- $refKind := .kind | default "Secret" }}
                                         {{- if eq $refKind "Secret" }}
-                                            {{- printf ", cert:%s/%s" $refKind .name | cyan | nindent 6 }}
                                             {{- $refNs := coalesce .namespace $ns }}
+                                            {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
                                             {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
                                             {{- if not $secret.Object }}
                                                 {{- " doesn't exist" | red | bold }}

--- a/pkg/plugin/templates/ListenerSet.tmpl
+++ b/pkg/plugin/templates/ListenerSet.tmpl
@@ -32,7 +32,9 @@
             {{- with .tls }}
                 {{- printf "TLS mode:%s" (.mode | default "Terminate") | nindent 6 }}
                 {{- with .certificateRefs }}
-                    {{- range . }}{{ printf ", cert:%s/%s" (.kind | default "Secret") .name | cyan }}{{ end }}
+                    {{- range . }}
+                        {{- ", cert:" }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "Secret") "name" .name "namespace" (coalesce .namespace $.Namespace) "callerNamespace" $.Namespace) }}
+                    {{- end }}
                 {{- end }}
             {{- end }}
             {{- range $statusListener.conditions }}

--- a/pkg/plugin/templates/TLSRoute.tmpl
+++ b/pkg/plugin/templates/TLSRoute.tmpl
@@ -46,6 +46,7 @@
                                             {{- if eq $refKind "Secret" }}
                                                 {{- $refNs := coalesce .namespace $gwNs }}
                                                 {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
+                                                {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
                                                 {{- if $secret.Object }}
                                                     {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
                                                     {{- if $cert.WrongType }}

--- a/tests/artifacts/gateway-tls-problems.out
+++ b/tests/artifacts/gateway-tls-problems.out
@@ -19,6 +19,9 @@ Gateway/eg -n default, created 1m ago, gen:1
     hostname-mismatch: port=447/HTTPS, host=wrong-host.example.com, namespaces=Same, routes=1
       TLS mode:Terminate, cert:Secret/gateway-tls
       ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m
+    cross-namespace-cert: port=448/HTTPS, namespaces=Same, routes=0
+      TLS mode:Terminate, cert:Secret/gateway-tls -n certs
+      ResolvedRefs:False RefNotPermitted, Secret certs/gateway-tls not permitted by any ReferenceGrant for 1m
 
 Secret/opaque-secret -n default, created 1m ago
   Keys: foo

--- a/tests/artifacts/gateway-tls-problems.yaml
+++ b/tests/artifacts/gateway-tls-problems.yaml
@@ -66,6 +66,18 @@ spec:
       certificateRefs:
       - kind: Secret
         name: gateway-tls
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: cross-namespace-cert
+    port: 448
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: gateway-tls
+        namespace: certs
 status:
   conditions:
   - lastTransitionTime: "2026-06-26T23:42:41Z"
@@ -120,6 +132,15 @@ status:
       status: "True"
       type: ResolvedRefs
     name: hostname-mismatch
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2026-06-26T23:42:41Z"
+      message: Secret certs/gateway-tls not permitted by any ReferenceGrant
+      observedGeneration: 1
+      reason: RefNotPermitted
+      status: "False"
+      type: ResolvedRefs
+    name: cross-namespace-cert
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/e2e-artifacts/tls-validation-crossns-grant.yaml
+++ b/tests/e2e-artifacts/tls-validation-crossns-grant.yaml
@@ -1,0 +1,19 @@
+# Lives in the certificate's namespace, so it is applied separately from
+# tls-validation-crossns.yaml -- applyManifestInNamespace passes a single `kubectl -n`, which
+# kubectl rejects against an object carrying a different explicit metadata.namespace.
+#
+# Nothing in the rendering depends on this grant (the fixtures' GatewayClass has no controller
+# behind it, so no admission ever checks it); it is here because a cross-namespace certificateRef
+# without one isn't a configuration anybody would actually run.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: e2e-tls-allow-gateway-certs
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: e2e-tls-validation
+  to:
+  - group: ""
+    kind: Secret

--- a/tests/e2e-artifacts/tls-validation-crossns-httproute.regex
+++ b/tests/e2e-artifacts/tls-validation-crossns-httproute.regex
@@ -1,0 +1,11 @@
+\A
+HTTPRoute/e2e-tls-httproute-crossns -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-crossns \[https\]
+      cert:Secret/e2e-tls-leaf-tls -n e2e-tls-validation-certs
+  Rules:
+    PathPrefix /
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-crossns-tlsroute.regex
+++ b/tests/e2e-artifacts/tls-validation-crossns-tlsroute.regex
@@ -1,0 +1,10 @@
+\A
+TLSRoute/e2e-tlsroute-crossns -n e2e-tls-validation, created 1m ago, gen:1
+  Current: Resource is current
+  Hostnames: e2e-tls\.example\.com
+  Parents:
+    Gateway/e2e-tls-gw-crossns \[tls\]
+      cert:Secret/e2e-tls-leaf-tls -n e2e-tls-validation-certs
+  Rules:
+    → Service/e2e-tls-svc:80
+\z

--- a/tests/e2e-artifacts/tls-validation-crossns.yaml
+++ b/tests/e2e-artifacts/tls-validation-crossns.yaml
@@ -1,0 +1,73 @@
+# A certificateRef may name a Secret in another namespace, which a ReferenceGrant there permits
+# (tls-validation-crossns-grant.yaml). The rendered reference has to carry that namespace:
+# without it the certificate reads as if it sat alongside the Gateway, and the one Secret that
+# actually terminates TLS is indistinguishable from a same-namespace one.
+#
+# The Secret itself is copied into e2e-tls-validation-certs by the test rather than issued
+# there -- the CA Issuer backing the leaf certificate is namespaced to the route's namespace,
+# so a second cert-manager Certificate would need a ClusterIssuer to reach it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: e2e-tls-gw-crossns
+spec:
+  gatewayClassName: e2e-tls-unused-gwc
+  listeners:
+  - name: https
+    port: 443
+    protocol: HTTPS
+    hostname: e2e-tls.example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-leaf-tls
+        namespace: e2e-tls-validation-certs
+  - name: tls
+    port: 8443
+    protocol: TLS
+    hostname: e2e-tls.example.com
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: e2e-tls-leaf-tls
+        namespace: e2e-tls-validation-certs
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: e2e-tls-httproute-crossns
+spec:
+  hostnames:
+  - e2e-tls.example.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: e2e-tls-gw-crossns
+    sectionName: https
+  rules:
+  - backendRefs:
+    - name: e2e-tls-svc
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: e2e-tlsroute-crossns
+spec:
+  hostnames:
+  - e2e-tls.example.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: e2e-tls-gw-crossns
+    sectionName: tls
+  rules:
+  - backendRefs:
+    - name: e2e-tls-svc
+      port: 80

--- a/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-healthy.regex
@@ -4,7 +4,7 @@ HTTPRoute/e2e-tls-httproute-healthy -n e2e-tls-validation, created 1m ago, gen:1
   Hostnames: e2e-tls\.example\.com
   Parents:
     Gateway/e2e-tls-gw-healthy \[https\]
-      , cert:Secret/e2e-tls-leaf-tls
+      cert:Secret/e2e-tls-leaf-tls
   Rules:
     PathPrefix /
     → Service/e2e-tls-svc:80

--- a/tests/e2e-artifacts/tls-validation-httproute-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-mismatch.regex
@@ -4,7 +4,7 @@ HTTPRoute/e2e-tls-httproute-mismatch -n e2e-tls-validation, created 1m ago, gen:
   Hostnames: wrong-host\.example\.com
   Parents:
     Gateway/e2e-tls-gw-mismatch \[https\]
-      , cert:Secret/e2e-tls-leaf-tls, hostname mismatch
+      cert:Secret/e2e-tls-leaf-tls, hostname mismatch
   Rules:
     PathPrefix /
     → Service/e2e-tls-svc:80

--- a/tests/e2e-artifacts/tls-validation-httproute-wildcard-host.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-wildcard-host.regex
@@ -4,7 +4,7 @@ HTTPRoute/e2e-tls-httproute-wildcard-host -n e2e-tls-validation, created 1m ago,
   Hostnames: \*\.example\.com
   Parents:
     Gateway/e2e-tls-gw-healthy \[https\]
-      , cert:Secret/e2e-tls-leaf-tls
+      cert:Secret/e2e-tls-leaf-tls
   Rules:
     PathPrefix /
     → Service/e2e-tls-svc:80

--- a/tests/e2e-artifacts/tls-validation-httproute-wildcard-listener.regex
+++ b/tests/e2e-artifacts/tls-validation-httproute-wildcard-listener.regex
@@ -4,7 +4,7 @@ HTTPRoute/e2e-tls-httproute-wildcard-listener -n e2e-tls-validation, created 1m 
   Hostnames: e2e-tls\.example\.com
   Parents:
     Gateway/e2e-tls-gw-wildcard-host
-      , cert:Secret/e2e-tls-leaf-tls
+      cert:Secret/e2e-tls-leaf-tls
   Rules:
     PathPrefix /
     → Service/e2e-tls-svc:80

--- a/tests/e2e-artifacts/tls-validation-tlsroute-healthy.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-healthy.regex
@@ -4,6 +4,7 @@ TLSRoute/e2e-tlsroute-healthy -n e2e-tls-validation, created 1m ago, gen:1
   Hostnames: e2e-tls\.example\.com
   Parents:
     Gateway/e2e-tls-gw-tlsroute \[tls-term\]
+      cert:Secret/e2e-tls-leaf-tls
   Rules:
     → Service/e2e-tls-svc:80
 \z

--- a/tests/e2e-artifacts/tls-validation-tlsroute-mismatch.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-mismatch.regex
@@ -3,7 +3,8 @@ TLSRoute/e2e-tlsroute-mismatch -n e2e-tls-validation, created 1m ago, gen:1
   Current: Resource is current
   Hostnames: wrong-host\.example\.com
   Parents:
-    Gateway/e2e-tls-gw-tlsroute \[tls-term\], hostname mismatch
+    Gateway/e2e-tls-gw-tlsroute \[tls-term\]
+      cert:Secret/e2e-tls-leaf-tls, hostname mismatch
   Rules:
     → Service/e2e-tls-svc:80
 \z

--- a/tests/e2e-artifacts/tls-validation-tlsroute-multi-listener.regex
+++ b/tests/e2e-artifacts/tls-validation-tlsroute-multi-listener.regex
@@ -4,6 +4,7 @@ TLSRoute/e2e-tlsroute-multi-listener -n e2e-tls-validation, created 1m ago, gen:
   Hostnames: e2e-tls\.example\.com
   Parents:
     Gateway/e2e-tls-gw-tlsroute-multi
+      cert:Secret/e2e-tls-leaf-tls
   Rules:
     → Service/e2e-tls-svc:80
 \z


### PR DESCRIPTION
Started from a question about why an HTTPRoute's certificate rendered on its own line with a stray leading comma, and whether it went through `resource_ref`. It didn't — and that turned out to be the interesting part.

## Cross-namespace certificateRefs didn't name their namespace

All four Gateway API templates that render a listener's `certificateRef` built the reference by hand:

```gotemplate
{{- printf ", cert:%s/%s" $refKind .name | cyan }}
```

A `certificateRef` may point at a Secret in another namespace (legal, via a `ReferenceGrant`), and the resolved namespace was already sitting in `$refNs` for the `KubeGetFirst` lookup — it just never reached the output, so a cross-namespace certificate was indistinguishable from a local one. All four now go through the `resource_ref` helper, which appends `-n <ns>` when the ref lands outside the rendered object's namespace (and bolds the kind, matching every other reference in the output).

## HTTPRoute's stray leading comma

`HTTPRoute.tmpl` was copied from `Gateway.tmpl`, where the `", "` correctly continues an existing `TLS mode:Terminate` line. HTTPRoute has no such prefix — it starts a fresh line with its own `nindent 6`, so the separator ended up as the first character after the indent:

```
    Gateway/e2e-tls-gw-wildcard-listener
      , cert:Secret/e2e-tls-leaf-tls
```

`GRPCRoute.tmpl` already dropped the comma; the e2e fixtures had the inconsistency baked in, which is why nothing caught it.

## TLSRoute never named the Secret

`TLSRoute.tmpl` ran the same `certificateRefs` loop but emitted only the problem suffixes, never a cert line — so a mismatch was reported without saying which certificate it was about:

```
    Gateway/e2e-tls-gw-tlsroute [tls-term], hostname mismatch
```

It now renders the cert line like the other route kinds.

## Coverage

The `-n` path had no test anywhere: every fixture used same-namespace refs, offline `.out` artifacts render with `--local --shallow` (so the route templates' cert blocks never execute), and the route-side cert lines only exist in e2e.

- `tests/artifacts/gateway-tls-problems.yaml` gains a `cross-namespace-cert` listener, pinning `cert:Secret/gateway-tls -n certs` in the golden output.
- New e2e cases render an HTTPRoute and a TLSRoute whose listener certificate lives in a second namespace, asserting the namespace appears and no spurious cert problems are flagged. The leaf Secret is copied there by the test rather than issued there — the CA Issuer is namespaced, so a second cert-manager Certificate would mean promoting it to a ClusterIssuer for every other subtest.

## Verification

- `go test ./...`, `go vet ./...`, `make staticcheck` clean.
- `make update-artifacts` changed **only** the new fixture's `.out` — every pre-existing golden file is byte-identical, confirming the `resource_ref` switch is a no-op for same-namespace refs.
- `make test-e2e-quick RUN='TestE2EParallel/tls-validation'` — 25 tests pass against a real cluster (23 before, plus the 2 new cross-namespace cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)