### PR TITLE
Migrate get template calls off deprecated sprig-compat signature (#688)

### DIFF
--- a/pkg/plugin/templates/Kustomization.tmpl
+++ b/pkg/plugin/templates/Kustomization.tmpl
@@ -52,12 +52,12 @@
             {{- /* An id that doesn't split into four is bucketed rather than counted under its own
                    text, which would otherwise put the whole malformed id in the kind summary. */ -}}
             {{- $kind := ternary (last $parts) "unparsable" (eq (len $parts) 4) }}
-            {{- $_ := set $countsByKind $kind (add1 (int (get $countsByKind $kind))) }}
+            {{- $_ := set $countsByKind $kind (add1 (int ($countsByKind | get $kind))) }}
             {{- $ids = append $ids (.id | default "" | toString) }}
         {{- end }}
         {{- $kindSummaries := list }}
         {{- range $kind := keys $countsByKind | sortAlpha }}
-            {{- $kindSummaries = append $kindSummaries (printf "%s×%d" $kind (int (get $countsByKind $kind))) }}
+            {{- $kindSummaries = append $kindSummaries (printf "%s×%d" $kind (int ($countsByKind | get $kind))) }}
         {{- end }}
         {{- "Manages" | bold | nindent 2 }} {{ len $entries | toString | cyan }} resources: {{ join ", " $kindSummaries | cyan }}
         {{- /* Sorted by id so the list is stable across reconciliations -- the controller writes

--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -30,7 +30,7 @@
                 {{- end }}
                 {{- if not (hasKey $volStats "usedBytes") }}
                     {{- $volName := .name }}
-                    {{- $nodeSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
+                    {{- $nodeSummary := $pod.KubeGetNodeStatsSummary ($pod.Spec | get "nodeName") }}
                     {{- $podStat := dict }}
                     {{- if $nodeSummary }}
                         {{- $podStat = $nodeSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -262,7 +262,7 @@
 {{- define "pod_init_containers" }}
     {{- /* Expects a dict "pod" (Pod RenderableObject) "podPullSecretsBroken" (bool) */ -}}
     {{- $pod := .pod }}
-    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
+    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary ($pod.Spec | get "nodeName") }}
     {{- $podStatsSummary := dict }}
     {{- if $nodeStatsSummary }}
         {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}
@@ -282,7 +282,7 @@
     {{- $pod := .pod }}
     {{- $defaultLogsContainer := index $pod.Annotations "kubectl.kubernetes.io/default-logs-container" }}
     {{- $defaultContainer := index $pod.Annotations "kubectl.kubernetes.io/default-container" }}
-    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
+    {{- $nodeStatsSummary := $pod.KubeGetNodeStatsSummary ($pod.Spec | get "nodeName") }}
     {{- $podStatsSummary := dict }}
     {{- if $nodeStatsSummary }}
         {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}
@@ -494,7 +494,7 @@
 
 {{- define "pod_volumes" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- $nodeStatsSummary := $.KubeGetNodeStatsSummary (get $.Spec "nodeName") }}
+    {{- $nodeStatsSummary := $.KubeGetNodeStatsSummary ($.Spec | get "nodeName") }}
     {{- $podStatsSummary := dict }}
     {{- if $nodeStatsSummary }}
         {{- $podStatsSummary = $nodeStatsSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $.Metadata.uid) }}
@@ -880,7 +880,7 @@
                 {{- "postStart:" | yellow | nindent 2 }} {{ template "lifecycle_hook_summary" . }}
             {{- end }}
         {{- end }}
-        {{- if and (or (eq .reason "ImagePullBackOff") (eq .reason "ErrImagePull")) (ne (get ($.containerSpec | default dict) "imagePullPolicy") "Never") }}
+        {{- if and (or (eq .reason "ImagePullBackOff") (eq .reason "ErrImagePull")) (ne (($.containerSpec | default dict) | get "imagePullPolicy") "Never") }}
             {{- if not $.podImagePullSecrets }}
                 {{- "(no imagePullSecrets on this Pod — if this image is on a private registry not covered by node-level credentials, that's likely why)" | yellow | nindent 2 }}
             {{- else if $.podPullSecretsBroken }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -103,7 +103,7 @@
                 {{- $pod := . }}
                 {{- range $pod.Spec.volumes | default list }}
                     {{- if eq .name $tmplName }}
-                        {{- $nodeSummary := $pod.KubeGetNodeStatsSummary (get $pod.Spec "nodeName") }}
+                        {{- $nodeSummary := $pod.KubeGetNodeStatsSummary ($pod.Spec | get "nodeName") }}
                         {{- $podStat := dict }}
                         {{- if $nodeSummary }}
                             {{- $podStat = $nodeSummary.pods | default list | getMatchingItemInMapList (dict "podRef.uid" $pod.Metadata.uid) }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -582,14 +582,14 @@
     {{- $forProvider := .Spec.forProvider }}
     {{- if and (kindIs "map" $forProvider) $forProvider }}
         {{- $annotations := .Annotations }}
-        {{- with get $annotations "crossplane.io/external-name" }}
+        {{- with $annotations | get "crossplane.io/external-name" }}
             {{- "External name" | bold | nindent 2 }}: {{ . | cyan }}
         {{- end }}
-        {{- with get $annotations "crossplane.io/composition-resource-name" }}
+        {{- with $annotations | get "crossplane.io/composition-resource-name" }}
             {{- "Composition resource name" | bold | nindent 2 }}: {{ . | cyan }}
         {{- end }}
-        {{- $pending := get $annotations "crossplane.io/external-create-pending" }}
-        {{- $succeeded := get $annotations "crossplane.io/external-create-succeeded" }}
+        {{- $pending := $annotations | get "crossplane.io/external-create-pending" }}
+        {{- $succeeded := $annotations | get "crossplane.io/external-create-succeeded" }}
         {{- if $pending }}
             {{- if not $succeeded }}
                 {{- "External create" | red | bold | nindent 2 }}: pending since {{ $pending | colorAgo }}{{ agoSuffix }}, {{ "external-create-succeeded not set yet" | yellow }}
@@ -635,21 +635,21 @@
     {{- if .Config.GetBool "include-application-details" }}
         {{- $labels := .Labels }}
         {{- $annotations := .Annotations }}
-        {{- $clusterService := get $labels "kubernetes.io/cluster-service" }}
-        {{- $addonManager := get $labels "addonmanager.kubernetes.io/mode" }}
-        {{- $managedBy := coalesce (get $labels "app.kubernetes.io/managed-by") $labels.heritage }}
-        {{- $createdBy := get $labels "app.kubernetes.io/created-by" }}
-        {{- $name := coalesce (get $labels "helm.sh/chart") $labels.chart (get $labels "app.kubernetes.io/name") $labels.app (get $labels "k8s-app") (get $labels "kubernetes.io/name") $labels.ame | default "" }}
-        {{- $partOf := get $labels "app.kubernetes.io/part-of" }}
-        {{- $component := get $labels "app.kubernetes.io/component" }}
-        {{- $instance := coalesce (get $annotations "meta.helm.sh/release-name") $labels.release (get $labels "app.kubernetes.io/instance") }}
-        {{- $releaseNamespace := get $annotations "meta.helm.sh/release-namespace" }}
+        {{- $clusterService := $labels | get "kubernetes.io/cluster-service" }}
+        {{- $addonManager := $labels | get "addonmanager.kubernetes.io/mode" }}
+        {{- $managedBy := coalesce ($labels | get "app.kubernetes.io/managed-by") $labels.heritage }}
+        {{- $createdBy := $labels | get "app.kubernetes.io/created-by" }}
+        {{- $name := coalesce ($labels | get "helm.sh/chart") $labels.chart ($labels | get "app.kubernetes.io/name") $labels.app ($labels | get "k8s-app") ($labels | get "kubernetes.io/name") $labels.ame | default "" }}
+        {{- $partOf := $labels | get "app.kubernetes.io/part-of" }}
+        {{- $component := $labels | get "app.kubernetes.io/component" }}
+        {{- $instance := coalesce ($annotations | get "meta.helm.sh/release-name") $labels.release ($labels | get "app.kubernetes.io/instance") }}
+        {{- $releaseNamespace := $annotations | get "meta.helm.sh/release-namespace" }}
         {{- $namespace := eq $releaseNamespace .Namespace | ternary "" $releaseNamespace }}
         {{- /* Helm's own release-storage Secret (type helm.sh/release.v1) carries a "version"
                label too, but there it's the release revision number, not an app version -- the
                dedicated Helm section in Secret.tmpl already reports the revision explicitly, so
                falling back to it here would print a misleading "using version 1" line. */ -}}
-        {{- $version := coalesce (get $labels "app.kubernetes.io/version") (ternary "" $labels.version (eq .Object.type "helm.sh/release.v1")) }}
+        {{- $version := coalesce ($labels | get "app.kubernetes.io/version") (ternary "" $labels.version (eq .Object.type "helm.sh/release.v1")) }}
         {{- if or $clusterService $addonManager $managedBy $createdBy $name $partOf $component $instance $namespace $version }}
             {{- "Managed" | nindent 2 }}
             {{- with $addonManager }} by {{ "AddonManager" | bold | yellow }} in {{ . | redBoldIf (eq . "Reconcile") }} mode{{ end }}
@@ -1467,9 +1467,9 @@
     {{- /* The ownership pair is read from labels alone: kustomize-controller writes it there
            (fluxcd/pkg/ssa/manager.go GetOwnerLabels) and matches on labels alone when deciding
            what to garbage collect, so an annotation of the same name owns nothing. */ -}}
-    {{- $owner := get (.Labels | default dict) "kustomize.toolkit.fluxcd.io/name" | default "" | toString }}
+    {{- $owner := (.Labels | default dict) | get "kustomize.toolkit.fluxcd.io/name" | default "" | toString }}
     {{- with $owner }}
-        {{- $ownerNamespace := get ($.Labels | default dict) "kustomize.toolkit.fluxcd.io/namespace" | default "" | toString }}
+        {{- $ownerNamespace := ($.Labels | default dict) | get "kustomize.toolkit.fluxcd.io/namespace" | default "" | toString }}
         {{- /* Not paired with deep_render_ref, unlike every other ref in the Flux templates: a
                Kustomization deep-renders its own healthChecks, each of which would then deep-render
                the Kustomization that owns it. The render engine has no cycle or depth guard, so
@@ -1479,10 +1479,10 @@
     {{- /* reconcile:disabled and ssa:Ignore both drop the object out of apply *and* prune, so it
            keeps whatever state it has however far the source moves on -- and its Kustomization
            still reports Ready, because skipping is a success. */ -}}
-    {{- if eq (get $meta "kustomize.toolkit.fluxcd.io/reconcile" | default "" | toString | lower) "disabled" }}
+    {{- if eq ($meta | get "kustomize.toolkit.fluxcd.io/reconcile" | default "" | toString | lower) "disabled" }}
         {{- "Flux reconcile disabled" | yellow | bold | nindent 2 }}: neither applied nor pruned by its Kustomization, however far the source moves on
     {{- end }}
-    {{- $ssa := get $meta "kustomize.toolkit.fluxcd.io/ssa" | default "" | toString | lower }}
+    {{- $ssa := $meta | get "kustomize.toolkit.fluxcd.io/ssa" | default "" | toString | lower }}
     {{- if eq $ssa "ignore" }}
         {{- "Flux apply policy Ignore" | yellow | bold | nindent 2 }}: never applied and never pruned, even while it is still in the source
     {{- else if eq $ssa "merge" }}
@@ -1492,17 +1492,17 @@
     {{- end }}
     {{- /* Usually set on a Namespace, PVC or PV to protect it from an accidental prune, and just as
            usually forgotten -- after which deleting it from the source silently leaves it running. */ -}}
-    {{- if eq (get $meta "kustomize.toolkit.fluxcd.io/prune" | default "" | toString | lower) "disabled" }}
+    {{- if eq ($meta | get "kustomize.toolkit.fluxcd.io/prune" | default "" | toString | lower) "disabled" }}
         {{- "Flux prune disabled" | yellow | bold | nindent 2 }}: kept running in the cluster after it is removed from the source
     {{- end }}
     {{- /* Meant to be removed once the immutable change is through; left on a StatefulSet it turns
            an ordinary field change into a delete and recreate. */ -}}
-    {{- if eq (get $meta "kustomize.toolkit.fluxcd.io/force" | default "" | toString | lower) "enabled" }}
+    {{- if eq ($meta | get "kustomize.toolkit.fluxcd.io/force" | default "" | toString | lower) "enabled" }}
         {{- "Flux force enabled" | yellow | bold | nindent 2 }}: deleted and recreated when a patch hits an immutable field
     {{- end }}
     {{- /* Only bites on a HelmRelease that turned drift detection on; there it is the reason one
            object in the release keeps its out-of-band edits while the rest lose theirs. */ -}}
-    {{- if eq (get $meta "helm.toolkit.fluxcd.io/driftDetection" | default "" | toString | lower) "disabled" }}
+    {{- if eq ($meta | get "helm.toolkit.fluxcd.io/driftDetection" | default "" | toString | lower) "disabled" }}
         {{- "Flux drift detection disabled" | bold | nindent 2 }}: out-of-band changes to this object are not reverted
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
Part of #688 this PR covers only the `get` function migration
Per the 5-small-PRs approach you suggested in the issue.

This PR covers only the `get` function migration.
This is PR 1 of 5:
1. get ✓
2. hasKey
3. append
4. set
5. float64 → toFloat64

## Change

Converted all genuine old-order `get $dict "key"` calls to the new
sprout pipe order `$dict | get "key"`. Pure argument-order swap, no
logic changes.

21 genuine call sites converted across 5 files:
- PersistentVolumeClaim.tmpl - 1
- StatefulSet.tmpl - 1
- Kustomization.tmpl - 2
- Pod.tmpl - 4
- common.tmpl - 13

## Verification

- `go build ./...`
- `make test`
- Manually confirmed via `-v 3` that the `function=get notice=deprecated`
  warning no longer fires for any of the converted call sites, by
  temporarily disabling the deprecation filter in render_engine.go
  and reverting afterward. Other not-yet-migrated functions (hasKey,
  set, append, etc.) still fire as expected, since they're out of
  scope for this PR.