### PR TITLE
Fix e2e flakiness exposed by running the Flux subtest in the parallel pool

### DIFF
--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -431,9 +431,16 @@ func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
 // waitForInNamespace targets a namespace explicitly via `kubectl -n` instead of the kubeconfig's
 // default -- pairs with applyManifestInNamespace for subtests moved off the shared default
 // namespace.
+//
+// The timeout has margin above what any single wait needs on an idle cluster: TestE2EParallel's
+// pool shares one minikube VM across -parallel subtests, and runFluxSubtests' ensureFlux install
+// is the heaviest of them, so a controller (e.g. the PDB/disruption controller another subtest is
+// waiting on) can legitimately take longer to reconcile while it's running. A 4m budget measured
+// this timing out at ~248s on a loaded CI runner; 8m keeps a real hang catchable well inside the
+// job's -timeout=25m without the wait racing pool contention it doesn't control.
 func waitForInNamespace(t *testing.T, resource, forParam, namespace string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "wait", "-n", namespace, "--for", forParam, resource, "--timeout=4m")
+	cmd := exec.Command("kubectl", "wait", "-n", namespace, "--for", forParam, resource, "--timeout=8m")
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s in namespace %s: %s", resource, namespace, string(output))
 	require.NoError(t, err)

--- a/tests/e2e-artifacts/flux-kustomization-inventory-deep.regex
+++ b/tests/e2e-artifacts/flux-kustomization-inventory-deep.regex
@@ -30,8 +30,7 @@ Kustomization/podinfo -n e2e-flux-kustomization, created 1m ago, gen:1
           ScalingLimited:True TooFewReplicas, the desired replica count is less than the minimum replica count for 1m
           Applied by Flux Kustomization/podinfo
           Flux apply policy Merge: fields added by other tools are preserved rather than reverted
-      Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
-      Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m
+      (?:Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n      Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m|Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m\n      Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
     HorizontalPodAutoscaler/podinfo\[e2e-flux-kustomization\] is already printed
   Ready covers the apply only: without wait or healthChecks, unhealthy managed resources leave it Ready
   Reconciles every 60m


### PR DESCRIPTION
## Summary
- Master's `ci-test` failed twice in a row right after #786 merged (both retry attempts): `pdb-empty-selector-conflict` timed out at ~248s against a 4m `kubectl wait` budget, and the Flux subtest's `--deep` assertion failed because `Deployment/podinfo`'s `Available`/`Progressing` conditions printed in the opposite order from the fixture. The same commit had passed CI on its own PR branch, so this is timing-dependent, not a deterministic break.
- `ensureFlux` is the suite's heaviest install; now that it runs inside `TestE2EParallel`'s `-parallel=4` pool, other subtests sharing the single-node CI minikube can see slower controller reconciles while it's installing/reconciling.
- Condition ordering was already latent — kubectl-status renders `status.conditions` in API order, which the Deployment controller doesn't guarantee is stable — Flux's own added load just made it likely enough to actually show up. `flux-kustomization-inventory-deep.regex` now accepts either order, the same way it already tolerates the analogous `AbleToScale` race a few lines above.
- `waitForInNamespace`'s timeout goes from 4m to 8m so a wait that's slowed by a neighbour's contention doesn't fail a few seconds short, matching the margin the job's `-timeout=25m` was already given for the same reason.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass locally
- [x] Compiled the updated `.regex` fixture and confirmed it matches stdout with both condition orderings
- [ ] CI (`ci-test`, includes the live e2e suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)