### PR TITLE
Move the Flux e2e scenario into TestE2EParallel's pool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,12 +261,12 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 
 ### Running e2e Tests Locally
 
-`make test-e2e` runs the `TestE2E*` suite against a real cluster. That suite has four top-level
+`make test-e2e` runs the `TestE2E*` suite against a real cluster. That suite has three top-level
 entry points — `TestE2EParallel` (`cmd/main_test.go`), which calls one topical `runXSubtests`
-function per `cmd/e2e_*_test.go` file, plus `TestE2EDynamicManifests` (`cmd/e2e_dynamic_test.go`),
-`TestE2EFluxKustomizationInventory` (`cmd/e2e_flux_test.go`) and `TestE2EAgainstVanillaMinikube`
-(`cmd/e2e_vanilla_test.go`) — sharing the harness in `cmd/e2e_helpers_test.go` (`cmdTest`,
-`applyManifest`/`waitFor`, the `ensureX` dependency installers). `cmd/local_test.go` holds the
+function per `cmd/e2e_*_test.go` file, plus `TestE2EDynamicManifests` (`cmd/e2e_dynamic_test.go`)
+and `TestE2EAgainstVanillaMinikube` (`cmd/e2e_vanilla_test.go`) — sharing the harness in
+`cmd/e2e_helpers_test.go` (`cmdTest`, `applyManifest`/`waitFor`, the `ensureX` dependency
+installers). `cmd/local_test.go` holds the
 tests that need no cluster and so run under plain `make test` instead. `make test-e2e` manages one
 **shared** minikube cluster/profile (`kstat-e2e-shared`), reused across every worktree, branch, and
 session on your machine — not one per branch/session. Run `make print-e2e-profile` to see the
@@ -317,11 +317,15 @@ the filter — cert-manager, Gateway API CRDs and Cilium/Calico CRDs go in even 
 matches nothing. On a warm cluster that's a few seconds and not worth restructuring for; on a fresh
 one it's the bulk of a narrow run's wall clock. `TestE2EDynamicManifests` doesn't have this
 property: its `ensureX` calls sit inside the subtest bodies, so filtering does skip them.
+`runFluxSubtests` is the one pool group that does the same, for the same reason — `ensureFlux` is
+the suite's heaviest install, so it sits inside the `t.Run` rather than at the top of the group,
+where it would go in on any `TestE2EParallel` run whose pattern doesn't even reach that subtest.
 
 The installers are the `ensureX(t)` functions in `cmd/e2e_helpers_test.go`; keep new ones there
-rather than inline in a test file. A topical group calls the ones it needs at the top of its
-`runXSubtests` function; in `TestE2EDynamicManifests`, where a dependency usually serves a single
-scenario, the call goes at the top of that subtest instead. Most install CRDs only —
+rather than inline in a test file. A topical group in `TestE2EParallel` calls the ones it needs at
+the top of its `runXSubtests` function; under `TestE2EDynamicManifests`, where a dependency usually
+serves a single scenario, the call goes at the top of that subtest instead — including when the
+scenario lives in its own file behind a `runXSubtests` function. Most install CRDs only —
 kubectl-status reads and matches these objects client-side, so no real controller is needed;
 `ensureVPA`/`ensureCrossplane`/`ensureFlux` are the exceptions, where the test asserts on state
 only a running controller writes.
@@ -368,12 +372,41 @@ pre-push/CI gate — the targeted `test-e2e-quick` checks above are what a dev-l
 check should use, not the full suite.
 
 When a template change adds or touches `$.KubeGetFirst`, `$.IncludeRenderableObject`/`$.Include`,
-or any other interaction with a live cluster, add or extend a case in `TestE2EDynamicManifests`
-(`cmd/e2e_dynamic_test.go`) plus matching manifests/regex fixtures under `tests/e2e-artifacts/`. The
-offline golden-file tests (`TestAllArtifactsLocal*`) run with `--shallow` (alongside `--local`,
-since there's no live cluster to query either way), which makes `KubeGetFirst` a no-op — they
-can't exercise the "found the related object" or `--deep` include branches, so the live e2e suite
-is the only place that covers them.
+or any other interaction with a live cluster, add or extend a live e2e subtest plus matching
+manifests/regex fixtures under `tests/e2e-artifacts/`. The offline golden-file tests
+(`TestAllArtifactsLocal*`) run with `--shallow` (alongside `--local`, since there's no live cluster
+to query either way), which makes `KubeGetFirst` a no-op — they can't exercise the "found the
+related object" or `--deep` include branches, so the live e2e suite is the only place that covers
+them.
+
+**Put new subtests in `TestE2EParallel`'s pool by default.** `TestE2EDynamicManifests` is the
+exception, and a subtest only earns a place in it by tripping one of the two criteria in
+`TestE2EParallel`'s doc comment (`cmd/main_test.go`) — with the reason written on the subtest, so
+the next person inherits a rule rather than a precedent. The qualifying reasons are all about what
+a subtest does *to* its neighbours: it perturbs cluster-wide state they read (deleting the
+metrics-server `APIService`), it starves a shared dependency (the VPA subtest pegs a full CPU and
+takes metrics-server's readiness probe down with it on a single-node cluster), or it can't be given
+a namespace/generated name of its own.
+
+Several things look disqualifying but aren't, and shouldn't be used to justify a serial subtest:
+
+- **Needing a live-cluster query.** Most of the pool needs one; that's the normal case, not an
+  exception.
+- **Installing a real controller and waiting for it to reconcile.** The `ensureX` installers are
+  shared `onceInstaller`s serialized by `installMu`, so calling one from inside a `t.Parallel()`
+  subtest is safe — `ensureFlux` does exactly that.
+- **Depending on metrics.** Fine as long as the subtest *consumes* metrics rather than threatening
+  them, and its fixtures pin values that are a function of its own workload rather than of cluster
+  load. Relative timestamps aren't a hazard either: `ApplyTestHack` freezes `DurationRound`, so
+  `created 1m ago` is a constant, not elapsed time.
+- **How the objects come into being** (built in Go, applied from static YAML, or patched in place).
+  This distinguishes nothing, whatever the `DynamicManifests` name suggests.
+
+See #784: the Flux scenario was a standalone top-level test, then a serial subtest, before anyone
+checked it against the criteria — which it met, so it's a pool group now. Don't add a fourth
+top-level `TestE2E*` function either; a scenario long enough to crowd its host file can live in its
+own `cmd/e2e_*_test.go` behind a `runXSubtests` function, the way `runFluxSubtests` does. The file a
+subtest sits in and the entry point it runs under are separate choices.
 
 Assert on stdout with a whole-output `.regex` fixture (`stdoutRegexPath`, or
 `assertStdoutMatchesRegexFixture` when the subtest also needs to assert something the fixture can't

--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -39,6 +39,37 @@ func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []
 	return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
 }
 
+// TestE2EDynamicManifests holds the scenarios that have a specific, stated reason not to be in
+// TestE2EParallel's pool. It is the exception, not the default: a new subtest belongs in the pool
+// (cmd/main_test.go) unless it trips one of that function's two criteria, and the reason goes in a
+// comment on the subtest -- every one below has one.
+//
+// The reasons that actually qualify are narrow, and all of them are about what the subtest does
+// *to* its neighbours:
+//   - it perturbs cluster-wide state they read (the metrics-server APIService subtest deletes the
+//     APIService other renders depend on),
+//   - it starves a shared dependency (the VPA subtest pegs a full CPU to give the recommender
+//     something to act on, which on a single-node cluster takes metrics-server's readiness probe
+//     down with it),
+//   - it can't be given a namespace or generated name of its own.
+//
+// Several things that look disqualifying aren't. Needing a live cluster interaction the offline
+// artifacts can't reach ($.KubeGetFirst, $.IncludeRenderableObject/$.Include) doesn't -- most of the
+// pool needs one. Installing a real controller and waiting for it to reconcile doesn't either: the
+// installers are shared onceInstallers serialized by installMu, so ensureX is safe from inside a
+// t.Parallel() subtest, and the Flux scenario (runFluxSubtests, cmd/e2e_flux_test.go) is in the pool
+// on exactly that basis. Nor does depending on metrics, as long as the subtest is a consumer of them
+// rather than a threat to them. And how the objects come into being certainly doesn't, whatever the
+// "DynamicManifests" name suggests: the subtests below build objects in Go, apply static YAML from
+// tests/e2e-artifacts, and mutate objects the cluster already has, in no particular pattern.
+//
+// See #784, where the Flux scenario went from a standalone top-level test to a subtest here before
+// anyone checked it against the pool's criteria -- which it met.
+//
+// The other two entry points exist for reasons this one can't absorb: TestE2EParallel owns the
+// concurrent pool and the single e2eClients() setup its subtests share (see #719), and
+// TestE2EAgainstVanillaMinikube (cmd/e2e_vanilla_test.go) covers CLI error/usage paths that need no
+// cluster dependency at all. Don't add a fourth.
 func TestE2EDynamicManifests(t *testing.T) {
 	e2eMinikubeTest(t)
 	hackOpts, clientset, dynamicClient := e2eClients(t)

--- a/cmd/e2e_flux_test.go
+++ b/cmd/e2e_flux_test.go
@@ -9,89 +9,114 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/bergerx/kubectl-status/pkg/plugin"
 )
 
-// TestE2EFluxKustomizationInventory covers Kustomization.tmpl's live-query branches, which every
-// offline artifact under tests/artifacts/kustomization-* leaves untouched because --shallow/--local
-// make KubeGetFirst a no-op:
+// runFluxSubtests is one of TestE2EParallel's topical groups (cmd/main_test.go). It qualifies on
+// both of that function's criteria: the scenario below owns a namespace no other subtest touches
+// (e2e-flux-kustomization), and every object it asserts on is namespaced -- the only cluster-scoped
+// thing in play is the Flux install itself, which is a shared onceInstaller like the CRD bundles
+// the other groups pull in, not a fixed object name this test could collide on.
 //
-//   - default mode resolves each status.inventory entry into a per-kind health summary
-//     (managed_resource_line -> resource_health_summary),
-//   - --deep inlines each entry's full render instead,
-//   - an entry whose object is no longer in the cluster is flagged, and is *not* flagged under
-//     --shallow, where every lookup comes back empty for an unrelated reason.
-//
-// It also pins the one --deep behaviour that can't be reached offline: an inlined object naming the
-// Kustomization that owns it (via common.tmpl's flux_object_management) without recursing back into
-// it. The render engine has no cycle guard, so a deep_render_ref there would not terminate.
-//
-// Flux is installed and left to reconcile a real source rather than having its status written by
-// the test. Every field asserted on here -- the inventory, lastAppliedRevision, the
-// kustomize.toolkit.fluxcd.io ownership labels, the applied policy annotations -- is one only
-// kustomize-controller writes, so a hand-patched status would only ever confirm our own reading of
-// the Flux API, never Flux's behaviour, and would keep passing after Flux changed it.
-//
-// What that costs: the inventory is whatever the pinned source actually contains, which is three
-// namespaced objects. Inventory entry *id shapes* -- a cluster-scoped entry's empty namespace
-// segment, an id that doesn't split into four parts -- are covered offline instead, by
-// tests/artifacts/kustomization-reconcile-pending, where a hand-written status is the point rather
-// than a substitute for one.
-func TestE2EFluxKustomizationInventory(t *testing.T) {
-	e2eMinikubeTest(t)
-	hackOpts, clientset, _ := e2eClients(t)
-	opts := combineOpts(hackOpts, viperTestHackOpts())
-	ensureFlux(t)
+// Installing a real controller doesn't by itself make a scenario serial, and neither does depending
+// on metrics: the fixtures pin podinfo's HPA at its resting 2/2 against a 99%-of-request CPU target,
+// which is a function of podinfo being idle rather than of what else is on the cluster, and the
+// render's relative timestamps are frozen by ApplyTestHack's DurationRound rather than measured. The
+// one subtest that genuinely can't run here (VPA, in TestE2EDynamicManifests) is excluded because it
+// *pegs a CPU* and starves metrics-server for everyone else -- a cause, not a sensitivity. See #784:
+// this scenario was a standalone top-level test, then briefly serial, before either was checked
+// against the criteria above.
+func runFluxSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
+	// This covers Kustomization.tmpl's live-query branches, which every offline artifact under
+	// tests/artifacts/kustomization-* leaves untouched because --shallow/--local make KubeGetFirst
+	// a no-op:
+	//
+	//   - default mode resolves each status.inventory entry into a per-kind health summary
+	//     (managed_resource_line -> resource_health_summary),
+	//   - --deep inlines each entry's full render instead,
+	//   - an entry whose object is no longer in the cluster is flagged, and is *not* flagged under
+	//     --shallow, where every lookup comes back empty for an unrelated reason.
+	//
+	// It also pins the one --deep behaviour that can't be reached offline: an inlined object naming
+	// the Kustomization that owns it (via common.tmpl's flux_object_management) without recursing
+	// back into it. The render engine has no cycle guard, so a deep_render_ref there would not
+	// terminate.
+	//
+	// Flux is installed and left to reconcile a real source rather than having its status written by
+	// the test. Every field asserted on here -- the inventory, lastAppliedRevision, the
+	// kustomize.toolkit.fluxcd.io ownership labels, the applied policy annotations -- is one only
+	// kustomize-controller writes, so a hand-patched status would only ever confirm our own reading
+	// of the Flux API, never Flux's behaviour, and would keep passing after Flux changed it.
+	//
+	// What that costs: the inventory is whatever the pinned source actually contains, which is three
+	// namespaced objects. Inventory entry *id shapes* -- a cluster-scoped entry's empty namespace
+	// segment, an id that doesn't split into four parts -- are covered offline instead, by
+	// tests/artifacts/kustomization-reconcile-pending, where a hand-written status is the point
+	// rather than a substitute for one.
+	t.Run("Flux Kustomization resolves its inventory entries, inlines them under --deep, and flags a missing one", func(t *testing.T) {
+		t.Parallel()
+		// ensureFlux sits inside the subtest rather than at the top of the group, which is where the
+		// other topical groups put theirs: Flux is the suite's heaviest install (four controller
+		// Deployments, each a cold image pull), and at group level it would go in on any
+		// TestE2EParallel run whose -run pattern doesn't even reach this subtest. Safe to call from a
+		// t.Parallel() subtest because installMu (cmd/e2e_helpers_test.go) serializes every install
+		// against every other -- that mutex exists for exactly this call site.
+		ensureFlux(t)
+		opts := combineOpts(hackOpts, viperTestHackOpts())
 
-	ns := "e2e-flux-kustomization"
-	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		ns := "e2e-flux-kustomization"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		})
+
+		applyManifestInNamespace(t, "e2e-artifacts/flux-kustomization-inventory.yaml", ns)
+		// Ready on the Kustomization means the apply succeeded and the inventory has been written --
+		// with spec.wait false it says nothing about the applied objects' health, hence the second
+		// wait. The source clone and the podinfo image pull both happen inside this window.
+		waitForInNamespace(t, "gitrepository/podinfo", "condition=Ready", ns)
+		waitForInNamespace(t, "kustomization/podinfo", "condition=Ready", ns)
+		waitForInNamespace(t, "deployment/podinfo", "condition=Available", ns)
+		// The HPA is in the inventory too, and its render includes the scale target's current replica
+		// count -- which only settles once the HPA has computed a recommendation and stopped moving.
+		waitForFluxHPASettled(t, ns, "podinfo")
+
+		// Delete one applied object out-of-band. This is the state the "missing" marker reports: the
+		// inventory still records an apply that succeeded, the object is gone, and the Kustomization
+		// goes on reporting Ready because nothing re-checks it until spec.interval (60m) elapses.
+		// kubectl, not the clientset, so the deletion is ordered against the waits above the same way
+		// every other manifest change in this suite is.
+		out, err := exec.Command("kubectl", "delete", "service", "podinfo", "-n", ns, "--wait").CombinedOutput()
+		require.NoErrorf(t, err, "failed to delete the managed Service out-of-band: %s", out)
+		t.Logf("deleted managed Service podinfo in %s out-of-band: %s", ns, out)
+
+		cmdTest{
+			args:            []string{"kustomization/podinfo", "-n", ns, "--include-events=false", "--include-managed-fields=false"},
+			stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory.regex",
+		}.assert(t, nil, opts...)
+		// The node-usage/kubelet-summary/lease sections are switched off because --deep reaches them
+		// through the inlined Deployment's Pods, and they render host-specific numbers that would pin
+		// this fixture to one machine. What's left of that subtree is matched tolerantly by the
+		// fixture: Pod, Node and Service rendering belong to other subtests, and this one is about the
+		// inventory entries being inlined at all.
+		cmdTest{
+			args: []string{"kustomization/podinfo", "-n", ns, "--deep",
+				"--include-events=false", "--include-managed-fields=false",
+				"--include-node-detailed-usage=false", "--include-node-kubelet-api-summary=false",
+				"--include-node-lease=false", "--include-owners=false"},
+			stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory-deep.regex",
+		}.assert(t, nil, opts...)
+		// --shallow must list the same entries as bare refs and call none of them missing: there every
+		// lookup returns nothing because live queries are off, not because the object is gone.
+		cmdTest{
+			args:            []string{"kustomization/podinfo", "-n", ns, "--shallow"},
+			stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory-shallow.regex",
+		}.assert(t, nil, opts...)
 	})
-
-	applyManifestInNamespace(t, "e2e-artifacts/flux-kustomization-inventory.yaml", ns)
-	// Ready on the Kustomization means the apply succeeded and the inventory has been written --
-	// with spec.wait false it says nothing about the applied objects' health, hence the second wait.
-	// The source clone and the podinfo image pull both happen inside this window.
-	waitForInNamespace(t, "gitrepository/podinfo", "condition=Ready", ns)
-	waitForInNamespace(t, "kustomization/podinfo", "condition=Ready", ns)
-	waitForInNamespace(t, "deployment/podinfo", "condition=Available", ns)
-	// The HPA is in the inventory too, and its render includes the scale target's current replica
-	// count -- which only settles once the HPA has computed a recommendation and stopped moving.
-	waitForFluxHPASettled(t, ns, "podinfo")
-
-	// Delete one applied object out-of-band. This is the state the "missing" marker reports: the
-	// inventory still records an apply that succeeded, the object is gone, and the Kustomization
-	// goes on reporting Ready because nothing re-checks it until spec.interval (60m) elapses.
-	// kubectl, not the clientset, so the deletion is ordered against the waits above the same way
-	// every other manifest change in this suite is.
-	out, err := exec.Command("kubectl", "delete", "service", "podinfo", "-n", ns, "--wait").CombinedOutput()
-	require.NoErrorf(t, err, "failed to delete the managed Service out-of-band: %s", out)
-	t.Logf("deleted managed Service podinfo in %s out-of-band: %s", ns, out)
-
-	cmdTest{
-		args:            []string{"kustomization/podinfo", "-n", ns, "--include-events=false", "--include-managed-fields=false"},
-		stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory.regex",
-	}.assert(t, nil, opts...)
-	// The node-usage/kubelet-summary/lease sections are switched off because --deep reaches them
-	// through the inlined Deployment's Pods, and they render host-specific numbers that would pin
-	// this fixture to one machine. What's left of that subtree is matched tolerantly by the
-	// fixture: Pod, Node and Service rendering belong to other subtests, and this one is about the
-	// inventory entries being inlined at all.
-	cmdTest{
-		args: []string{"kustomization/podinfo", "-n", ns, "--deep",
-			"--include-events=false", "--include-managed-fields=false",
-			"--include-node-detailed-usage=false", "--include-node-kubelet-api-summary=false",
-			"--include-node-lease=false", "--include-owners=false"},
-		stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory-deep.regex",
-	}.assert(t, nil, opts...)
-	// --shallow must list the same entries as bare refs and call none of them missing: there every
-	// lookup returns nothing because live queries are off, not because the object is gone.
-	cmdTest{
-		args:            []string{"kustomization/podinfo", "-n", ns, "--shallow"},
-		stdoutRegexPath: "e2e-artifacts/flux-kustomization-inventory-shallow.regex",
-	}.assert(t, nil, opts...)
 }
 
 // waitForFluxHPASettled waits until the HorizontalPodAutoscaler that podinfo's kustomize/ ships has

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -727,15 +727,16 @@ type onceInstaller struct {
 
 // installMu serializes every install against every other one, across all onceInstallers. The
 // sync.Once above only keeps a single dependency from being installed twice; it says nothing about
-// two *different* ones overlapping. Today they can't -- no top-level TestE2E* calls t.Parallel(),
-// TestE2EDynamicManifests has no parallel subtests at all, and TestE2EParallel's group-level
-// ensureX calls all run in its own goroutine, which a parallel subtest can't resume ahead of (t.Run
-// parks such a subtest and only releases it once the parent function returns). But that's a
-// property of where the call sites happen to sit, not something the type enforces: an ensureX added
-// inside a t.Parallel() subtest would quietly start racing installs of unrelated dependencies
-// against each other. Serializing here costs nothing to be sure of -- a warm re-run of every
-// installer totals ~15s, and a cold one is exactly the case you want taking the cluster one
-// dependency at a time rather than several controller rollouts at once.
+// two *different* ones overlapping. Most call sites can't overlap on their own: a group-level
+// ensureX in TestE2EParallel runs in that function's own goroutine, which a parallel subtest can't
+// resume ahead of (t.Run parks such a subtest and only releases it once the parent function
+// returns), and TestE2EDynamicManifests has no parallel subtests at all. But that's a property of
+// where those call sites happen to sit, not something the type enforces, and ensureFlux is already
+// the exception: it's called from inside a t.Parallel() subtest (runFluxSubtests,
+// cmd/e2e_flux_test.go), where without this mutex it would race installs of unrelated dependencies
+// running concurrently in sibling subtests. Serializing here costs nothing to be sure of -- a warm
+// re-run of every installer totals ~15s, and a cold one is exactly the case you want taking the
+// cluster one dependency at a time rather than several controller rollouts at once.
 //
 // Held only around the install itself, never around require.NoError: install closures are t-free by
 // contract (see above), but keeping the assertion outside means even a stray require inside one
@@ -1016,7 +1017,7 @@ func ensureCrossplane(t *testing.T) {
 
 var fluxInstaller onceInstaller
 
-// ensureFlux installs Flux, needed by TestE2EFluxKustomizationInventory. Unlike the CRDs-only
+// ensureFlux installs Flux, needed by TestE2EParallel's Flux subtest. Unlike the CRDs-only
 // installs above, this one has to actually reconcile: what that test asserts on is
 // status.inventory, status.lastAppliedRevision and the kustomize.toolkit.fluxcd.io ownership
 // labels -- all of them written by kustomize-controller as it applies a real source, none of them

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -47,4 +47,5 @@ func TestE2EParallel(t *testing.T) {
 	runTLSValidationSubtests(t, hackOpts, clientset)
 	runPodVolumeSubtests(t, hackOpts, clientset)
 	runPodLogsAndMetricsSubtests(t, hackOpts, clientset)
+	runFluxSubtests(t, hackOpts, clientset)
 }

--- a/tests/e2e-artifacts/README.md
+++ b/tests/e2e-artifacts/README.md
@@ -3,7 +3,7 @@
 This file holds setup commands and sample manifests for third-party tools whose CRDs kubectl-status
 renders, kept here as reference material for whoever picks up live e2e coverage for them. See
 CONTRIBUTING.md's "Running e2e Tests Locally" section for how the two-tier test suite works and the
-recipe for adding a new `TestE2EDynamicManifests` subtest.
+recipe for adding a new live e2e subtest (and for choosing which entry point it runs under).
 
 None of the gaps below currently have an open GitHub issue — they're test-coverage gaps for
 templates that already render correctly under Tier 1 (static fixtures), just not yet exercised by
@@ -109,9 +109,10 @@ flux get helmreleases
 
 Both templates now exist (issue #660). `Kustomization.tmpl`'s live-query branches — resolving
 `status.inventory` entries into health summaries, inlining them under `--deep`, and flagging entries
-whose object is gone — are covered by `TestE2EFluxKustomizationInventory`. That test installs Flux
-and lets it reconcile `tests/e2e-artifacts/flux-kustomization-inventory.yaml`: a `GitRepository` on
-podinfo pinned to an immutable tag, and a `Kustomization` over it. Nothing in its `.status` is
+whose object is gone — are covered by the Flux subtest of `TestE2EParallel`
+(`runFluxSubtests`, cmd/e2e_flux_test.go). That subtest installs Flux and lets it reconcile
+`tests/e2e-artifacts/flux-kustomization-inventory.yaml`: a `GitRepository` on podinfo pinned to an
+immutable tag, and a `Kustomization` over it. Nothing in its `.status` is
 written by the test — the inventory, `lastAppliedRevision` and the `kustomize.toolkit.fluxcd.io`
 ownership labels on the applied objects are all kustomize-controller's, which is the only way an
 assertion about them tests Flux rather than our reading of it.

--- a/tests/e2e-artifacts/flux-kustomization-inventory.yaml
+++ b/tests/e2e-artifacts/flux-kustomization-inventory.yaml
@@ -1,4 +1,5 @@
-# A real Flux source and Kustomization for TestE2EFluxKustomizationInventory. Everything the test
+# A real Flux source and Kustomization for the Flux subtest of TestE2EParallel
+# (runFluxSubtests, cmd/e2e_flux_test.go). Everything the test
 # asserts on -- status.inventory, status.lastAppliedRevision, and the kustomize.toolkit.fluxcd.io
 # ownership labels on the applied objects -- is written by source-controller and
 # kustomize-controller as they reconcile this, so there is no status here to fabricate.
@@ -7,8 +8,7 @@
 # (applyManifestInNamespace). spec.targetNamespace is the exception and has to name the namespace
 # outright -- kustomize-controller does *not* fall back to the Kustomization's own namespace for
 # manifests that leave it unset (it fails the apply with "namespace not specified"), and podinfo's
-# manifests set no namespace. It must stay in step with the `ns` constant in
-# TestE2EFluxKustomizationInventory.
+# manifests set no namespace. It must stay in step with the `ns` constant in that subtest.
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository


### PR DESCRIPTION
Closes #784.

`TestE2EFluxKustomizationInventory` was a fourth top-level e2e entry point with no recorded reason for standing alone — not in the file's doc comment, not in ea1a53c or b1b414f, not in CONTRIBUTING.

#784 proposed folding it into `TestE2EDynamicManifests`, on the grounds that it was structurally identical to the Crossplane subtest already living there. That's true, but it skips a question nobody had asked: **does it need to be serial at all?** It doesn't. It meets both of `TestE2EParallel`'s admission criteria — it owns a namespace no other subtest touches (`e2e-flux-kustomization`, verified unique across all 40 in the suite), and every object it asserts on is namespaced. So it lands in the pool as `runFluxSubtests` rather than in the serial entry point.

### Three things that look disqualifying but aren't

- **Installing a real controller.** The `ensureX` installers are shared `onceInstaller`s serialized by `installMu`, which exists precisely so an install is safe from inside a `t.Parallel()` subtest. `ensureFlux` is the first caller to actually rely on that, so `installMu`'s comment — which asserted no such call site existed — is updated rather than left to go stale.
- **Depending on metrics.** The fixtures pin podinfo's HPA at its resting `2/2` against a 99%-of-request CPU target, a function of podinfo being idle rather than of cluster load. The one subtest that genuinely can't be parallel (VPA) is excluded because it *pegs a full CPU and starves metrics-server for everyone else* — a cause, not a sensitivity.
- **Relative timestamps in the fixtures.** `ApplyTestHack` freezes `DurationRound`, so `created 1m ago` is a constant, not elapsed time.

`ensureFlux` stays inside the `t.Run` rather than at group level, where the other groups put theirs: it's the heaviest install in the suite, and at group level it would go in on any `TestE2EParallel` run whose `-run` pattern doesn't even reach the subtest.

### Recording the rule

#784 asked that whichever entry point hosts the scenario say *why*, so the next one has a rule instead of a precedent. Both places it was missing now do:

- `TestE2EDynamicManifests`' doc comment states it's the exception rather than the default, lists the three reasons that actually qualify (perturbs shared state / starves a shared dependency / can't own a namespace), and names the non-reasons above.
- CONTRIBUTING states the preference outright — new subtests go in the pool unless they trip a criterion, with the reason written on the subtest — and drops the now-wrong "four top-level entry points".

### Verification

Against the shared minikube cluster:

- `make test-e2e-quick RUN='TestE2EParallel'` — **72 tests, 0 failures, 4m49s** at `-parallel=4`.
- `make test-e2e-quick RUN='TestE2EParallel/Flux'` — `DONE 2 tests`, confirming the scenario is reachable and passing under its new entry point.
- `make test` (vet + staticcheck + unit) — clean.

An earlier pool run showed 4 failures in the rollouts group; those were stale `e2e-rollouts-*` namespaces left on the shared cluster by runs killed on 2026-07-29/30, failing at 0.00s before the subtests did anything. Cleared with the recovery command in CONTRIBUTING; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)