### PR TITLE
Stable-sort status.conditions by type instead of trusting API order

### DIFF
--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -118,9 +118,13 @@ func (r RenderableObject) Namespace() string {
 	return r.GetNamespace()
 }
 
+// StatusConditions returns status.conditions sorted by type, ascending. Controllers don't
+// guarantee a stable order for this list (see #787, where a Deployment's Available/Progressing
+// conditions flipped order between runs), so every caller gets a deterministic order here rather
+// than each render site having to tolerate either ordering on its own.
 func (r RenderableObject) StatusConditions() (conditions []interface{}) {
 	if x := r.Status()["conditions"]; x != nil {
-		conditions = x.([]interface{})
+		conditions = sortMapListByKeysValue("type", x.([]interface{}))
 	}
 	return
 }

--- a/pkg/plugin/templates/BackendTLSPolicy.tmpl
+++ b/pkg/plugin/templates/BackendTLSPolicy.tmpl
@@ -39,7 +39,7 @@
         {{- range . }}
             {{- $.Include "resource_ref" (dict "kind" (.ancestorRef.kind | default "Gateway") "name" .ancestorRef.name "namespace" .ancestorRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
             {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/GRPCRoute.tmpl
@@ -99,7 +99,7 @@
             {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
             {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
             {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/Gateway.tmpl
+++ b/pkg/plugin/templates/Gateway.tmpl
@@ -62,7 +62,7 @@
                     {{- end }}
                 {{- end }}
             {{- end }}
-            {{- range $statusListener.conditions }}
+            {{- range $statusListener.conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/HTTPRoute.tmpl
@@ -92,7 +92,7 @@
             {{- with $statusEntry.controllerName }}
                 {{- "controller" | nindent 6 }}: {{ . | cyan }}
             {{- end }}
-            {{- range $statusEntry.conditions }}
+            {{- range $statusEntry.conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/ListenerSet.tmpl
+++ b/pkg/plugin/templates/ListenerSet.tmpl
@@ -37,7 +37,7 @@
                     {{- end }}
                 {{- end }}
             {{- end }}
-            {{- range $statusListener.conditions }}
+            {{- range $statusListener.conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -651,7 +651,7 @@
     {{- else }}
         {{- $.Include "pod_condition_arrow_label" (dict "condition" $readyCondition "label" "Ready") }}
     {{- end }}
-    {{- range .Status.conditions }}
+    {{- range .StatusConditions }}
         {{- /* show details for only unhealthy conditions */ -}}
         {{- if (not (isStatusConditionHealthy .)) }}
             {{- $.Include "condition_summary" . | nindent 2}}

--- a/pkg/plugin/templates/TCPRoute.tmpl
+++ b/pkg/plugin/templates/TCPRoute.tmpl
@@ -35,7 +35,7 @@
             {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
             {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
             {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/TLSRoute.tmpl
+++ b/pkg/plugin/templates/TLSRoute.tmpl
@@ -89,7 +89,7 @@
             {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
             {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
             {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/UDPRoute.tmpl
+++ b/pkg/plugin/templates/UDPRoute.tmpl
@@ -35,7 +35,7 @@
             {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
             {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
             {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -194,7 +194,7 @@ func TestPodNodeProblemFlags(t *testing.T) {
 			name:       "everything the node itself reports is grouped behind one node prefix",
 			spec:       `"unschedulable":true`,
 			conditions: `{"type":"Ready","status":"False"},{"type":"","status":"False"},{"type":"MemoryPressure","status":"True"}`,
-			want:       "node cordoned & Ready:False & MemoryPressure:True",
+			want:       "node cordoned & MemoryPressure:True & Ready:False",
 		},
 	}
 	for _, tt := range tests {

--- a/tests/artifacts/crd-certificate.out
+++ b/tests/artifacts/crd-certificate.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/certificates.cert-manager.io, created 1m ago, gen:1
   Current: CRD is established
   cert-manager.io, scope: Namespaced, short: cert, certs, categories: cert-manager
   Versions: v1 [storage]
-  NamesAccepted:True NoConflicts, no conflicts found for 1m
   Established:True InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m

--- a/tests/artifacts/crd-dbconn.out
+++ b/tests/artifacts/crd-dbconn.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/databaseconnections.example.com, created 1m ago, gen:2
   Current: CRD is established
   example.com, scope: Namespaced, short: dbconn
   Versions: v1alpha1 [storage]
-  NamesAccepted:True NoConflicts, no conflicts found for 1m
   Established:True InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m

--- a/tests/artifacts/crd-prometheus.out
+++ b/tests/artifacts/crd-prometheus.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/prometheuses.monitoring.coreos.com, created 1m ago, gen
   Current: CRD is established
   monitoring.coreos.com, scope: Namespaced, short: prom, categories: prometheus-operator
   Versions: v1 [storage]
-  NamesAccepted:True NoConflicts, no conflicts found for 1m
   Established:True InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m

--- a/tests/artifacts/crd-servicemonitor.out
+++ b/tests/artifacts/crd-servicemonitor.out
@@ -3,5 +3,5 @@ CustomResourceDefinition/servicemonitors.monitoring.coreos.com, created 1m ago, 
   Current: CRD is established
   monitoring.coreos.com, scope: Namespaced, short: smon, categories: prometheus-operator
   Versions: v1 [storage]
-  NamesAccepted:True NoConflicts, no conflicts found for 1m
   Established:True InitialNamesAccepted, the initial names have been accepted for 1m
+  NamesAccepted:True NoConflicts, no conflicts found for 1m

--- a/tests/artifacts/crossplane-managed-resource-details.out
+++ b/tests/artifacts/crossplane-managed-resource-details.out
@@ -8,5 +8,5 @@ Bucket/checkout-bucket, created 1m ago, gen:1
   ProviderConfig/aws-provider
   Management policies: Observe, LateInitialize
   initProvider: tags (applied only at creation time)
-  Synced:True ReconcileSuccess for 1m
   Ready:True Available for 1m
+  Synced:True ReconcileSuccess for 1m

--- a/tests/artifacts/crossplane-managed-resource-drift.out
+++ b/tests/artifacts/crossplane-managed-resource-drift.out
@@ -11,5 +11,5 @@ VPC/checkout-network, created 1m ago, gen:2
     -  environment: production
     +  environment: staging
   Management policies: * (full control)
-  Synced:True ReconcileSuccess for 1m
   Ready:True Available for 1m
+  Synced:True ReconcileSuccess for 1m

--- a/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
+++ b/tests/artifacts/crossplane-xr-composed-cluster-scoped.out
@@ -6,6 +6,6 @@ XStatusProbe/probe-a, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config
-  Synced:True ReconcileSuccess for 1m
   Ready:False Creating, Unready resources: blocked-workload, config for 1m
   Responsive:True WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m

--- a/tests/artifacts/crossplane-xr-composed.out
+++ b/tests/artifacts/crossplane-xr-composed.out
@@ -6,6 +6,6 @@ XStatusProbe/probe-a -n crossplane-e2e, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked
     ConfigMap/probe-a-config
-  Synced:True ReconcileSuccess for 1m
   Ready:False Creating, Unready resources: blocked-workload, config for 1m
   Responsive:True WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m

--- a/tests/artifacts/deployment-unavailable-replicas.out
+++ b/tests/artifacts/deployment-unavailable-replicas.out
@@ -4,7 +4,7 @@ Deployment/httpbin-deployment -n test1, created 1m ago, gen:1 rev:1
     Reconciling: LessReplicas, Replicas: 0/3
   desired:3, ready:0, updated:0, available:0, unavailable:3
   Selector: run=httpbin-deployment
-  Progressing:True NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
   Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability. for 1m
+  Progressing:True NewReplicaSetCreated, Created new replica set "httpbin-deployment-79f6dfbb9" for 1m
   Ongoing Rollout: Waiting for deployment "httpbin-deployment" rollout to finish: 0 out of 3 new replicas have been updated...
   Outage: Deployment has no Ready replicas.

--- a/tests/artifacts/gateway-not-programmed.out
+++ b/tests/artifacts/gateway-not-programmed.out
@@ -6,6 +6,6 @@ Gateway/eg -n default, created 1m ago, gen:1
   Programmed:False AddressNotAssigned, No addresses have been assigned to the Gateway for 1m
   Listeners:
     http: port=80/HTTP, namespaces=Same, accepts=HTTPRoute/GRPCRoute, routes=1
-      Programmed:True Programmed, Sending translated listener configuration to the data plane for 1m
       Accepted:True Accepted, Listener has been successfully translated for 1m
+      Programmed:True Programmed, Sending translated listener configuration to the data plane for 1m
       ResolvedRefs:True ResolvedRefs, Listener references have been resolved for 1m

--- a/tests/artifacts/job-fail-exit1.out
+++ b/tests/artifacts/job-fail-exit1.out
@@ -2,5 +2,5 @@
 Job/job-fail-exit1 -n default, created 1m ago, gen:1, started at 2026-06-29T02:31:34Z (1m ago), Failed: 2/1
   Failed: Job Failed. failed: 2/1
     Stalled: JobFailed, Job Failed. failed: 2/1
-  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
   Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-failed.out
+++ b/tests/artifacts/job-failed.out
@@ -2,5 +2,5 @@
 Job/job-failed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:23Z (1m ago), Failed: 3/2
   Failed: Job Failed. failed: 3/1
     Stalled: JobFailed, Job Failed. failed: 3/1
-  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
   Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-from-cronjob-failed.out
+++ b/tests/artifacts/job-from-cronjob-failed.out
@@ -2,5 +2,5 @@
 Job/cronjob-failing-29711681 -n default, created 1m ago by CronJob/cronjob-failing, gen:1, started at 2026-06-29T02:41:00Z (1m ago), Failed: 1
   Failed: Job Failed. failed: 1/1
     Stalled: JobFailed, Job Failed. failed: 1/1
-  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
   Failed:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m
+  FailureTarget:True BackoffLimitExceeded, Job has reached the specified backoff limit for 1m

--- a/tests/artifacts/job-indexed-complete.out
+++ b/tests/artifacts/job-indexed-complete.out
@@ -2,5 +2,5 @@
 Job/job-indexed -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:52Z (1m ago) and completed in 1m, Succeeded
   Indexed: 5/5 (0-4)
   Current: Job Completed. succeeded: 5/5
-  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
   Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-indexed-partial-failure.out
+++ b/tests/artifacts/job-indexed-partial-failure.out
@@ -4,5 +4,5 @@ Job/job-indexed-backoff -n default, created 1m ago, gen:1, started at 2026-06-29
   Failed indexes: 0,2,4 (limit: 1 per index)
   Failed: Job Failed. failed: 6/6
     Stalled: JobFailed, Job Failed. failed: 6/6
-  FailureTarget:True FailedIndexes, Job has failed indexes for 1m
   Failed:True FailedIndexes, Job has failed indexes for 1m
+  FailureTarget:True FailedIndexes, Job has failed indexes for 1m

--- a/tests/artifacts/job-simple-complete.out
+++ b/tests/artifacts/job-simple-complete.out
@@ -1,5 +1,5 @@
 
 Job/job-simple -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:22Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
-  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
   Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/job-with-sidecar-complete.out
+++ b/tests/artifacts/job-with-sidecar-complete.out
@@ -1,5 +1,5 @@
 
 Job/job-with-sidecar -n default, created 1m ago, gen:1, started at 2026-06-29T01:27:55Z (1m ago) and completed in 1m, Succeeded
   Current: Job Completed. succeeded: 1/1
-  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m
   Complete:True CompletionsReached, Reached expected number of succeeded pods for 1m
+  SuccessCriteriaMet:True CompletionsReached, Reached expected number of succeeded pods for 1m

--- a/tests/artifacts/node-aks.out
+++ b/tests/artifacts/node-aks.out
@@ -5,8 +5,8 @@ Node/aks-cpuworkers-41776494-vmss00006u, created 1m ago
     providerID: azure:///subscriptions/f198f0d7-73af-486e-ad9c-f17f5c3f6664/resourceGroups/mc_cluster-nimbus_cluster-nimbus_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-cpuworkers-41776494-vmss/virtualMachines/246
   images 50 volumes inuse=1/16, attached=1
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status. AppArmor enabled for 1m
   addresses: Hostname=aks-cpuworkers-41776494-vmss00006u InternalIP=10.250.4.65

--- a/tests/artifacts/node-and-service.out
+++ b/tests/artifacts/node-and-service.out
@@ -3,8 +3,8 @@ Node/minikube, created 1m ago
   linux Ubuntu 22.04.4 LTS (amd64), kernel 6.6.41-1-MANJARO, kubelet v1.30.0, kube-proxy v1.30.0, docker://26.1.1
   images 8
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.49.2 Hostname=minikube

--- a/tests/artifacts/node-eks.out
+++ b/tests/artifacts/node-eks.out
@@ -4,8 +4,8 @@ Node/ip-10-0-1-23.ec2.internal, created 1m ago
   cloudprovider AWS us-east-1/us-east-1a m5.large
     providerID: aws:///us-east-1a/i-0123456789abcdef0
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=10.0.1.23 Hostname=ip-10-0-1-23.ec2.internal

--- a/tests/artifacts/node-empty-condition.out
+++ b/tests/artifacts/node-empty-condition.out
@@ -3,8 +3,8 @@ Node/node-with-empty-condition, created 1m ago
   linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.102 Hostname=minikube

--- a/tests/artifacts/node-minikube-with-metrics.out
+++ b/tests/artifacts/node-minikube-with-metrics.out
@@ -3,8 +3,8 @@ Node/minikube, created 1m ago
   linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.105 Hostname=minikube

--- a/tests/artifacts/node-minikube.out
+++ b/tests/artifacts/node-minikube.out
@@ -3,8 +3,8 @@ Node/minikube, created 1m ago
   linux Buildroot 2019.02.9 (amd64), kernel 4.19.94, kubelet v1.17.3, kube-proxy v1.17.3, docker://19.3.6
   images 13
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=192.168.99.102 Hostname=minikube

--- a/tests/artifacts/nodeclaim-healthy.out
+++ b/tests/artifacts/nodeclaim-healthy.out
@@ -4,7 +4,7 @@ NodeClaim/default-abcde, created 1m ago by NodePool/default, gen:1
   NodeClass: EC2NodeClass/default
   Capacity: m5.large (spot) in us-east-1a
   Node: Node/ip-10-0-1-23.ec2.internal
-  Launched:True Launched for 1m
-  Registered:True Registered for 1m
   Initialized:True Initialized for 1m
+  Launched:True Launched for 1m
   Ready:True Ready for 1m
+  Registered:True Registered for 1m

--- a/tests/artifacts/nodeclaim-launch-failed.out
+++ b/tests/artifacts/nodeclaim-launch-failed.out
@@ -4,7 +4,7 @@ NodeClaim/default-fghij, created 1m ago by NodePool/default, gen:1
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default
   Capacity: (spot)
-  Launched:False LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
-  Registered:Unknown AwaitingLaunch for 1m
   Initialized:Unknown AwaitingRegistration for 1m
+  Launched:False LaunchFailed, InsufficientInstanceCapacity: We currently do not have sufficient m5.large capacity in the Availability Zone you requested for 1m
   Ready:False NodeClaimNotInitialized, NodeClaim is not initialized for 1m
+  Registered:Unknown AwaitingLaunch for 1m

--- a/tests/artifacts/nodeclaim-registration-failed.out
+++ b/tests/artifacts/nodeclaim-registration-failed.out
@@ -4,7 +4,7 @@ NodeClaim/default-klmno, created 1m ago by NodePool/default, gen:1
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default
   Capacity: m5.large (on-demand) in us-east-1b
-  Launched:True Launched for 1m
-  Registered:False NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m
   Initialized:Unknown AwaitingRegistration for 1m
+  Launched:True Launched for 1m
   Ready:False NodeClaimNotInitialized, NodeClaim is not initialized for 1m
+  Registered:False NodeNotFound, node object not found for provider ID aws:///us-east-1b/i-0fedcba9876543210 after 15m0s for 1m

--- a/tests/artifacts/nodepool-healthy.out
+++ b/tests/artifacts/nodepool-healthy.out
@@ -14,6 +14,6 @@ NodePool/default, created 1m ago, gen:3
     cpu: 48/1000
     memory: 206.1GB/1TB
     pods: 220/unlimited
-  Ready:True Ready for 1m
   NodeClassReady:True NodeClassReady for 1m
+  Ready:True Ready for 1m
   ValidationSucceeded:True ValidationSucceeded for 1m

--- a/tests/artifacts/pod-deleted-due-to-missing-container.out
+++ b/tests/artifacts/pod-deleted-due-to-missing-container.out
@@ -2,7 +2,7 @@
 Pod/prometheus-operator-5c5784bc5f-4h65z -n prometheus, created 1m ago by ReplicaSet/prometheus-operator-5c5784bc5f, started after 1m Failed Evicted BestEffort, message: The node was low on resource: ephemeral-storage. Container kube-prometheus-stack was using 19212Ki, which exceeds its request of 0.
   Current: Pod has completed, but not successfully
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False PodFailed for 1m
     ContainersReady:False PodFailed for 1m
+    Ready:False PodFailed for 1m
   Containers: kube-prometheus-stack (quay.io/prometheus-operator/prometheus-operator:v0.58.0) Terminated as ContainerStatusUnknown with "The container could not be located when the pod was terminated" exit with 137 (SIGKILL), restarted 1 times
   previously: Terminated as ContainerStatusUnknown with "The container could not be located when the pod was deleted.  The container used to be Running" exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-imagepullbackoff-never-policy.out
+++ b/tests/artifacts/pod-imagepullbackoff-never-policy.out
@@ -3,7 +3,7 @@ Pod/backoff-never-policy -n test1, created 1m ago, started after 1m Pending Best
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [main] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
   Standalone POD.
   Containers: main (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"

--- a/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
+++ b/tests/artifacts/pod-imagepullbackoff-with-valid-secret.out
@@ -3,8 +3,8 @@ Pod/backoff-with-valid-secret -n test1, created 1m ago, started after 1m Pending
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [main] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [main] for 1m
   Standalone POD.
   Containers: main (private-registry.example.com/some/image:latest) Waiting ImagePullBackOff: Back-off pulling image "private-registry.example.com/some/image:latest"
 

--- a/tests/artifacts/pod-job-completed.out
+++ b/tests/artifacts/pod-job-completed.out
@@ -2,6 +2,6 @@
 Pod/hello-1584492660-d2c6p -n default, created 1m ago by Job/hello-1584492660, started after 1m Succeeded BestEffort
   Current: Pod has completed successfully
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False PodCompleted for 1m
     ContainersReady:False PodCompleted for 1m
+    Ready:False PodCompleted for 1m
   Containers: hello (busybox:latest) Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-liveness-kill-137.out
+++ b/tests/artifacts/pod-liveness-kill-137.out
@@ -3,8 +3,8 @@ Pod/pod-liveness-kill-137 -n default, created 1m ago, gen:1, started after 1m Ru
   Failed: Containers in CrashLoop state: app
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: app
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (busybox:1.36) Waiting CrashLoopBackOff: back-off 20s restarting failed container=app pod=pod-liveness-kill-137_default(d2bf2b74-5f4b-45e4-b391-5b8cd9d253eb), restarted 3 times
   previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-marked-for-deletion-completed.out
+++ b/tests/artifacts/pod-marked-for-deletion-completed.out
@@ -2,6 +2,6 @@
 Pod/hello-1584492660-d2c6p -n default, created 1m ago by Job/hello-1584492660, started after 1m Succeeded BestEffort
   Terminating: Resource scheduled for deletion
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False PodCompleted for 1m
     ContainersReady:False PodCompleted for 1m
+    Ready:False PodCompleted for 1m
   Containers: hello (busybox:latest) Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-non-existing-image.out
+++ b/tests/artifacts/pod-non-existing-image.out
@@ -3,7 +3,7 @@ Pod/missing-image-755c8c54f7-26v4c -n test1, created 1m ago by ReplicaSet/missin
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [missing-image] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [missing-image] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [missing-image] for 1m
   Containers: missing-image (this-image-doesnt-exist) Waiting ImagePullBackOff: Back-off pulling image "this-image-doesnt-exist"
   (no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)

--- a/tests/artifacts/pod-pending-waiting-container.out
+++ b/tests/artifacts/pod-pending-waiting-container.out
@@ -3,6 +3,6 @@ Pod/hello-1584492840-kqf62 -n default, created 1m ago by Job/hello-1584492840, s
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [hello] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [hello] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [hello] for 1m
   Containers: hello (busybox) Waiting ContainerCreating

--- a/tests/artifacts/pod-poststart-hook-error.out
+++ b/tests/artifacts/pod-poststart-hook-error.out
@@ -3,8 +3,8 @@ Pod/pod-poststart-hook-error -n default, created 1m ago, gen:1, started after 1m
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (busybox:1.36) Waiting PostStartHookError: Exec lifecycle hook ([/bin/sh -c exit 1]) for Container "app" in Pod "pod-poststart-hook-error_default(9af6a317-3023-4f5d-b537-68ca9118a791)" failed - error: command '/bin/sh -c exit 1' exited with 1: , message: ""
   previously: Started 1m ago and Error after 1m with exit code exit with 137 (SIGKILL)

--- a/tests/artifacts/pod-probe-liveness-restarting.out
+++ b/tests/artifacts/pod-probe-liveness-restarting.out
@@ -3,8 +3,8 @@ Pod/probe-liveness-restarting -n default, created 1m ago, gen:1, started after 1
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready, restarted 1 times
   previously: Started 1m ago and Completed after 1m

--- a/tests/artifacts/pod-probe-readiness-failing.out
+++ b/tests/artifacts/pod-probe-readiness-failing.out
@@ -3,8 +3,8 @@ Pod/probe-readiness-failing -n default, created 1m ago, gen:1, started after 1m 
   InProgress: Pod is running but is not Ready
     Reconciling: PodRunningNotReady, Pod is running but is not Ready
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: [app] for 1m
+    Ready:False ContainersNotReady, containers with unready status: [app] for 1m
   Standalone POD.
   Containers: app (registry.k8s.io/pause:3.9) Running for 1m but Not Ready
   readinessProbe: httpGet HTTP://localhost:8080/ready (delay 1s, every 5s, timeout 1s, fail after 3x)

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -51,14 +51,14 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                   Composed resources:
                     Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
                     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
-                  Synced:True ReconcileSuccess for 1m
                   Ready:False Creating, Unready resources: blocked-workload, config for 1m
                   Responsive:True WatchCircuitClosed for 1m
-          Synced:True ReconcileSuccess for 1m
+                  Synced:True ReconcileSuccess for 1m
           Ready:False Creating, Unready resources: blocked-workload, config for 1m
           Responsive:True WatchCircuitClosed for 1m
+          Synced:True ReconcileSuccess for 1m
     ConfigMap/probe-a-config\[e2e-crossplane-xr\] is already printed
-  Synced:True ReconcileSuccess for 1m
   Ready:False Creating, Unready resources: blocked-workload, config for 1m
   Responsive:True WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
 \z

--- a/tests/e2e-artifacts/crossplane-xr.regex
+++ b/tests/e2e-artifacts/crossplane-xr.regex
@@ -6,7 +6,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
   Composed resources:
     Deployment/probe-a-blocked, created 1m ago, 0/1 ready, rolling out
     ConfigMap/probe-a-config, created 1m ago, Current: Resource is always ready
-  Synced:True ReconcileSuccess for 1m
   Ready:False Creating, Unready resources: blocked-workload, config for 1m
   Responsive:True WatchCircuitClosed for 1m
+  Synced:True ReconcileSuccess for 1m
 \z

--- a/tests/e2e-artifacts/flux-kustomization-inventory-deep.regex
+++ b/tests/e2e-artifacts/flux-kustomization-inventory-deep.regex
@@ -4,8 +4,8 @@ Kustomization/podinfo -n e2e-flux-kustomization, created 1m ago, gen:1
   Applies \./kustomize from GitRepository/podinfo into namespace e2e-flux-kustomization
     GitRepository/podinfo -n e2e-flux-kustomization, created 1m ago, gen:1
       Current: Resource is Ready
-      Ready:True Succeeded, stored artifact for revision '6\.9\.2@sha1:[0-9a-f]+' for 1m
       ArtifactInStorage:True Succeeded, stored artifact for revision '6\.9\.2@sha1:[0-9a-f]+' for 1m
+      Ready:True Succeeded, stored artifact for revision '6\.9\.2@sha1:[0-9a-f]+' for 1m
   Applied revision 6\.9\.2@[0-9a-f]+
   Manages 3 resources: Deployment×1, HorizontalPodAutoscaler×1, Service×1
     Service/podinfo missing: no such object in the cluster
@@ -30,7 +30,8 @@ Kustomization/podinfo -n e2e-flux-kustomization, created 1m ago, gen:1
           ScalingLimited:True TooFewReplicas, the desired replica count is less than the minimum replica count for 1m
           Applied by Flux Kustomization/podinfo
           Flux apply policy Merge: fields added by other tools are preserved rather than reverted
-      (?:Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n      Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m|Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m\n      Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
+      Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+      Progressing:True NewReplicaSetAvailable, ReplicaSet "podinfo-[0-9a-z]+" has successfully progressed\. for 1m
     HorizontalPodAutoscaler/podinfo\[e2e-flux-kustomization\] is already printed
   Ready covers the apply only: without wait or healthChecks, unhealthy managed resources leave it Ready
   Reconciles every 60m

--- a/tests/e2e-artifacts/node-metrics-multi-namespace.regex
+++ b/tests/e2e-artifacts/node-metrics-multi-namespace.regex
@@ -4,8 +4,8 @@ Node/[a-z0-9.-]+, created \d+[a-z]+ ago
   images \d+
   Current: Resource is Ready
   kubelet ok(?:, \S+:\S+)*, container logs: retains up to [\d.]+[A-Za-z]+ per container \(\S+ x \d+ files\)
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for \d+[a-z]+
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for \d+[a-z]+
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for \d+[a-z]+
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for \d+[a-z]+
   Ready:True KubeletReady, kubelet is posting ready status for \d+[a-z]+
   addresses: InternalIP=[\d.]+ Hostname=[a-z0-9.-]+

--- a/tests/e2e-artifacts/node-query.regex
+++ b/tests/e2e-artifacts/node-query.regex
@@ -3,8 +3,8 @@ Node/[a-z0-9-]+, created 1m ago
   linux [^\n]+ \(amd64\), kernel [^\n,]+, kubelet v[0-9][^\n,]*(?:, kube-proxy v[0-9][^\n,]*)?, [a-z]+://[0-9][^\n,]*
   images [0-9]+
   Current: Resource is Ready
-  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   DiskPressure:False KubeletHasNoDiskPressure, kubelet has no disk pressure for 1m
+  MemoryPressure:False KubeletHasSufficientMemory, kubelet has sufficient memory available for 1m
   PIDPressure:False KubeletHasSufficientPID, kubelet has sufficient PID available for 1m
   Ready:True KubeletReady, kubelet is posting ready status for 1m
   addresses: InternalIP=[0-9.]+ Hostname=[a-z0-9-]+

--- a/tests/e2e-artifacts/pod-container-logs.regex
+++ b/tests/e2e-artifacts/pod-container-logs.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-container-logs -n e2e-pod-container-logs, created 1m ago, gen:1, sta
   Failed: Containers in CrashLoop state: crasher
     Stalled: ContainerCrashLooping, Containers in CrashLoop state: crasher
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: \[crasher\] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: \[crasher\] for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[crasher\] for 1m
   Standalone POD\.
   InitContainers:
     init-setup \(busybox:latest\) Started 1m ago and Completed after 1m

--- a/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-healthy.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-healthy-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, g
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
 \z

--- a/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-missing-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, g
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*

--- a/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
@@ -3,8 +3,8 @@ Pod/e2e-pod-wrong-type-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
-    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
     ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
+    Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD.
   Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*

--- a/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node-for-rs.regex
@@ -3,7 +3,7 @@ ReplicaSet/bad-rs -n e2e-bad-node-rs, created 1m ago, gen:1
   InProgress: Available: 0/1
     Reconciling: LessAvailable, Available: 0/1
   Selector: app=kubectl-status-test-bad-rs
-    Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned & Ready:False & MemoryPressure:True, untolerated node taint
+    Pod/pod-on-bad-node-for-rs, created 1m ago Pending, node cordoned & MemoryPressure:True & Ready:False, untolerated node taint
   Not matched by any Service
   Outage: ReplicaSet has no Ready replicas\.
 \z

--- a/tests/e2e-artifacts/pod-on-bad-node.regex
+++ b/tests/e2e-artifacts/pod-on-bad-node.regex
@@ -4,8 +4,8 @@ Pod/pod-on-bad-node -n e2e-bad-node-pod, created 1m ago, gen:1 Pending BestEffor
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:Unknown -> Initialized:Unknown -> ContainersReady:Unknown -> Ready:Unknown
   Node/kubectl-status-test-bad-node-[a-z0-9]+ cordoned \(unschedulable\)
-    Ready:False KubeletNotReady, kubelet is not ready for 1m
     MemoryPressure:True KubeletHasInsufficientMemory, kubelet has insufficient memory available for 1m
+    Ready:False KubeletNotReady, kubelet is not ready for 1m
     taint dedicated=gpu:NoSchedule \(not tolerated\)
     taint node\.kubernetes\.io/unschedulable:NoSchedule \(not tolerated\)
 (?:    taint node\.kubernetes\.io/memory-pressure:NoSchedule \(not tolerated\)

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-configmap.regex
@@ -3,9 +3,9 @@ Pod/e2e-pod-volume-missing-configmap -n e2e-pod-volume-configmap-secret, created
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
     PodReadyToStartContainers:False for 1m
     Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: cfg \(ConfigMap/e2e-cm-does-not-exist\) doesn't exist

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-key.regex
@@ -3,9 +3,9 @@ Pod/e2e-pod-volume-missing-key -n e2e-pod-volume-configmap-secret, created 1m ag
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
     PodReadyToStartContainers:False for 1m
     Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: cfg \(ConfigMap/e2e-cm-with-data\) missing key "missing-key"

--- a/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
+++ b/tests/e2e-artifacts/pod-volume-configmap-secret-missing-secret.regex
@@ -3,9 +3,9 @@ Pod/e2e-pod-volume-missing-secret -n e2e-pod-volume-configmap-secret, created 1m
   InProgress: Pod is in the Pending phase
     Reconciling: PodPending, Pod is in the Pending phase
   PodScheduled:True -> Initialized:True -> ContainersReady:False -> Ready:False
+    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
     PodReadyToStartContainers:False for 1m
     Ready:False ContainersNotReady, containers with unready status: \[main\] for 1m
-    ContainersReady:False ContainersNotReady, containers with unready status: \[main\] for 1m
   Standalone POD\.
   Containers: main \(registry\.k8s\.io/pause:3\.9\) Waiting ContainerCreating
   Volumes: sec \(Secret/e2e-secret-does-not-exist\) doesn't exist

--- a/tests/e2e-artifacts/quota-headroom-blocked-deployment.regex
+++ b/tests/e2e-artifacts/quota-headroom-blocked-deployment.regex
@@ -8,8 +8,8 @@ Deployment/e2e-quota-headroom -n e2e-quota-headroom, created 1m ago, gen:1 rev:1
     Pod/e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
   Not matched by any Service
   Available:False MinimumReplicasUnavailable, Deployment does not have minimum availability\. for 1m
-  ReplicaFailure:True FailedCreate, pods "e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+" is forbidden: exceeded quota: compute, requested: requests\.memory=256Mi, used: requests\.memory=512Mi, limited: requests\.memory=512Mi for 1m
   Progressing:True ReplicaSetUpdated, ReplicaSet "e2e-quota-headroom-[a-z0-9]+" is progressing\. for 1m
+  ReplicaFailure:True FailedCreate, pods "e2e-quota-headroom-[a-z0-9]+-[a-z0-9]+" is forbidden: exceeded quota: compute, requested: requests\.memory=256Mi, used: requests\.memory=512Mi, limited: requests\.memory=512Mi for 1m
   Ongoing Rollout: Waiting for deployment "e2e-quota-headroom" rollout to finish: 2 out of 3 new replicas have been updated\.\.\.
   Quota Headroom: ResourceQuota/compute doesn't have room for the 2 more Pods a rollout needs to create:
     requests\.memory: needs 512Mi, only 0 free \(used 512Mi of 512Mi\)

--- a/tests/e2e-artifacts/vpa-workload-reverse-match.regex
+++ b/tests/e2e-artifacts/vpa-workload-reverse-match.regex
@@ -6,5 +6,6 @@ Deployment/vpa-burner -n e2e-vpa, created 1m ago, gen:1 rev:1
     Pod/vpa-burner-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
   Not matched by any Service
   VerticalPodAutoscaler: VerticalPodAutoscaler/vpa-burner, Recreate, burner: cpu=\d+m mem=\d+Mi
-  (?:Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m\n  Progressing:True NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m|Progressing:True NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m\n  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m)
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "vpa-burner-[a-z0-9]+" has successfully progressed\. for 1m
 \z


### PR DESCRIPTION
## Summary
- #787 found that kubectl-status renders `status.conditions` in whatever order the API returns them, which controllers don't guarantee is stable -- a Deployment's `Available`/`Progressing` conditions flipped order between CI runs. The fix at the time made `flux-kustomization-inventory-deep.regex` tolerate either order rather than fixing the underlying non-determinism.
- `RenderableObject.StatusConditions()` now sorts by `type` ascending, so every template gets a deterministic order regardless of what the controller returns.
- Eight route/gateway templates (`Gateway`, `HTTPRoute`, `GRPCRoute`, `TLSRoute`, `TCPRoute`, `UDPRoute`, `BackendTLSPolicy`, `ListenerSet`) ranged over raw nested `conditions` arrays (per-listener/per-parentRef status) instead of going through that method -- piped those through the same `sortMapListByKeysValue "type"` helper. `Pod.tmpl`'s `pod_conditions_summary` bypassed the method entirely via `range .Status.conditions`; switched it to `.StatusConditions`.
- Regenerated the offline golden `.out` fixtures and updated the live e2e `.regex` fixtures for the new deterministic order. Replaced the alternation #787 added to `flux-kustomization-inventory-deep.regex`, plus an identical one already latent in `vpa-workload-reverse-match.regex`, with plain static text now that ordering no longer needs tolerating.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass locally
- [x] `make update-artifacts` regenerated all affected offline `.out` fixtures; diffs reviewed line by line
- [x] Live e2e against the shared minikube cluster: `TestE2EParallel` (72 subtests) passes clean
- [x] Live e2e: `TestE2EDynamicManifests` passes (Crossplane XR); the VPA subtest hits a pre-existing `kubectl wait --for=condition=Available` timeout unrelated to this change (reproduces identically before and after, and fails before the regex assertion runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)