### PR TITLE
Warn when a stuck rollout doesn't fit the namespace ResourceQuota

### DIFF
--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -308,5 +309,60 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 				stdoutRegexPath: "e2e-artifacts/rollouts-three-revisions-with-diffs.regex",
 			}.assert(t, nil, opts...)
 		})
+	})
+	t.Run("a rollout that can't fit in the namespace ResourceQuota reports the headroom shortfall (#658)", func(t *testing.T) {
+		t.Parallel()
+		// The quota only has room for 2 of the 3 replicas, so the Deployment is stuck with a
+		// ReplicaFailure and the headroom check explains which resource ran out. Needs a live
+		// cluster: the quota lives on a separate object that only a KubeGet can reach.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-quota-headroom"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		_, err = clientset.CoreV1().ResourceQuotas(ns).Create(context.TODO(), &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "compute", Namespace: ns},
+			Spec: corev1.ResourceQuotaSpec{Hard: corev1.ResourceList{
+				corev1.ResourceRequestsMemory: resource.MustParse("512Mi"),
+			}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		name := "e2e-quota-headroom"
+		three := int32(3)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &three,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name:  "app",
+						Image: "registry.k8s.io/pause:3.10",
+						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						}},
+					}}},
+				},
+			},
+		}
+		_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
+		require.NoError(t, err)
+		defer clientset.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		waitForInNamespace(t, "deployment/"+name, "condition=ReplicaFailure", ns)
+		// The 2 Pods the quota does allow start out Pending, and the Deployment's own
+		// readyReplicas lags behind their readiness, so wait on the field the render actually
+		// prints rather than on the Pods.
+		waitForInNamespace(t, "deployment/"+name, "jsonpath={.status.readyReplicas}=2", ns)
+
+		cmdTest{
+			args:            []string{"deployment/" + name, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/quota-headroom-blocked-deployment.regex",
+		}.assert(t, nil, opts...)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/apimachinery v0.36.3
 	k8s.io/cli-runtime v0.36.3
 	k8s.io/client-go v0.36.3
+	k8s.io/component-helpers v0.36.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubectl v0.36.3
 	sigs.k8s.io/cli-utils v0.37.2
@@ -85,7 +86,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.36.3 // indirect
-	k8s.io/component-helpers v0.36.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -27,10 +27,14 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	resource2 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
@@ -120,6 +124,7 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"colorPercent":                    colorPercent,
 		"evictionHeadroom":                evictionHeadroom,
 		"evictionAnnotation":              evictionAnnotation,
+		"quotaRolloutHeadroom":            quotaRolloutHeadroom,
 		"humanizeSI":                      humanizeSI,
 		"humanizeSIPair":                  humanizeSIPair,
 		"getMatchingItemInMapList":        getMatchingItemInMapList,
@@ -313,6 +318,206 @@ func colorPercent(format string, percent float64) string {
 		return color.YellowString(str)
 	}
 	return str
+}
+
+// quotaHeadroomReport is what quotaRolloutHeadroom found for one workload: how many Pods the
+// workload still has to create before its rollout can finish, and the ResourceQuotas that don't
+// currently have room for them. Quotas is empty whenever every quota in the namespace has room
+// (the common case), so templates can render nothing at all without inspecting further.
+type quotaHeadroomReport struct {
+	ExtraPods int
+	Quotas    []quotaHeadroomQuota
+}
+
+// quotaHeadroomQuota is one ResourceQuota that is short on at least one of the resources the
+// pending Pods would consume. Only the short resources are listed -- a quota that tracks ten
+// resources and is short on one shouldn't print the nine that fit.
+type quotaHeadroomQuota struct {
+	Name       string
+	Shortfalls []quotaShortfall
+}
+
+// quotaShortfall is one resource of one quota. The figures are resource.Quantity strings, i.e. the
+// same canonical form the quota itself is written in ("512Mi", "500m"), so the reader can compare
+// them against their own manifests and against kubectl's own quota output.
+type quotaShortfall struct {
+	Resource string
+	Need     string
+	Free     string
+	Used     string
+	Hard     string
+}
+
+// quotaRolloutHeadroom answers "will the Pods this rollout still has to create fit in the
+// namespace's ResourceQuota?" -- the warning a reader wants *before* the rollout wedges on
+// FailedCreate. quotas are the namespace's ResourceQuota objects and workload is a Deployment or
+// StatefulSet, all as unstructured maps, which are converted to their API types so that the
+// per-Pod resource total comes from the same k8s.io/component-helpers/resource implementation the
+// scheduler and quota controller use (sidecars, init containers, pod-level resources and
+// RuntimeClass overhead all have non-obvious rules there that aren't worth restating).
+//
+// The comparison is deliberately conservative, because a false "you're out of quota" on a workload
+// that is merely slow to roll out is worse than saying nothing:
+//
+//   - Quotas carrying spec.scopes or spec.scopeSelector are skipped entirely. Whether these Pods
+//     fall in a scope depends on fields (priorityClassName, BestEffort-ness, termination) whose
+//     matching rules live in k8s.io/kubernetes and can't be imported, and guessing wrong means
+//     blaming a quota that never applied to these Pods.
+//   - A quota resource the Pod template requests nothing for is skipped, so nothing is reported
+//     for object-count quotas (count/deployments.apps, services, ...).
+//   - A resource missing from status.used is skipped: the quota controller hasn't reported on it
+//     yet, so its free capacity is unknown rather than equal to hard.
+//   - Only an actual shortfall is returned; a quota with room produces no entry.
+//
+// status.used is namespace-wide and shared with every other workload in the namespace, and quota
+// headroom says nothing about whether a node can fit the Pod -- callers must word the output so
+// neither is implied.
+func quotaRolloutHeadroom(quotas []interface{}, workload map[string]interface{}) quotaHeadroomReport {
+	extraPods, podSpec := rolloutPendingPods(workload)
+	report := quotaHeadroomReport{ExtraPods: extraPods}
+	if extraPods <= 0 || podSpec == nil {
+		return report
+	}
+	pod := &corev1.Pod{Spec: *podSpec}
+	requests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{})
+	for _, q := range quotas {
+		quotaObject, ok := q.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var quota corev1.ResourceQuota
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(quotaObject, &quota); err != nil {
+			klog.V(3).ErrorS(err, "ignoring unconvertible ResourceQuota in quota headroom check")
+			continue
+		}
+		if len(quota.Spec.Scopes) > 0 || quota.Spec.ScopeSelector != nil {
+			continue
+		}
+		var shortfalls []quotaShortfall
+		for _, name := range sortedResourceNames(quota.Status.Hard) {
+			used, reported := quota.Status.Used[name]
+			if !reported {
+				continue
+			}
+			perPod, consumed := quotaResourcePerPod(name, requests, limits)
+			if !consumed {
+				continue
+			}
+			need := multiplyQuantity(perPod, extraPods)
+			hard := quota.Status.Hard[name]
+			free := hard.DeepCopy()
+			free.Sub(used)
+			if free.Sign() < 0 {
+				free.Set(0)
+			}
+			if need.Cmp(free) <= 0 {
+				continue
+			}
+			shortfalls = append(shortfalls, quotaShortfall{
+				Resource: string(name),
+				Need:     need.String(),
+				Free:     free.String(),
+				Used:     used.String(),
+				Hard:     hard.String(),
+			})
+		}
+		if len(shortfalls) > 0 {
+			report.Quotas = append(report.Quotas, quotaHeadroomQuota{Name: quota.Name, Shortfalls: shortfalls})
+		}
+	}
+	return report
+}
+
+// rolloutPendingPods is how many Pods the workload's controller still has to create before its
+// rollout is complete -- the replica count it may run at once minus the Pods it already has --
+// along with the Pod spec each of them will be created from. A Deployment's allowance includes
+// rolling-update surge, resolved with the same intstr helper the Deployment controller's
+// ResolveFenceposts uses, since surge is what makes a rollout need more quota than the steady
+// state. A StatefulSet gets no surge allowance -- it deletes a Pod before creating its replacement
+// -- so for one only a scale-up shows up here. Returns 0 and a nil spec for any other kind, or
+// when the object doesn't convert to its API type (a hand-written manifest rendered with -f can be
+// missing or mistype anything).
+func rolloutPendingPods(workload map[string]interface{}) (int, *corev1.PodSpec) {
+	switch cast.ToString(workload["kind"]) {
+	case "Deployment":
+		var deployment appsv1.Deployment
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(workload, &deployment); err != nil {
+			klog.V(3).ErrorS(err, "ignoring unconvertible Deployment in quota headroom check")
+			return 0, nil
+		}
+		desired := 1
+		if deployment.Spec.Replicas != nil {
+			desired = int(*deployment.Spec.Replicas)
+		}
+		surge := 0
+		if strategy := deployment.Spec.Strategy; strategy.Type == "" || strategy.Type == appsv1.RollingUpdateDeploymentStrategyType {
+			maxSurge := intstr.FromString("25%")
+			if strategy.RollingUpdate != nil && strategy.RollingUpdate.MaxSurge != nil {
+				maxSurge = *strategy.RollingUpdate.MaxSurge
+			}
+			surge, _ = intstr.GetScaledValueFromIntOrPercent(&maxSurge, desired, true)
+		}
+		return desired + surge - int(deployment.Status.Replicas), &deployment.Spec.Template.Spec
+	case "StatefulSet":
+		var statefulSet appsv1.StatefulSet
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(workload, &statefulSet); err != nil {
+			klog.V(3).ErrorS(err, "ignoring unconvertible StatefulSet in quota headroom check")
+			return 0, nil
+		}
+		desired := 1
+		if statefulSet.Spec.Replicas != nil {
+			desired = int(*statefulSet.Spec.Replicas)
+		}
+		return desired - int(statefulSet.Status.Replicas), &statefulSet.Spec.Template.Spec
+	}
+	return 0, nil
+}
+
+// resourceLimitsPrefix is the "limits.<resource>" counterpart of core/v1's
+// DefaultResourceRequestsPrefix, which upstream declares only for the requests form.
+const resourceLimitsPrefix = "limits."
+
+// quotaResourcePerPod maps a ResourceQuota resource name to how much of it a single Pod of the
+// template consumes, following the quota resource naming: "requests.<name>"/"limits.<name>", the
+// bare "cpu"/"memory" aliases for the requests form, and "pods" for the Pod count itself. consumed
+// is false for a resource the Pod template doesn't ask for, including object counts.
+func quotaResourcePerPod(quotaResource corev1.ResourceName, requests, limits corev1.ResourceList) (quantity resource2.Quantity, consumed bool) {
+	if quotaResource == corev1.ResourcePods {
+		return *resource2.NewQuantity(1, resource2.DecimalSI), true
+	}
+	amounts, name := requests, string(quotaResource)
+	switch {
+	case strings.HasPrefix(name, corev1.DefaultResourceRequestsPrefix):
+		name = strings.TrimPrefix(name, corev1.DefaultResourceRequestsPrefix)
+	case strings.HasPrefix(name, resourceLimitsPrefix):
+		amounts, name = limits, strings.TrimPrefix(name, resourceLimitsPrefix)
+	}
+	perPod, ok := amounts[corev1.ResourceName(name)]
+	if !ok || perPod.IsZero() {
+		return resource2.Quantity{}, false
+	}
+	return perPod, true
+}
+
+// multiplyQuantity returns quantity added to itself count times, keeping it a resource.Quantity
+// (which has no multiplication of its own) so the result stays exact and prints in the same
+// canonical form as the quota's own values. Pod counts here are small.
+func multiplyQuantity(quantity resource2.Quantity, count int) resource2.Quantity {
+	total := quantity.DeepCopy()
+	for i := 1; i < count; i++ {
+		total.Add(quantity)
+	}
+	return total
+}
+
+func sortedResourceNames(list corev1.ResourceList) []corev1.ResourceName {
+	names := make([]corev1.ResourceName, 0, len(list))
+	for name := range list {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	return names
 }
 
 // ansiEscape matches an SGR color/style escape sequence (e.g. from fatih/color), used by

--- a/pkg/plugin/template_functions_static_test.go
+++ b/pkg/plugin/template_functions_static_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"os"
@@ -2908,6 +2910,198 @@ func TestStatefulSetRollbackTrapBlocker(t *testing.T) {
 			}
 			if gotRevision != "web-bad" {
 				t.Errorf("statefulSetRollbackTrapBlocker() revision = %q, want %q", gotRevision, "web-bad")
+			}
+		})
+	}
+}
+
+// unstructuredFromJSON decodes a manifest into the map form templates see. Written as JSON rather
+// than as a Go map literal because quotaRolloutHeadroom converts its inputs to their API types,
+// and that conversion is typed: replicas has to arrive as an int64, exactly as it does from the
+// apiserver or from a -f manifest, which a hand-written map literal makes easy to get wrong.
+func unstructuredFromJSON(t *testing.T, manifest string) map[string]interface{} {
+	t.Helper()
+	obj := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(manifest), &obj); err != nil {
+		t.Fatalf("unmarshalling test manifest: %v", err)
+	}
+	return obj
+}
+
+// resourceQuotaJSON is a namespace quota tracking requests.memory, with hard and used given as
+// quantity strings the way the quota controller writes them.
+func resourceQuotaJSON(hard, used string) string {
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+		"status":{"hard":{"requests.memory":%q},"used":{"requests.memory":%q}}}`, hard, used)
+}
+
+// deploymentJSON is a Deployment of replicas Pods, each requesting 256Mi, with status.replicas
+// Pods currently existing and the default (25%) surge allowance.
+func deploymentJSON(replicas, existing int, extraSpec string) string {
+	return fmt.Sprintf(`{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"test"},
+		"spec":{"replicas":%d,%s"template":{"spec":{"containers":[{"name":"main","resources":{"requests":{"memory":"256Mi"}}}]}}},
+		"status":{"replicas":%d}}`, replicas, extraSpec, existing)
+}
+
+func TestQuotaRolloutHeadroom(t *testing.T) {
+	tests := []struct {
+		name          string
+		workload      string
+		quotas        []string
+		wantExtraPods int
+		wantShortfall *quotaShortfall
+	}{
+		{
+			// 4 replicas + 25% surge = 5 allowed, 4 exist, so one 256Mi Pod is pending and the
+			// quota has 128Mi left for it.
+			name:          "rolling update surge doesn't fit the remaining headroom",
+			workload:      deploymentJSON(4, 4, ""),
+			quotas:        []string{resourceQuotaJSON("2Gi", "1920Mi")},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "requests.memory", Need: "256Mi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name:          "no shortfall reported when the surge fits",
+			workload:      deploymentJSON(4, 4, ""),
+			quotas:        []string{resourceQuotaJSON("2Gi", "1Gi")},
+			wantExtraPods: 1,
+		},
+		{
+			// A blocked scale-up needs a Pod per missing replica, not just the surge one.
+			name:          "need scales with the number of Pods still missing",
+			workload:      deploymentJSON(4, 1, ""),
+			quotas:        []string{resourceQuotaJSON("2Gi", "1920Mi")},
+			wantExtraPods: 4,
+			wantShortfall: &quotaShortfall{Resource: "requests.memory", Need: "1Gi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name:          "explicit maxSurge percentage is resolved against the replica count",
+			workload:      deploymentJSON(4, 4, `"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":"50%"}},`),
+			quotas:        []string{resourceQuotaJSON("2Gi", "1920Mi")},
+			wantExtraPods: 2,
+			wantShortfall: &quotaShortfall{Resource: "requests.memory", Need: "512Mi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name:          "Recreate strategy gets no surge allowance",
+			workload:      deploymentJSON(4, 4, `"strategy":{"type":"Recreate"},`),
+			quotas:        []string{resourceQuotaJSON("2Gi", "1920Mi")},
+			wantExtraPods: 0,
+		},
+		{
+			// A StatefulSet deletes a Pod before creating its replacement, so a rollout at full
+			// replica count needs no extra headroom.
+			name: "StatefulSet at full replica count needs no headroom",
+			workload: `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"db","namespace":"test"},
+				"spec":{"replicas":3,"template":{"spec":{"containers":[{"name":"main","resources":{"requests":{"memory":"256Mi"}}}]}}},
+				"status":{"replicas":3}}`,
+			quotas:        []string{resourceQuotaJSON("2Gi", "2Gi")},
+			wantExtraPods: 0,
+		},
+		{
+			name: "StatefulSet scale-up blocked by quota",
+			workload: `{"apiVersion":"apps/v1","kind":"StatefulSet","metadata":{"name":"db","namespace":"test"},
+				"spec":{"replicas":3,"template":{"spec":{"containers":[{"name":"main","resources":{"requests":{"memory":"256Mi"}}}]}}},
+				"status":{"replicas":2}}`,
+			quotas:        []string{resourceQuotaJSON("2Gi", "2Gi")},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "requests.memory", Need: "256Mi", Free: "0", Used: "2Gi", Hard: "2Gi"},
+		},
+		{
+			// Sidecars (restarting initContainers) run alongside the main containers so they add
+			// up, which upstream's PodRequests handles -- 256Mi + 64Mi here.
+			name: "sidecar requests count towards the Pod's total",
+			workload: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"test"},
+				"spec":{"replicas":1,"template":{"spec":{
+					"containers":[{"name":"main","resources":{"requests":{"memory":"256Mi"}}}],
+					"initContainers":[{"name":"proxy","restartPolicy":"Always","resources":{"requests":{"memory":"64Mi"}}},
+						{"name":"setup","resources":{"requests":{"memory":"128Mi"}}}]}}},
+				"status":{"replicas":1}}`,
+			quotas:        []string{resourceQuotaJSON("2Gi", "1920Mi")},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "requests.memory", Need: "320Mi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name:     "a pods count quota is measured in Pods, not bytes",
+			workload: deploymentJSON(4, 4, ""),
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+				"status":{"hard":{"pods":"4"},"used":{"pods":"4"}}}`},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "pods", Need: "1", Free: "0", Used: "4", Hard: "4"},
+		},
+		{
+			// Whether these Pods fall in the scope isn't decidable here, so the quota is skipped
+			// rather than reported against.
+			name:     "scoped quota is skipped",
+			workload: deploymentJSON(4, 4, ""),
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+				"spec":{"scopes":["BestEffort"]},
+				"status":{"hard":{"requests.memory":"2Gi"},"used":{"requests.memory":"2Gi"}}}`},
+			wantExtraPods: 1,
+		},
+		{
+			name:     "object count quota the Pods don't consume is skipped",
+			workload: deploymentJSON(4, 4, ""),
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"objects","namespace":"test"},
+				"status":{"hard":{"count/deployments.apps":"1"},"used":{"count/deployments.apps":"1"}}}`},
+			wantExtraPods: 1,
+		},
+		{
+			// status.used not yet reported for a tracked resource means unknown free capacity,
+			// which must not be read as the full hard limit being available either way.
+			name:     "resource missing from status.used is skipped",
+			workload: deploymentJSON(4, 4, ""),
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+				"status":{"hard":{"requests.memory":"2Gi"},"used":{}}}`},
+			wantExtraPods: 1,
+		},
+		{
+			// The bare "memory"/"cpu" quota names are aliases of the requests form.
+			name:     "bare memory quota name is treated as requests.memory",
+			workload: deploymentJSON(4, 4, ""),
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+				"status":{"hard":{"memory":"2Gi"},"used":{"memory":"1920Mi"}}}`},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "memory", Need: "256Mi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name: "limits quota is compared against the Pod's limits, not its requests",
+			workload: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"test"},
+				"spec":{"replicas":1,"template":{"spec":{"containers":[{"name":"main","resources":{
+					"requests":{"memory":"256Mi"},"limits":{"memory":"512Mi"}}}]}}},
+				"status":{"replicas":1}}`,
+			quotas: []string{`{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+				"status":{"hard":{"limits.memory":"2Gi"},"used":{"limits.memory":"1920Mi"}}}`},
+			wantExtraPods: 1,
+			wantShortfall: &quotaShortfall{Resource: "limits.memory", Need: "512Mi", Free: "128Mi", Used: "1920Mi", Hard: "2Gi"},
+		},
+		{
+			name:          "a kind with no rollout of its own reports nothing",
+			workload:      `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"web","namespace":"test"}}`,
+			quotas:        []string{resourceQuotaJSON("2Gi", "2Gi")},
+			wantExtraPods: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var quotas []interface{}
+			for _, quota := range tt.quotas {
+				quotas = append(quotas, unstructuredFromJSON(t, quota))
+			}
+			got := quotaRolloutHeadroom(quotas, unstructuredFromJSON(t, tt.workload))
+			if got.ExtraPods != tt.wantExtraPods {
+				t.Errorf("quotaRolloutHeadroom() ExtraPods = %d, want %d", got.ExtraPods, tt.wantExtraPods)
+			}
+			if tt.wantShortfall == nil {
+				if len(got.Quotas) != 0 {
+					t.Fatalf("quotaRolloutHeadroom() Quotas = %+v, want none", got.Quotas)
+				}
+				return
+			}
+			if len(got.Quotas) != 1 || len(got.Quotas[0].Shortfalls) != 1 {
+				t.Fatalf("quotaRolloutHeadroom() Quotas = %+v, want exactly one shortfall", got.Quotas)
+			}
+			if got.Quotas[0].Shortfalls[0] != *tt.wantShortfall {
+				t.Errorf("quotaRolloutHeadroom() shortfall = %+v, want %+v", got.Quotas[0].Shortfalls[0], *tt.wantShortfall)
 			}
 		})
 	}

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -43,6 +43,11 @@
             {{- end }}
         {{- end }}
     {{- end }}
+    {{- /* Only when the rollout already looks unhealthy, or in --deep, per CONVENTIONS.md: a
+           Deployment that currently fits its quota shouldn't spend a query to say so. */ -}}
+    {{- if or (not $rolloutStatus.done) (ne (.Status.replicas | int) (.Status.readyReplicas | int)) (.Config.GetBool "deep") }}
+        {{- template "quota_headroom" . }}
+    {{- end }}
     {{- template "recent_deployment_rollouts" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -66,6 +66,11 @@
             {{- "Stuck rollout" | red | bold | nindent 2 }}: No ready replicas, this StatefulSet won't likely go further.
         {{- end }}
     {{- end }}
+    {{- /* Only when the rollout already looks unhealthy, or in --deep, per CONVENTIONS.md: a
+           StatefulSet that currently fits its quota shouldn't spend a query to say so. */ -}}
+    {{- if or (not $rolloutStatus.done) (ne ($status.currentReplicas | int) ($status.readyReplicas | int)) (.Config.GetBool "deep") }}
+        {{- template "quota_headroom" . }}
+    {{- end }}
     {{- template "recent_statefulset_rollouts" . }}
     {{- template "statefulset_volume_claims" . }}
     {{- template "recent_updates" . }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -54,6 +54,37 @@
     {{- end }}
 {{- end -}}
 
+{{- define "quota_headroom" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects a Deployment or StatefulSet. Warns when the namespace's ResourceQuota doesn't
+           have room for the Pods the workload still has to create, which is why a rollout that
+           looks stuck for no reason is stuck -- and, in --deep, before it gets stuck. Callers gate
+           this on the rollout already looking unhealthy (or --deep), so a healthy workload never
+           pays for the extra query or the extra lines; quotaRolloutHeadroom itself only reports an
+           actual shortfall, so even then the common case renders nothing.
+           Wording is deliberate: the numbers are namespace-wide and say nothing about node
+           capacity, so the note below spells both out rather than letting the reader assume this
+           quota is the workload's own, or that free quota means the Pods will schedule. */ -}}
+    {{- $quotaObjects := list }}
+    {{- range .KubeGet .Namespace "resourcequotas" }}
+        {{- $quotaObjects = append $quotaObjects .Object }}
+    {{- end }}
+    {{- with $quotaObjects }}
+        {{- $headroom := quotaRolloutHeadroom . $.Object }}
+        {{- with $headroom.Quotas }}
+            {{- $pods := printf "%d more Pods" $headroom.ExtraPods }}
+            {{- if eq $headroom.ExtraPods 1 }}{{ $pods = "1 more Pod" }}{{ end }}
+            {{- range . }}
+                {{- "Quota Headroom" | yellow | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "ResourceQuota" "name" .Name) }} doesn't have room for the {{ $pods }} a rollout needs to create:
+                {{- range .Shortfalls }}
+                    {{- printf "%s: needs %s, only %s free" .Resource .Need .Free | yellow | nindent 4 }} (used {{ .Used | cyan }} of {{ .Hard | cyan }})
+                {{- end }}
+            {{- end }}
+            {{- "" | nindent 4 }}Quota is namespace-wide and shared with every workload in the namespace; free quota is not a guarantee that a node can fit the {{ $pods }}.
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
 {{- define "resource_ref" }}
     {{- /* Expects dict "kind" "name" "namespace" (optional) "callerNamespace" (optional -- the
            namespace of the object doing the referencing; when it matches "namespace" the

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -1521,3 +1521,91 @@ func TestResourceHealthSummaryTemplate_FallsBackToGenericForUnknownKind(t *testi
 		t.Errorf("got = %q, want the generic_health_summary fallback", got)
 	}
 }
+
+// TestQuotaHeadroomTemplate covers the rendered form of the quota headroom warning (issue #658):
+// the numbers come from quotaRolloutHeadroom's own tests, what's asserted here is that the section
+// reaches the reader with the ResourceQuota named, and with the two caveats the figures need --
+// that the quota is namespace-wide, and that free quota isn't a scheduling guarantee.
+func TestQuotaHeadroomTemplate(t *testing.T) {
+	quotaList := `{"apiVersion":"v1","kind":"ResourceQuotaList","items":[
+		{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+		 "status":{"hard":{"requests.memory":"2Gi"},"used":{"requests.memory":"1920Mi"}}}]}`
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     cmdtesting.DefaultHeader(),
+				Body:       io.NopCloser(strings.NewReader(quotaList)),
+			}, nil
+		}),
+	}
+	f.Client = f.UnstructuredClient
+	t.Cleanup(func() { f.Cleanup() })
+	cfg := NewRenderConfig(viper.New())
+	tmpl, _ := getTemplate(cfg)
+	repo, err := input.NewResourceRepo(f, cfg.Viper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	// 4 replicas at 256Mi each, all 4 running: the 25% surge Pod of the next rollout step needs
+	// 256Mi and the quota has 128Mi left.
+	deployment := newRenderableObject(unstructuredFromJSON(t, deploymentJSON(4, 4, "")), e, repo)
+	got, err := deployment.renderTemplate("quota_headroom", deployment)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	for _, want := range []string{
+		"ResourceQuota/compute",
+		"doesn't have room for the 1 more Pod a rollout needs to create",
+		"requests.memory: needs 256Mi, only 128Mi free",
+		"used 1920Mi of 2Gi",
+		"namespace-wide",
+		"not a guarantee that a node can fit",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("quota_headroom got = %q, should contain %q", got, want)
+		}
+	}
+}
+
+// TestQuotaHeadroomTemplateSilentWhenQuotaHasRoom keeps the healthy path free of the warning: the
+// section is reached whenever a rollout looks unhealthy for any reason, and most of those have
+// nothing to do with quota.
+func TestQuotaHeadroomTemplateSilentWhenQuotaHasRoom(t *testing.T) {
+	quotaList := `{"apiVersion":"v1","kind":"ResourceQuotaList","items":[
+		{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"name":"compute","namespace":"test"},
+		 "status":{"hard":{"requests.memory":"2Gi"},"used":{"requests.memory":"512Mi"}}}]}`
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     cmdtesting.DefaultHeader(),
+				Body:       io.NopCloser(strings.NewReader(quotaList)),
+			}, nil
+		}),
+	}
+	f.Client = f.UnstructuredClient
+	t.Cleanup(func() { f.Cleanup() })
+	cfg := NewRenderConfig(viper.New())
+	tmpl, _ := getTemplate(cfg)
+	repo, err := input.NewResourceRepo(f, cfg.Viper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, _ := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	e.Template = *tmpl
+	deployment := newRenderableObject(unstructuredFromJSON(t, deploymentJSON(4, 4, "")), e, repo)
+	got, err := deployment.renderTemplate("quota_headroom", deployment)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if strings.TrimSpace(got) != "" {
+		t.Errorf("quota_headroom got = %q, want nothing when the quota has room", got)
+	}
+}

--- a/tests/e2e-artifacts/quota-headroom-blocked-deployment.regex
+++ b/tests/e2e-artifacts/quota-headroom-blocked-deployment.regex
@@ -1,0 +1,19 @@
+\A
+Deployment/e2e-quota-headroom -n e2e-quota-headroom, created 1m ago, gen:1 rev:1
+  InProgress: Replicas: 2/3
+    Reconciling: LessReplicas, Replicas: 2/3
+  desired:3, existing:2, ready:2, updated:2, available:2, unavailable:1
+  Selector: app=e2e-quota-headroom
+    Pod/e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
+    Pod/e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
+  Not matched by any Service
+  Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
+  ReplicaFailure:True FailedCreate, pods "e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+" is forbidden: exceeded quota: compute, requested: requests\.memory=256Mi, used: requests\.memory=512Mi, limited: requests\.memory=512Mi for 1m
+  Progressing:True ReplicaSetUpdated, ReplicaSet "e2e-quota-headroom-[a-z0-9]+" is progressing\. for 1m
+  Ongoing Rollout: Waiting for deployment "e2e-quota-headroom" rollout to finish: 2 out of 3 new replicas have been updated\.\.\.
+  Quota Headroom: ResourceQuota/compute doesn't have room for the 2 more Pods a rollout needs to create:
+    requests\.memory: needs 512Mi, only 0 free \(used 512Mi of 512Mi\)
+    Quota is namespace-wide and shared with every workload in the namespace; free quota is not a guarantee that a node can fit the 2 more Pods\.
+  Rollouts: Use the `--include-rollout-diffs` flag to see the diff between each rollout!
+    1m ago, managed by ReplicaSet/e2e-quota-headroom-[a-z0-9]+, has 2 replicas
+\z


### PR DESCRIPTION
Fixes #658

A rollout that is silently blocked on quota looks identical to one that is merely slow: the Deployment sits at fewer Replicas than it wants and nothing in its status explains why. The reason lives on a separate object, so `status` never showed it.

Adds a **Quota Headroom** section to `Deployment` and `StatefulSet` that fetches the namespace's ResourceQuotas, works out how many more Pods the rollout still has to create, and reports any quota resource that can't cover them:

```
Deployment/e2e-quota-headroom -n e2e-quota-headroom, created 1m ago, gen:1 rev:1
  InProgress: Replicas: 2/3
  desired:3, existing:2, ready:2, updated:2, available:2, unavailable:1
  ...
  Ongoing Rollout: Waiting for deployment "e2e-quota-headroom" rollout to finish: 2 out of 3 new replicas have been updated...
  Quota Headroom: ResourceQuota/compute doesn't have room for the 2 more Pods a rollout needs to create:
    requests.memory: needs 512Mi, only 0 free (used 512Mi of 512Mi)
    Quota is namespace-wide and shared with every workload in the namespace; free quota is not a guarantee that a node can fit the 2 more Pods.
```

### Kept quiet by design

Per CONVENTIONS.md's rendering-depth rule, the section is gated on the rollout *already* looking unhealthy — or on `--deep`, which turns it into an early warning before the rollout gets stuck. Even then only an actual shortfall renders, so the healthy path costs neither the extra query nor extra lines. `--shallow`/`--local` skip it for free, since `KubeGet` returns nothing when live queries are disabled.

### Uses upstream logic rather than reimplementing it

- `component-helpers/resource` `PodRequests`/`PodLimits` for the per-Pod cost, so sidecars (`restartPolicy: Always` init containers), plain init containers' max-semantics, pod-level resources and RuntimeClass overhead all follow the same rules the quota admission plugin uses.
- `intstr.GetScaledValueFromIntOrPercent` for `maxSurge`, matching the Deployment controller's own fencepost maths.
- `runtime.DefaultUnstructuredConverter` and `resource.Quantity` arithmetic throughout — which also means the output prints canonical quantities (`512Mi`, `500m`) matching the user's own manifests.

Surge semantics differ per kind: a Deployment needs `desired + maxSurge - status.replicas`, a StatefulSet only `desired - status.replicas`, since delete-before-create means a same-size rolling update needs no extra headroom and only a scale-up does.

### Conservative about what the numbers mean

The issue called out two ways this could mislead, and the wording addresses both explicitly: `status.used` is namespace-wide and is *not* the workload's own, and free quota is *not* a promise that a node can fit the Pods. Scoped quotas (`spec.scopes`/`scopeSelector`) are skipped rather than guessed at, and a resource missing from `status.used` is treated as unknown rather than free.

### Tests

- 16 table-driven unit cases covering surge maths, `Recreate`, StatefulSet scale-up, sidecar requests, `pods` count quota, scoped/object-count quotas, `limits.*` vs `requests.*`, and bare aliases.
- 2 template-render tests driving the real `KubeGet` path through a fake REST client — including one asserting the output is *empty* when the quota has room. This covers the issue's concern that live-cluster reverse-match logic can't be exercised by the local golden-file suite.
- A `tests/e2e-artifacts` minikube fixture (`quota-headroom-blocked-deployment.regex`) built from a real quota-blocked rollout, verified against a live cluster.

Verified live for both kinds and both gating modes: a Deployment surge blocked with a real `ReplicaFailure: FailedCreate exceeded quota`, and a StatefulSet scale-up blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)