### PR TITLE
Render Gatekeeper Constraint match/enforcement/audit for any ConstraintTemplate Kind

### DIFF
--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -63,6 +63,13 @@ func (r RenderableObject) Kind() (kind string) {
 	return
 }
 
+func (r RenderableObject) APIVersion() (apiVersion string) {
+	if x := r.Object["apiVersion"]; x != nil {
+		apiVersion = x.(string)
+	}
+	return
+}
+
 func (r RenderableObject) Spec() (spec map[string]interface{}) {
 	if x := r.Object["spec"]; x != nil {
 		spec = x.(map[string]interface{})

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -11,6 +11,7 @@
     {{- template "crossplane_composed_resources" . }}
     {{- template "crossplane_managed_resource_drift" . }}
     {{- template "crossplane_managed_resource_details" . }}
+    {{- template "gatekeeper_constraint_fallback" . }}
     {{- template "conditions_summary" . }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -32,7 +32,7 @@
                mismatched name), so the association is fully determined by the Kind string alone
                -- no lookup needed to know the name, only to fetch the object itself in --deep. */ -}}
         {{- $ctName := . | lower }}
-        {{- "Template" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "ConstraintTemplate" "name" $ctName) }}
+        {{- $.Include "resource_ref" (dict "kind" "ConstraintTemplate" "name" $ctName) | nindent 2 }}
         {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ConstraintTemplate" "name" $ctName) }}
     {{- end }}
     {{- with .Spec.match }}

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -24,6 +24,17 @@
            per installed ConstraintTemplate -- K8sRequiredLabels, K8sAllowedRepos, etc. -- all with
            an identical spec.match/spec.enforcementAction and status.violations/byPod shape).
            Renders spec.match (which objects this constraint evaluates) and the enforcement mode. */ -}}
+    {{- with .Kind }}
+        {{- /* A Constraint carries no field of its own naming the ConstraintTemplate that
+               generated its Kind -- no ownerReference, no annotation. But Gatekeeper's own
+               controller hard-rejects any ConstraintTemplate whose name isn't the lowercase of
+               its spec.crd.spec.names.kind (confirmed live: status.byPod[].errors rejects a
+               mismatched name), so the association is fully determined by the Kind string alone
+               -- no lookup needed to know the name, only to fetch the object itself in --deep. */ -}}
+        {{- $ctName := . | lower }}
+        {{- "Template" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "ConstraintTemplate" "name" $ctName) }}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ConstraintTemplate" "name" $ctName) }}
+    {{- end }}
     {{- with .Spec.match }}
         {{- /* .kinds is optional -- matching by namespaces/namespaceSelector alone is valid, and
                len on a genuinely absent (nil) value errors out rather than returning 0, so check

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -1,3 +1,23 @@
+{{- define "gatekeeper_constraint_fallback" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Called unconditionally from DefaultResource, same as the crossplane_* snippets above it
+           -- Gatekeeper generates one CRD Kind per installed ConstraintTemplate (K8sAllowedRepos,
+           a custom one, ...), so findTemplateName can never route most of them to a dedicated
+           <Kind>.tmpl the way K8sRequiredLabels.tmpl is routed to today; they all land here
+           instead. Unlike Crossplane, which has no fixed apiVersion group to key off (every
+           provider owns its own), every Constraint CRD Gatekeeper generates -- regardless of Kind
+           -- shares one fixed group, confirmed against a live-cluster-generated CRD: only the
+           Kind varies, never constraints.gatekeeper.sh. That makes apiVersion an exact eligibility
+           check here, not a shape heuristic that could coincidentally match an unrelated CRD with
+           a similarly named spec.match/spec.enforcementAction field. K8sRequiredLabels itself
+           never reaches this: findTemplateName already routes it to its own template, which calls
+           the same two shared defines below directly. */ -}}
+    {{- if hasPrefix "constraints.gatekeeper.sh/" .APIVersion }}
+        {{- template "gatekeeper_constraint_match_and_enforcement" . }}
+        {{- template "gatekeeper_constraint_audit_status" . }}
+    {{- end }}
+{{- end }}
+
 {{- define "gatekeeper_constraint_match_and_enforcement" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* Shared by all Gatekeeper constraint kinds (constraints.gatekeeper.sh/*, one dynamic Kind

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -1372,6 +1372,65 @@ func TestManagedResourceDetailsTemplate_NotAManagedResource(t *testing.T) {
 	}
 }
 
+// TestGatekeeperConstraintFallback_RendersForArbitraryKind proves DefaultResource's
+// gatekeeper_constraint_fallback reaches the shared match/enforcement/audit rendering for a
+// Gatekeeper Constraint Kind that has no dedicated <Kind>.tmpl (K8sRequiredLabels is the only
+// Kind with one; everything else -- K8sAllowedRepos, any custom ConstraintTemplate's Kind --
+// falls through to DefaultResource, which must still reach this rendering generically).
+func TestGatekeeperConstraintFallback_RendersForArbitraryKind(t *testing.T) {
+	obj := map[string]interface{}{
+		"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+		"kind":       "K8sAllowedRepos",
+		"metadata":   map[string]interface{}{"name": "repo-must-be-internal"},
+		"spec": map[string]interface{}{
+			"enforcementAction": "deny",
+			"match": map[string]interface{}{
+				"kinds": []interface{}{
+					map[string]interface{}{"apiGroups": []interface{}{""}, "kinds": []interface{}{"Pod"}},
+				},
+			},
+		},
+		"status": map[string]interface{}{},
+	}
+	got, err := renderCrossplaneTemplate(t, "gatekeeper_constraint_fallback", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if !strings.Contains(got, "Match: core/Pod") {
+		t.Errorf("got = %q, want the shared match summary", got)
+	}
+	if !strings.Contains(got, "enforcementAction") {
+		t.Errorf("got = %q, want the shared enforcementAction line", got)
+	}
+}
+
+// TestGatekeeperConstraintFallback_IneligibleForNonGatekeeperGroup proves eligibility is an exact
+// apiVersion-group check, not a spec.match/spec.enforcementAction shape heuristic: an unrelated
+// CRD that happens to reuse those field names under a different group must render nothing here.
+func TestGatekeeperConstraintFallback_IneligibleForNonGatekeeperGroup(t *testing.T) {
+	obj := map[string]interface{}{
+		"apiVersion": "example.com/v1",
+		"kind":       "NotAConstraint",
+		"metadata":   map[string]interface{}{"name": "coincidental-shape"},
+		"spec": map[string]interface{}{
+			"enforcementAction": "deny",
+			"match": map[string]interface{}{
+				"kinds": []interface{}{
+					map[string]interface{}{"apiGroups": []interface{}{""}, "kinds": []interface{}{"Pod"}},
+				},
+			},
+		},
+		"status": map[string]interface{}{},
+	}
+	got, err := renderCrossplaneTemplate(t, "gatekeeper_constraint_fallback", obj)
+	if err != nil {
+		t.Fatalf("renderTemplate() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected no output for a non-Gatekeeper object with a coincidentally similar shape, got = %q", got)
+	}
+}
+
 // renderObjHealthSummary renders "generic_health_summary" or "resource_health_summary" -- both
 // expect dict "obj" (RenderableObject) "callerNamespace" (optional) rather than the bare object
 // renderCrossplaneTemplate's callers pass.

--- a/tests/artifacts/constraint-clean.out
+++ b/tests/artifacts/constraint-clean.out
@@ -1,5 +1,6 @@
 
 K8sRequiredLabels/always-satisfied, created 1m ago, gen:1
+  Template: ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: deny
   Required labels: kubernetes.io/metadata.name

--- a/tests/artifacts/constraint-clean.out
+++ b/tests/artifacts/constraint-clean.out
@@ -1,6 +1,6 @@
 
 K8sRequiredLabels/always-satisfied, created 1m ago, gen:1
-  Template: ConstraintTemplate/k8srequiredlabels
+  ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: deny
   Required labels: kubernetes.io/metadata.name

--- a/tests/artifacts/constraint-deny-violations.out
+++ b/tests/artifacts/constraint-deny-violations.out
@@ -1,5 +1,6 @@
 
 K8sRequiredLabels/all-must-have-owner, created 1m ago, gen:5
+  Template: ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: deny
   Required labels: owner matching ^[a-zA-Z]+.agilebank.demo$

--- a/tests/artifacts/constraint-deny-violations.out
+++ b/tests/artifacts/constraint-deny-violations.out
@@ -1,6 +1,6 @@
 
 K8sRequiredLabels/all-must-have-owner, created 1m ago, gen:5
-  Template: ConstraintTemplate/k8srequiredlabels
+  ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: deny
   Required labels: owner matching ^[a-zA-Z]+.agilebank.demo$

--- a/tests/artifacts/constraint-dryrun-truncated.out
+++ b/tests/artifacts/constraint-dryrun-truncated.out
@@ -1,5 +1,6 @@
 
 K8sRequiredLabels/dryrun-check, created 1m ago, gen:1
+  Template: ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: dryrun (violations are not blocked)
   Required labels: owner

--- a/tests/artifacts/constraint-dryrun-truncated.out
+++ b/tests/artifacts/constraint-dryrun-truncated.out
@@ -1,6 +1,6 @@
 
 K8sRequiredLabels/dryrun-check, created 1m ago, gen:1
-  Template: ConstraintTemplate/k8srequiredlabels
+  ConstraintTemplate/k8srequiredlabels
   Match: core/Namespace
   enforcementAction: dryrun (violations are not blocked)
   Required labels: owner

--- a/tests/artifacts/constraint-generic-kind-fallback.out
+++ b/tests/artifacts/constraint-generic-kind-fallback.out
@@ -1,6 +1,7 @@
 
 K8sAllowedRepos/repo-must-be-internal, created 1m ago, gen:1
   Current: Resource is current
+  Template: ConstraintTemplate/k8sallowedrepos
   Match: core/Pod, namespaces:gk-fixture-capture
   enforcementAction: deny
   Last audited: 1m ago

--- a/tests/artifacts/constraint-generic-kind-fallback.out
+++ b/tests/artifacts/constraint-generic-kind-fallback.out
@@ -1,0 +1,8 @@
+
+K8sAllowedRepos/repo-must-be-internal, created 1m ago, gen:1
+  Current: Resource is current
+  Match: core/Pod
+  enforcementAction: deny
+  Last audited: 1m ago
+  Violations: 1
+    Pod/checkout-7d9f8c6b5-abcde -n default: container <app> has an invalid image repo <docker.io/library/nginx>, allowed repos are ["internal.registry.example.com/"]

--- a/tests/artifacts/constraint-generic-kind-fallback.out
+++ b/tests/artifacts/constraint-generic-kind-fallback.out
@@ -1,8 +1,8 @@
 
 K8sAllowedRepos/repo-must-be-internal, created 1m ago, gen:1
   Current: Resource is current
-  Match: core/Pod
+  Match: core/Pod, namespaces:gk-fixture-capture
   enforcementAction: deny
   Last audited: 1m ago
   Violations: 1
-    Pod/checkout-7d9f8c6b5-abcde -n default: container <app> has an invalid image repo <docker.io/library/nginx>, allowed repos are ["internal.registry.example.com/"]
+    Pod/checkout -n gk-fixture-capture: container <checkout> has an invalid image repo <nginx>, allowed repos are ["internal.registry.example.com/"]

--- a/tests/artifacts/constraint-generic-kind-fallback.out
+++ b/tests/artifacts/constraint-generic-kind-fallback.out
@@ -1,7 +1,7 @@
 
 K8sAllowedRepos/repo-must-be-internal, created 1m ago, gen:1
   Current: Resource is current
-  Template: ConstraintTemplate/k8sallowedrepos
+  ConstraintTemplate/k8sallowedrepos
   Match: core/Pod, namespaces:gk-fixture-capture
   enforcementAction: deny
   Last audited: 1m ago

--- a/tests/artifacts/constraint-generic-kind-fallback.yaml
+++ b/tests/artifacts/constraint-generic-kind-fallback.yaml
@@ -1,19 +1,14 @@
-# A Constraint of a Kind other than K8sRequiredLabels -- no dedicated <Kind>.tmpl exists for
-# K8sAllowedRepos (or any other ConstraintTemplate-generated Kind besides K8sRequiredLabels), so
-# findTemplateName routes it to DefaultResource, which must reach the same shared
-# gatekeeper_constraint_match_and_enforcement/gatekeeper_constraint_audit_status rendering via
-# gatekeeper_constraint_fallback. This is the case the K8sRequiredLabels-only fixtures don't cover.
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sAllowedRepos
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sAllowedRepos","metadata":{"annotations":{},"name":"repo-must-be-internal"},"spec":{"match":{"kinds":[{"apiGroups":[""],"kinds":["Pod"]}]},"parameters":{"repos":["internal.registry.example.com/"]}}}
-  creationTimestamp: "2026-07-27T10:22:03Z"
+      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sAllowedRepos","metadata":{"annotations":{},"name":"repo-must-be-internal"},"spec":{"enforcementAction":"deny","match":{"kinds":[{"apiGroups":[""],"kinds":["Pod"]}],"namespaces":["gk-fixture-capture"]},"parameters":{"repos":["internal.registry.example.com/"]}}}
+  creationTimestamp: "2026-08-06T22:56:04Z"
   generation: 1
   name: repo-must-be-internal
-  resourceVersion: "24020"
-  uid: 7c866d2e-289f-46e0-a61a-96487fd03399
+  resourceVersion: "3798302"
+  uid: 58d436f2-a791-402b-90ae-1da446e11dc8
 spec:
   enforcementAction: deny
   match:
@@ -22,24 +17,31 @@ spec:
       - ""
       kinds:
       - Pod
+    namespaces:
+    - gk-fixture-capture
   parameters:
     repos:
     - internal.registry.example.com/
 status:
-  auditTimestamp: "2026-07-28T13:33:23Z"
+  auditTimestamp: "2026-08-07T06:14:23Z"
   byPod:
-  - constraintUID: 7c866d2e-289f-46e0-a61a-96487fd03399
+  - constraintUID: 58d436f2-a791-402b-90ae-1da446e11dc8
     enforced: true
-    id: gatekeeper-audit-5cc96fbf64-8rlsb
+    enforcementPointsStatus:
+    - enforcementPoint: vap.k8s.io
+      message: K8sNativeValidation engine is missing
+      observedGeneration: 1
+      state: error
+    id: gatekeeper-audit-7dd45df4bb-cv99t
     observedGeneration: 1
     operations:
     - audit
     - generate
     - mutation-status
     - status
-  - constraintUID: 7c866d2e-289f-46e0-a61a-96487fd03399
+  - constraintUID: 58d436f2-a791-402b-90ae-1da446e11dc8
     enforced: true
-    id: gatekeeper-controller-manager-77cccb6c69-9vpj8
+    id: gatekeeper-controller-manager-5869889959-bssp2
     observedGeneration: 1
     operations:
     - mutation-webhook
@@ -49,7 +51,8 @@ status:
   - enforcementAction: deny
     group: ""
     kind: Pod
-    message: 'container <app> has an invalid image repo <docker.io/library/nginx>, allowed repos are ["internal.registry.example.com/"]'
-    name: checkout-7d9f8c6b5-abcde
-    namespace: default
+    message: container <checkout> has an invalid image repo <nginx>, allowed repos
+      are ["internal.registry.example.com/"]
+    name: checkout
+    namespace: gk-fixture-capture
     version: v1

--- a/tests/artifacts/constraint-generic-kind-fallback.yaml
+++ b/tests/artifacts/constraint-generic-kind-fallback.yaml
@@ -1,0 +1,55 @@
+# A Constraint of a Kind other than K8sRequiredLabels -- no dedicated <Kind>.tmpl exists for
+# K8sAllowedRepos (or any other ConstraintTemplate-generated Kind besides K8sRequiredLabels), so
+# findTemplateName routes it to DefaultResource, which must reach the same shared
+# gatekeeper_constraint_match_and_enforcement/gatekeeper_constraint_audit_status rendering via
+# gatekeeper_constraint_fallback. This is the case the K8sRequiredLabels-only fixtures don't cover.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sAllowedRepos
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"constraints.gatekeeper.sh/v1beta1","kind":"K8sAllowedRepos","metadata":{"annotations":{},"name":"repo-must-be-internal"},"spec":{"match":{"kinds":[{"apiGroups":[""],"kinds":["Pod"]}]},"parameters":{"repos":["internal.registry.example.com/"]}}}
+  creationTimestamp: "2026-07-27T10:22:03Z"
+  generation: 1
+  name: repo-must-be-internal
+  resourceVersion: "24020"
+  uid: 7c866d2e-289f-46e0-a61a-96487fd03399
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Pod
+  parameters:
+    repos:
+    - internal.registry.example.com/
+status:
+  auditTimestamp: "2026-07-28T13:33:23Z"
+  byPod:
+  - constraintUID: 7c866d2e-289f-46e0-a61a-96487fd03399
+    enforced: true
+    id: gatekeeper-audit-5cc96fbf64-8rlsb
+    observedGeneration: 1
+    operations:
+    - audit
+    - generate
+    - mutation-status
+    - status
+  - constraintUID: 7c866d2e-289f-46e0-a61a-96487fd03399
+    enforced: true
+    id: gatekeeper-controller-manager-77cccb6c69-9vpj8
+    observedGeneration: 1
+    operations:
+    - mutation-webhook
+    - webhook
+  totalViolations: 1
+  violations:
+  - enforcementAction: deny
+    group: ""
+    kind: Pod
+    message: 'container <app> has an invalid image repo <docker.io/library/nginx>, allowed repos are ["internal.registry.example.com/"]'
+    name: checkout-7d9f8c6b5-abcde
+    namespace: default
+    version: v1

--- a/tests/e2e-artifacts/namespace-gatekeeper-constraint-match-deep.regex
+++ b/tests/e2e-artifacts/namespace-gatekeeper-constraint-match-deep.regex
@@ -4,6 +4,9 @@ Namespace/e2e-gatekeeper-hint, created 1m ago Active
   PSA: no labels set \(cluster defaults apply — not readable via API\)
   Gatekeeper: 1 constraint may govern this namespace — PSA labels above may not reflect the effective policy
     K8sRequiredLabels/e2e-gatekeeper-hint-constraint-[a-z0-9]+, created 1m ago, gen:1
+      ConstraintTemplate/k8srequiredlabels
+        ConstraintTemplate/k8srequiredlabels, created 1m ago, gen:1
+          Current: Resource is current
       Match: core/Pod, namespaces:e2e-gatekeeper-hint
       enforcementAction: dryrun \(violations are not blocked\)
       Required labels: team


### PR DESCRIPTION
## Summary
- PR #776 built shared `gatekeeper_constraint_match_and_enforcement`/`gatekeeper_constraint_audit_status` rendering (spec.match, enforcementAction, violations, audit status), but only wired it into a dedicated `K8sRequiredLabels.tmpl`. Gatekeeper generates one CRD **Kind** per installed ConstraintTemplate (`K8sRequiredLabels`, `K8sAllowedRepos`, any custom name), so `findTemplateName` can only ever route that one literal Kind to a dedicated template -- every other Kind fell through to `DefaultResource` with none of this rendering.
- Adds `gatekeeper_constraint_fallback` (`pkg/plugin/templates/gatekeeper_constraint_common.tmpl`), called unconditionally from `DefaultResource` next to the existing `crossplane_*` snippets, gated on `apiVersion` having prefix `constraints.gatekeeper.sh/`.
- Confirmed against a live-cluster-generated CRD (`k8srequiredlabels.constraints.gatekeeper.sh` on the shared e2e cluster) that every Constraint CRD Gatekeeper generates shares this one fixed apiVersion group regardless of Kind -- an exact eligibility signal, unlike Crossplane's shape-based `spec.forProvider` check it sits next to, which has no fixed group to key off since each provider owns its own.
- New `APIVersion()` accessor on `RenderableObject` (`pkg/plugin/renderable.go`), sibling to the existing `Kind()`.
- Also points each Constraint at its generating ConstraintTemplate (`ConstraintTemplate/<name>` on its own line, shared so both `K8sRequiredLabels.tmpl` and the new fallback get it). A Constraint carries no field pointing back at it -- no ownerReference, no annotation -- but Gatekeeper's own controller hard-rejects a ConstraintTemplate whose name isn't the lowercase of its `spec.crd.spec.names.kind`, so the name is derivable from the Constraint's own Kind with no lookup needed. Rendered via the same `resource_ref`/`deep_render_ref` pair every other reference field uses (bare, unlabeled line -- matching `crossplane_composition_ref`'s existing convention for this same "points at what generated/defines it" relationship): default mode shows the ref, `--deep` inlines the real object, silent in `--shallow`/`--local`.

## Test plan
- [x] Two new unit tests in `templates_common_test.go`: the fallback renders Match/enforcementAction for an arbitrary Kind (`K8sAllowedRepos`) under the Gatekeeper group, and renders nothing for an unrelated object that coincidentally has the same `spec.match`/`spec.enforcementAction` field shape under a different apiVersion group -- proving the gate is exact, not a heuristic.
- [x] New golden fixture `tests/artifacts/constraint-generic-kind-fallback.yaml`: a **real capture** (`make new-artifact`) of a `K8sAllowedRepos` ConstraintTemplate + Constraint + violating Pod applied to the shared e2e cluster and driven through a real audit cycle -- not hand-written -- same provenance as the existing `constraint-*.yaml` fixtures from #776.
- [x] Verified the `ConstraintTemplate/<name>` ref live against the real cluster in both default and `--deep` mode (confirms it resolves and inlines correctly), and against partial manifests (`spec: {}`, missing `kind`) in both modes -- degrades cleanly, no crash, no literal `<nil>`.
- [x] `make update-artifacts` regenerated only the four `constraint-*.out` fixtures across both rounds of feedback -- confirmed no unrelated fixture drift.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- [x] Rebased onto master to pick up #799's `hasKey` signature migration -- no conflicts (this change doesn't call `hasKey`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)