### PR TITLE
Tighten e2e regex fixtures to pin deterministic field values

### DIFF
--- a/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-missing.regex
@@ -8,5 +8,5 @@ Pod/e2e-pod-missing-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago, g
   Standalone POD.
   Secret/e2e-pull-secret-does-not-exist doesn't exist, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
-  \(this Pod's imagePullSecrets have problems, see above .* that's likely why\)
+  \(this Pod's imagePullSecrets have problems, see above — that's likely why\)
 \z

--- a/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
+++ b/tests/e2e-artifacts/pod-image-pull-secrets-wrong-type.regex
@@ -8,5 +8,5 @@ Pod/e2e-pod-wrong-type-pull-secret -n e2e-pod-image-pull-secrets, created 1m ago
   Standalone POD.
   Secret/e2e-pull-secret-wrong-type wrong type: Opaque, but it's referenced in Pod's imagePullSecrets\.
   Containers: main \(registry\.invalid\.example/e2e-status-tests/does-not-exist:latest\) Waiting ImagePullBackOff: Back-off pulling image "registry\.invalid\.example/e2e-status-tests/does-not-exist:latest": ErrImagePull: [^\n]*
-  \(this Pod's imagePullSecrets have problems, see above .* that's likely why\)
+  \(this Pod's imagePullSecrets have problems, see above — that's likely why\)
 \z

--- a/tests/e2e-artifacts/rollout-diff.regex
+++ b/tests/e2e-artifacts/rollout-diff.regex
@@ -1,18 +1,18 @@
 \A
-Deployment/rollout-diff-test -n e2e-rollout-diff, created \d+[a-z]+ ago, gen:\d+ rev:\d+
+Deployment/rollout-diff-test -n e2e-rollout-diff, created 1m ago, gen:2 rev:2
   Current: Deployment is available\. Replicas: 1
   desired:1, existing:1, ready:1, updated:1, available:1
   Selector: app=rollout-diff-test
-(?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+, created \d+[a-z]+ ago Running, 1/1 ready
+(?:    Pod/rollout-diff-test-[a-z0-9]+-[a-z0-9]+, created 1m ago Running, 1/1 ready
 )+  Not matched by any Service
-  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for \d+[a-z]+
-  Progressing:True NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for \d+[a-z]+
+  Available:True MinimumReplicasAvailable, Deployment has minimum availability\. for 1m
+  Progressing:True NewReplicaSetAvailable, ReplicaSet "rollout-diff-test-7cf6c88cf8" has successfully progressed\. for 1m
   Rollouts:
-    \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-f96b445cf
-    \d+[a-z]+ ago, managed by ReplicaSet/rollout-diff-test-7cf6c88cf8, has 1 replicas
+    1m ago, managed by ReplicaSet/rollout-diff-test-f96b445cf
+    1m ago, managed by ReplicaSet/rollout-diff-test-7cf6c88cf8, has 1 replicas
       Diff:
-      --- a ReplicaSet/rollout-diff-test-f96b445cf\t\S.*\(\d+[a-z]+ ago\)
-      \+\+\+ b ReplicaSet/rollout-diff-test-7cf6c88cf8\t\S.*\(\d+[a-z]+ ago\)
+      --- a ReplicaSet/rollout-diff-test-f96b445cf\t\S+ \S+ \S+ \S+ \(1m ago\)
+      \+\+\+ b ReplicaSet/rollout-diff-test-7cf6c88cf8\t\S+ \S+ \S+ \S+ \(1m ago\)
       @@ -36,7 \+36,7 @@
              "spec": \{
                "containers": \[

--- a/tests/e2e-artifacts/web-cert.deep.regex
+++ b/tests/e2e-artifacts/web-cert.deep.regex
@@ -4,7 +4,7 @@ Secret/web-tls -n e2e-web-cert, created 1m ago
     Certificate/web-tls -n e2e-web-cert, created 1m ago, gen:1
       Current: Resource is Ready
       Issued by Issuer/web-ca-issuer for "web\.ks-demo\.svc" · stored in Secret/web-tls
-      Issued \d{4}-\d{2}-\d{2} \(1m ago\), expires \d{4}-\d{2}-\d{2}, auto-renews \d{4}-\d{2}-\d{2}(?: · rev [0-9]+)?
+      Issued \d{4}-\d{2}-\d{2} \(1m ago\), expires \d{4}-\d{2}-\d{2}, auto-renews \d{4}-\d{2}-\d{2} · rev 1
       Ready:True Ready, Certificate is up to date and has not expired for 1m
     Issuer/web-ca-issuer -n e2e-web-cert, created 1m ago, gen:1
       Current: Resource is Ready


### PR DESCRIPTION
## Summary
- A handful of `.regex` e2e fixtures used broad matchers (`\d+`, `.*`, optional groups) for field values that are actually fixed by the test setup, rather than matching them exactly.
- `rollout-diff.regex`: the Deployment gets exactly one image update, so generation/revision/durations are deterministic (`gen:2 rev:2`, `created 1m ago`, `for 1m`); pinned those instead of matching any digit/duration. Kept the pod-line repetition and the diff-header timestamp broad, since a stale old-ReplicaSet pod can still be listed transiently and the diff header's wall-clock timestamp genuinely varies.
- `pod-image-pull-secrets-missing.regex` / `pod-image-pull-secrets-wrong-type.regex`: `.* ` was standing in for a literal em dash in "see above — that's likely why"; replaced with the literal character.
- `web-cert.deep.regex`: certificate revision was matched as `(?: · rev [0-9]+)?` (optional, broad) even though this fixture issues the cert once with no renewal, so revision is always `1` — pinned to ` · rev 1`, matching the sibling TLS-validation fixtures.
- Audited the remaining broad matchers across all 116 `.regex` files (VPA recommendations, node/pod metrics, PV/StorageClass provisioner names, cert serial numbers, real node names) — those are legitimately non-deterministic (live metrics, cluster-dependent provisioners, random serials) and were left as-is.

## Test plan
- [x] Ran the four affected e2e subtests individually against a live cluster (`RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true go test ./cmd/...`) — all pass with the tightened fixtures.
- [x] Full `TestE2EParallel` suite run to confirm no other fixture regressed.