### PR TITLE
Wait for namespace deletion in e2e subtest cleanup

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -119,10 +119,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-vpa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		name := "vpa-burner"
 		one := int32(1)
@@ -210,10 +208,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-crossplane-xr"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		applyManifest(t, "e2e-artifacts/crossplane-xstatusprobe.yaml")
 		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Established",
@@ -261,10 +257,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-storageclass"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
 		require.NoError(t, err)
@@ -356,10 +350,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-rwop"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		// No storageClassName -- picks up the cluster's default class (Immediate binding), so
 		// the claim binds to a real PV before any Pod exists.
@@ -445,10 +437,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-rwop-conflict"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		const nodeName = "e2e-rwop-conflict-no-such-node"
 
@@ -512,10 +502,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-volumeattachment"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		require.NoError(t, err)
@@ -591,10 +579,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-volumesnapshot"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		// Source PVC the snapshot is (nominally) taken from.
 		sourcePVCName := "e2e-vs-source-pvc"
@@ -726,10 +712,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-pv-zone"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		pvName := "e2e-pv-zone-restricted"
 		_, err = clientset.CoreV1().PersistentVolumes().Create(context.TODO(), &corev1.PersistentVolume{
@@ -823,10 +807,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-pv-zone-wfc"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
 		require.NoError(t, err)
@@ -916,10 +898,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-karpenter-pod"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		// This NodePool only declares a zone requirement -- it says nothing about the custom
 		// label the first Pod below hard-requires (so every NodePool disqualifies on that key),
@@ -1008,10 +988,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		ns := "e2e-helm-release"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		configMapName := "e2e-helm-release-config"
 		_, err = clientset.CoreV1().ConfigMaps(ns).Create(context.TODO(), &corev1.ConfigMap{

--- a/cmd/e2e_flux_test.go
+++ b/cmd/e2e_flux_test.go
@@ -69,10 +69,8 @@ func runFluxSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), client
 		ns := "e2e-flux-kustomization"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		applyManifestInNamespace(t, "e2e-artifacts/flux-kustomization-inventory.yaml", ns)
 		// Ready on the Kustomization means the apply succeeded and the inventory has been written --

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -385,6 +386,30 @@ func waitForCrossplaneComposedRefs(t *testing.T, namespace, name string, wantCou
 		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("timed out waiting for xstatusprobe %s in namespace %s to have %d composed resource refs", name, namespace, wantCount)
+}
+
+// deleteNamespaceAndWait deletes a namespace and waits for it to be fully gone, instead of firing
+// the delete and moving on -- a fixed namespace name reused on the next run would otherwise race a
+// namespace this run left Terminating. Runs from t.Cleanup, so a slow or failed teardown only logs
+// a warning: it must not fail the test whose cleanup is calling it, and it must not stop other
+// subtests' cleanup from running.
+func deleteNamespaceAndWait(t *testing.T, clientset *kubernetes.Clientset, namespace string) {
+	t.Helper()
+	err := clientset.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("warning: failed to delete namespace %s: %v", namespace, err)
+		return
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Logf("namespace %s fully deleted", namespace)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("warning: namespace %s still terminating after 2m, leaving it be", namespace)
 }
 
 func applyManifest(t *testing.T, filepath string) {

--- a/cmd/e2e_istio_test.go
+++ b/cmd/e2e_istio_test.go
@@ -37,10 +37,8 @@ func runIstioSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clien
 		ns := "e2e-istio-routing"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		// A StatefulSet rather than a Deployment so the Pod the --deep render inlines has a
 		// predictable name, the same reason the service-routing scenarios use one.
 		applyManifestInNamespace(t, "e2e-artifacts/istio-routing.yaml", ns)

--- a/cmd/e2e_logs_metrics_test.go
+++ b/cmd/e2e_logs_metrics_test.go
@@ -34,10 +34,8 @@ func runPodLogsAndMetricsSubtests(t *testing.T, hackOpts []func(*plugin.RenderCo
 		ns := "e2e-pod-container-logs"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/pod-container-logs.yaml", ns)
 		// The fixture pins a usage line for both healthy containers -- wait for metrics-server to
 		// have scraped each of them specifically, not just the Pod overall: a container that
@@ -93,10 +91,8 @@ func runPodLogsAndMetricsSubtests(t *testing.T, hackOpts []func(*plugin.RenderCo
 		for _, ns := range []string{"e2e-node-metrics-a", "e2e-node-metrics-b"} {
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "e2e-metrics-pod", Namespace: ns},
 				Spec: corev1.PodSpec{

--- a/cmd/e2e_misc_fixture_test.go
+++ b/cmd/e2e_misc_fixture_test.go
@@ -23,10 +23,8 @@ func runMiscFixtureSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig),
 		ns := "e2e-vap-binding"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifest(t, "e2e-artifacts/vap-binding.yaml")
 		cmdTest{
 			args:            []string{"validatingadmissionpolicybinding/e2e-require-team-label-binding", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
@@ -66,10 +64,8 @@ func runMiscFixtureSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig),
 		ns := "e2e-web-cert"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/web-cert.yaml", ns)
 		waitForInNamespace(t, "certificate/web-ca", "condition=Ready", ns)
 		waitForInNamespace(t, "certificate/web-tls", "condition=Ready", ns)
@@ -90,10 +86,8 @@ func runMiscFixtureSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig),
 		ns := "e2e-web-policies"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/web.yaml", ns)
 		applyManifestInNamespace(t, "e2e-artifacts/web-policies.yaml", ns)
 		waitForInNamespace(t, "deployment/web", "condition=Available", ns)
@@ -109,10 +103,8 @@ func runMiscFixtureSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig),
 		ns := "e2e-sts-without-service"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/sts-without-service.yaml", ns)
 		waitForInNamespace(t, "sts/sts-without-service", "jsonpath={.status.readyReplicas}=1", ns)
 		cmdTest{

--- a/cmd/e2e_networkpolicy_test.go
+++ b/cmd/e2e_networkpolicy_test.go
@@ -29,10 +29,8 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-netpol-pod"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -84,10 +82,8 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-netpol-multi-pod"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		podLabels := map[string]string{"app": "kubectl-status-test-netpol-multi-target"}
 		pod := &corev1.Pod{
@@ -159,10 +155,8 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-cni-policy-pod"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		appLabel := "kubectl-status-test-cni-policy-target"
 		pod := &corev1.Pod{

--- a/cmd/e2e_owners_test.go
+++ b/cmd/e2e_owners_test.go
@@ -19,10 +19,8 @@ func runOwnersSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clie
 		ns := "e2e-owner-secret"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		owner := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/cmd/e2e_pod_scheduling_test.go
+++ b/cmd/e2e_pod_scheduling_test.go
@@ -24,10 +24,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-bad-node-pod"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		nodeName := createBadNode(t, clientset)
 
@@ -73,10 +71,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-pod-custom-sa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		f := false
 		sa := &corev1.ServiceAccount{
@@ -134,10 +130,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-pod-missing-sa"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{Name: "will-be-deleted", Namespace: ns},
@@ -183,10 +177,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-pod-runtimeclass-overhead"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		rc := &nodev1.RuntimeClass{
 			ObjectMeta: metav1.ObjectMeta{Name: "e2e-test-gvisor"},
@@ -228,10 +220,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-pod-priorityclass"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		// A minikube cluster has no globalDefault PriorityClass out of the box, so setting it here
 		// is safe: it won't clash with any other PriorityClass in the (parallel) test pool.
@@ -272,10 +262,8 @@ func runPodSchedulingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-bad-node-rs"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		nodeName := createBadNode(t, clientset)
 

--- a/cmd/e2e_pod_volume_test.go
+++ b/cmd/e2e_pod_volume_test.go
@@ -23,10 +23,8 @@ func runPodVolumeSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), c
 		ns := "e2e-pod-image-pull-secrets"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/pod-image-pull-secrets.yaml", ns)
 
 		// The kubelet keeps cycling a failing pull between ErrImagePull and ImagePullBackOff on
@@ -65,10 +63,8 @@ func runPodVolumeSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), c
 		ns := "e2e-pod-volume-configmap-secret"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/pod-volume-configmap-secret.yaml", ns)
 		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-volume-missing-configmap", "main", "ContainerCreating", ns)
 		waitForContainerWaitingReasonInNamespace(t, "pod/e2e-pod-volume-missing-secret", "main", "ContainerCreating", ns)

--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -23,10 +23,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 		ns := "e2e-rollout-diff"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		name := "rollout-diff-test"
 		one := int32(1)
@@ -80,10 +78,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-blocked-deployment"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-blocked-deployment"
 			one := int32(1)
 			dep := &appsv1.Deployment{
@@ -113,10 +109,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-blocked-statefulset"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-blocked-statefulset"
 			one := int32(1)
 			sts := &appsv1.StatefulSet{
@@ -151,10 +145,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-statefulset-rollback-trap"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-statefulset-rollback-trap"
 			one := int32(1)
 			goodImage := "nginx:1.27"
@@ -214,10 +206,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-blocked-daemonset"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-blocked-daemonset"
 			ds := &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
@@ -245,10 +235,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-healthy-deployment"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-healthy-deployment"
 			one := int32(1)
 			dep := &appsv1.Deployment{
@@ -280,10 +268,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			ns := "e2e-rollouts-three-revisions"
 			_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+			t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-			})
 			name := "e2e-rollouts-three-revisions"
 			applyManifestInNamespace(t, "e2e-artifacts/rollouts-three-revisions.yaml", ns)
 			waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
@@ -319,10 +305,8 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 		ns := "e2e-quota-headroom"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 
 		_, err = clientset.CoreV1().ResourceQuotas(ns).Create(context.TODO(), &corev1.ResourceQuota{
 			ObjectMeta: metav1.ObjectMeta{Name: "compute", Namespace: ns},

--- a/cmd/e2e_service_routing_test.go
+++ b/cmd/e2e_service_routing_test.go
@@ -20,10 +20,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-sts-with-ingress"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		// using sts here as the pod name is predictable in that case, not true for deployments and ds
 		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress.yaml", ns)
 		waitForInNamespace(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1", ns)
@@ -51,10 +49,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-sts-with-ingress-routes"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress.yaml", ns)
 		applyManifestInNamespace(t, "e2e-artifacts/sts-with-ingress-routes.yaml", ns)
 		waitForInNamespace(t, "sts/sts-with-ingress", "jsonpath={.status.readyReplicas}=1", ns)
@@ -73,10 +69,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-svc-httproute"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/svc-with-httproute.yaml", ns)
 		cmdTest{
 			args:            []string{"service/svc-with-httproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
@@ -93,10 +87,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-sts-nodeport"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		// using sts here as the pod name is predictable in that case, not true for deployments and ds
 		applyManifestInNamespace(t, "e2e-artifacts/sts-with-nodeport.yaml", ns)
 		waitForInNamespace(t, "sts/sts-with-nodeport", "jsonpath={.status.readyReplicas}=1", ns)
@@ -122,10 +114,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-pdb-conflict"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/pdb-empty-selector-conflict.yaml", ns)
 		waitForInNamespace(t, "sts/pdb-conflict-test", "jsonpath={.status.readyReplicas}=1", ns)
 		// Kubernetes' disruption controller picks one of the two overlapping PDBs arbitrarily
@@ -152,10 +142,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-tcproute"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/tcproute-with-gateway.yaml", ns)
 		cmdTest{
 			args:            []string{"tcproute/e2e-tcproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
@@ -172,10 +160,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-udproute"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/udproute-with-gateway.yaml", ns)
 		cmdTest{
 			args:            []string{"udproute/e2e-udproute", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
@@ -192,10 +178,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-listenerset"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/listenerset-with-gateway.yaml", ns)
 		cmdTest{
 			args:            []string{"listenerset/e2e-listenerset", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
@@ -212,10 +196,8 @@ func runServiceRoutingSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfi
 		ns := "e2e-backendtlspolicy"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/backendtlspolicy-with-target.yaml", ns)
 		cmdTest{
 			args:            []string{"backendtlspolicy/e2e-backendtlspolicy", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},

--- a/cmd/e2e_tls_validation_test.go
+++ b/cmd/e2e_tls_validation_test.go
@@ -24,10 +24,8 @@ func copyLeafSecretToNamespace(t *testing.T, clientset *kubernetes.Clientset, sr
 	t.Helper()
 	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dstNS}}, metav1.CreateOptions{})
+	t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, dstNS) })
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		clientset.CoreV1().Namespaces().Delete(context.TODO(), dstNS, metav1.DeleteOptions{})
-	})
 	src, err := clientset.CoreV1().Secrets(srcNS).Get(context.TODO(), "e2e-tls-leaf-tls", metav1.GetOptions{})
 	require.NoError(t, err)
 	_, err = clientset.CoreV1().Secrets(dstNS).Create(context.TODO(), &corev1.Secret{
@@ -53,10 +51,8 @@ func runTLSValidationSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 		ns := "e2e-tls-validation"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
 		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-		})
 		applyManifestInNamespace(t, "e2e-artifacts/tls-validation-ca.yaml", ns)
 		waitForInNamespace(t, "certificate/e2e-tls-root-ca", "condition=Ready", ns)
 		waitForInNamespace(t, "issuer/e2e-tls-ca-issuer", "condition=Ready", ns)


### PR DESCRIPTION
## Summary
- Each e2e subtest creates a fixed-name scratch namespace and used to delete it fire-and-forget in `t.Cleanup` — the `Delete` call returned before the namespace actually finished terminating, so a fast rerun could collide with a still-Terminating namespace from the previous run.
- Cleanup registration also used to happen *after* the `require.NoError(t, err)` check on `Create`, so a subtest that failed to create its namespace (e.g. a stale one left over from an earlier interrupted run) never attempted cleanup at all.
- Added `deleteNamespaceAndWait` (`cmd/e2e_helpers_test.go`) which deletes the namespace and polls until it's actually gone (up to 2m), logging a warning rather than failing the test on error/timeout — it runs from `t.Cleanup`, so it must not abort other subtests' cleanup over one slow teardown. All ~50 call sites across `cmd/e2e_*.go` now register this cleanup before checking the `Create` error.

## Test plan
- [x] `go build ./...`, `go vet ./cmd/...`, `gofmt -l` all clean
- [x] `make test-e2e` run locally against a live minikube cluster: 203/205 subtests pass. The one failure (`TestE2EDynamicManifests/VerticalPodAutoscaler_reverse-matches_its_target_workload_and_shows_an_applied_recommendation`) is a pre-existing flake unrelated to this change — reproduced identically with this diff stashed out, against `master`, on the same cluster. It's a `kubectl wait --for=condition=Available` timeout after the VPA recreates the burner pod at a 500m CPU recommendation, most likely a resource-constrained-sandbox issue rather than a real bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)