### PR TITLE
Migrate append template calls off deprecated sprig-compat signature (…

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -73,7 +73,7 @@ Apply `| cyan` to plain values so they are visually distinct from bold labels. N
 `{{- with .field }}` skips when the value is `false`, `0`, or `""`. This hides operationally meaningful zeroes — `routes=0` means nothing is attached and is worth showing. Use `if hasKey` when zero is significant:
 
 ```
-{{- if hasKey $status "attachedRoutes" }}, routes={{ $status.attachedRoutes | toString | cyan }}{{ end }}
+{{- if $status | hasKey "attachedRoutes" }}, routes={{ $status.attachedRoutes | toString | cyan }}{{ end }}
 ```
 
 Use `with` only when the zero/empty case genuinely means "omit this field entirely".

--- a/pkg/plugin/templates/Certificate.tmpl
+++ b/pkg/plugin/templates/Certificate.tmpl
@@ -64,14 +64,14 @@
     {{- /* Keystores */ -}}
     {{- with .Spec.keystores }}
         {{- $stores := list }}
-        {{- if .jks }}{{ if .jks.create }}{{ $stores = append $stores "JKS" }}{{ end }}{{ end }}
-        {{- if .pkcs12 }}{{ if .pkcs12.create }}{{ $stores = append $stores (printf "PKCS12/%s" (.pkcs12.profile | default "LegacyRC2")) }}{{ end }}{{ end }}
+        {{- if .jks }}{{ if .jks.create }}{{ $stores = $stores | append "JKS" }}{{ end }}{{ end }}
+        {{- if .pkcs12 }}{{ if .pkcs12.create }}{{ $stores = $stores | append (printf "PKCS12/%s" (.pkcs12.profile | default "LegacyRC2")) }}{{ end }}{{ end }}
         {{- with $stores }}
             {{- "Keystores" | bold | nindent 2 }}: {{ join ", " . | cyan }}
         {{- end }}
     {{- end }}
     {{- with .Spec.additionalOutputFormats }}
-        {{- $fmts := list }}{{ range . }}{{ $fmts = append $fmts .type }}{{ end }}
+        {{- $fmts := list }}{{ range . }}{{ $fmts = $fmts | append .type }}{{ end }}
         {{- "Extra output formats" | bold | nindent 2 }}: {{ join ", " $fmts | cyan }}
     {{- end }}
     {{- /* Issued validity window — strip time component for readability */ -}}

--- a/pkg/plugin/templates/CronJob.tmpl
+++ b/pkg/plugin/templates/CronJob.tmpl
@@ -24,7 +24,7 @@
         {{- $job := . }}
         {{- range .Metadata.ownerReferences }}
             {{- if and .controller (eq .kind "CronJob") (eq .name $.Name) }}
-                {{- $cronJobJobs = append $cronJobJobs $job }}
+                {{- $cronJobJobs = $cronJobJobs | append $job }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/CustomResourceDefinition.tmpl
+++ b/pkg/plugin/templates/CustomResourceDefinition.tmpl
@@ -31,7 +31,7 @@
     {{- $storageVersion := "" }}
     {{- range .Spec.versions }}{{ if .storage }}{{ $storageVersion = .name }}{{ end }}{{ end }}
     {{- $stale := list }}
-    {{- range .Status.storedVersions }}{{ if ne . $storageVersion }}{{ $stale = append $stale . }}{{ end }}{{ end }}
+    {{- range .Status.storedVersions }}{{ if ne . $storageVersion }}{{ $stale = $stale | append . }}{{ end }}{{ end }}
     {{- with $stale }}
         {{- "Stored" | red | bold | nindent 2 }}: {{ join ", " . | red }} (migration pending)
     {{- end }}

--- a/pkg/plugin/templates/DaemonSet.tmpl
+++ b/pkg/plugin/templates/DaemonSet.tmpl
@@ -44,7 +44,7 @@
     {{- range .KubeGetByLabelsMap .Namespace "controllerrevisions" .Labels }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- $revisions = append $revisions . }}
+            {{- $revisions = $revisions | append . }}
         {{- end }}
     {{- end }}
     {{- /* creationTimestamp only has second resolution, so ControllerRevisions created within the

--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -61,7 +61,7 @@
     {{- range .KubeGet .Namespace "ReplicaSets" }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- $replicaSets = append $replicaSets . }}
+            {{- $replicaSets = $replicaSets | append . }}
         {{- end }}
     {{- end }}
     {{- /* creationTimestamp only has second resolution, so ReplicaSets created within the same

--- a/pkg/plugin/templates/DestinationRule.tmpl
+++ b/pkg/plugin/templates/DestinationRule.tmpl
@@ -48,7 +48,7 @@
             {{- with .labels }}
                 {{- $labels := . }}
                 {{- $pairs := list }}
-                {{- range $key := keys . | sortAlpha }}{{ $pairs = append $pairs (printf "%s=%v" $key (index $labels $key)) }}{{ end }}
+                {{- range $key := keys . | sortAlpha }}{{ $pairs = $pairs | append (printf "%s=%v" $key (index $labels $key)) }}{{ end }}
                 {{- " " }}{{ join "," $pairs | cyan }}
             {{- end }}
             {{- /* A subset is the Service's endpoints narrowed by these labels, so it goes empty

--- a/pkg/plugin/templates/FlowSchema.tmpl
+++ b/pkg/plugin/templates/FlowSchema.tmpl
@@ -30,11 +30,11 @@
                 {{- $subjects := list }}
                 {{- range .subjects }}
                     {{- if eq .kind "Group" }}
-                        {{- $subjects = append $subjects (printf "group:%s" .group.name) }}
+                        {{- $subjects = $subjects | append (printf "group:%s" .group.name) }}
                     {{- else if eq .kind "User" }}
-                        {{- $subjects = append $subjects (printf "user:%s" .user.name) }}
+                        {{- $subjects = $subjects | append (printf "user:%s" .user.name) }}
                     {{- else if eq .kind "ServiceAccount" }}
-                        {{- $subjects = append $subjects (printf "sa:%s/%s" .serviceAccount.namespace .serviceAccount.name) }}
+                        {{- $subjects = $subjects | append (printf "sa:%s/%s" .serviceAccount.namespace .serviceAccount.name) }}
                     {{- end }}
                 {{- end }}
                 {{- join ", " $subjects | cyan | nindent 4 }}

--- a/pkg/plugin/templates/HelmRelease.tmpl
+++ b/pkg/plugin/templates/HelmRelease.tmpl
@@ -148,9 +148,9 @@
     {{- if or .Status.installFailures .Status.upgradeFailures .Status.failures }}
         {{- "Failures" | red | bold | nindent 2 }}:
         {{- $failureParts := list }}
-        {{- with .Status.installFailures }}{{ $failureParts = append $failureParts (printf "install:%d" (int .)) }}{{ end }}
-        {{- with .Status.upgradeFailures }}{{ $failureParts = append $failureParts (printf "upgrade:%d" (int .)) }}{{ end }}
-        {{- with .Status.failures }}{{ $failureParts = append $failureParts (printf "total:%d" (int .)) }}{{ end }}
+        {{- with .Status.installFailures }}{{ $failureParts = $failureParts | append (printf "install:%d" (int .)) }}{{ end }}
+        {{- with .Status.upgradeFailures }}{{ $failureParts = $failureParts | append (printf "upgrade:%d" (int .)) }}{{ end }}
+        {{- with .Status.failures }}{{ $failureParts = $failureParts | append (printf "total:%d" (int .)) }}{{ end }}
         {{- " " }}{{ join ", " $failureParts | red | bold }}
     {{- end }}
     {{- /* Remediation only matters once it deviates from the default of not retrying at all;
@@ -162,9 +162,9 @@
     {{- if or $installRetries $upgradeRetries $upgradeStrategy }}
         {{- "Remediation" | bold | nindent 2 }}:
         {{- $remediationParts := list }}
-        {{- with $installRetries }}{{ $remediationParts = append $remediationParts (printf "install retries %d" (int .)) }}{{ end }}
-        {{- with $upgradeRetries }}{{ $remediationParts = append $remediationParts (printf "upgrade retries %d" (int .)) }}{{ end }}
-        {{- with $upgradeStrategy }}{{ $remediationParts = append $remediationParts (printf "on failed upgrade: %s" .) }}{{ end }}
+        {{- with $installRetries }}{{ $remediationParts = $remediationParts | append (printf "install retries %d" (int .)) }}{{ end }}
+        {{- with $upgradeRetries }}{{ $remediationParts = $remediationParts | append (printf "upgrade retries %d" (int .)) }}{{ end }}
+        {{- with $upgradeStrategy }}{{ $remediationParts = $remediationParts | append (printf "on failed upgrade: %s" .) }}{{ end }}
         {{- " " }}{{ join ", " $remediationParts | cyan }}
     {{- end }}
     {{- /* Helm never touches CRDs on its own, so these two decide whether a chart's crds/ directory
@@ -182,12 +182,12 @@
                its default is still named, because "created on install" only means something once
                you can see what happens on upgrade next to it. */ -}}
         {{- $crdParts := list }}
-        {{- if eq $installCRDs "Skip" }}{{ $crdParts = append $crdParts "never installed" }}
-        {{- else if eq $installCRDs "CreateReplace" }}{{ $crdParts = append $crdParts "created and replaced on install" }}
-        {{- else }}{{ $crdParts = append $crdParts "created on install" }}{{ end }}
-        {{- if eq $upgradeCRDs "CreateReplace" }}{{ $crdParts = append $crdParts "replaced on upgrade" }}
-        {{- else if eq $upgradeCRDs "Create" }}{{ $crdParts = append $crdParts "created on upgrade" }}
-        {{- else if ne $installCRDs "Skip" }}{{ $crdParts = append $crdParts "left alone on upgrade" }}{{ end }}
+        {{- if eq $installCRDs "Skip" }}{{ $crdParts = $crdParts | append "never installed" }}
+        {{- else if eq $installCRDs "CreateReplace" }}{{ $crdParts = $crdParts | append "created and replaced on install" }}
+        {{- else }}{{ $crdParts = $crdParts | append "created on install" }}{{ end }}
+        {{- if eq $upgradeCRDs "CreateReplace" }}{{ $crdParts = $crdParts | append "replaced on upgrade" }}
+        {{- else if eq $upgradeCRDs "Create" }}{{ $crdParts = $crdParts | append "created on upgrade" }}
+        {{- else if ne $installCRDs "Skip" }}{{ $crdParts = $crdParts | append "left alone on upgrade" }}{{ end }}
         {{- "Chart CRDs" | bold | nindent 2 }} {{ join ", " $crdParts | cyan }}
     {{- end }}
     {{- /* Off by default: with it on, helm-controller diffs the cluster against the last release

--- a/pkg/plugin/templates/Ingress.tmpl
+++ b/pkg/plugin/templates/Ingress.tmpl
@@ -20,7 +20,7 @@
                 {{- if not $svc }}
                     {{- if not ($missingSvcs | has $ingSvcName) }}
                         {{- "Service" | bold | nindent 2 }}/{{ $ingSvcName }} {{ "doesn't exist" | red | bold }}, but it's referenced in Ingress.
-                        {{- $missingSvcs = append $missingSvcs $ingSvcName }}
+                        {{- $missingSvcs = $missingSvcs | append $ingSvcName }}
                     {{- end }}
                 {{- else }}
                     {{- $portDefinedInSvc := false }}
@@ -33,7 +33,7 @@
                         {{- "Service port doesnt exist" | red | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Service" "name" $ingSvcName) }}:{{ $ingSvcPort }} referenced in ingress, but Service doesn't have that port defined.
                     {{- else if not ($shownSvcs | has $ingSvcName) }}
                         {{- $.Include "service_health_summary" $svc | nindent 2 }}
-                        {{- $shownSvcs = append $shownSvcs $ingSvcName }}
+                        {{- $shownSvcs = $shownSvcs | append $ingSvcName }}
                     {{- end }}
                 {{- end }}
             {{- end }}
@@ -51,7 +51,7 @@
             {{- if not $secret.Object }}
                 {{- if not ($missingSecrets | has $secretName) }}
                     {{- "Secret" | bold | nindent 2 }}/{{ $secretName }} {{ "doesn't exist" | red | bold }}, but it's referenced in Ingress TLS for host(s) [{{ $hosts | join ", " }}].
-                    {{- $missingSecrets = append $missingSecrets $secretName }}
+                    {{- $missingSecrets = $missingSecrets | append $secretName }}
                 {{- end }}
             {{- else }}
                 {{- $certBase := parseTLSSecretCertificate $secret "" }}
@@ -76,7 +76,7 @@
                 {{- if $.Config.GetBool "deep" }}
                     {{- if not ($shownSecrets | has $secretName) }}
                         {{- $.IncludeRenderableObject $secret | nindent 4 }}
-                        {{- $shownSecrets = append $shownSecrets $secretName }}
+                        {{- $shownSecrets = $shownSecrets | append $secretName }}
                     {{- end }}
                 {{- end }}
             {{- end }}

--- a/pkg/plugin/templates/Issuer.tmpl
+++ b/pkg/plugin/templates/Issuer.tmpl
@@ -42,8 +42,8 @@
         {{- end }}
         {{- $solverTypes := list }}
         {{- range .Spec.acme.solvers | default list }}
-            {{- if .http01 }}{{ $solverTypes = append $solverTypes "HTTP-01" }}{{ end }}
-            {{- if .dns01 }}{{ $solverTypes = append $solverTypes "DNS-01" }}{{ end }}
+            {{- if .http01 }}{{ $solverTypes = $solverTypes | append "HTTP-01" }}{{ end }}
+            {{- if .dns01 }}{{ $solverTypes = $solverTypes | append "DNS-01" }}{{ end }}
         {{- end }}
         {{- with $solverTypes | uniq }}
             {{- "Solvers" | bold | nindent 4 }}: {{ join ", " . | cyan }}

--- a/pkg/plugin/templates/Job.tmpl
+++ b/pkg/plugin/templates/Job.tmpl
@@ -27,7 +27,7 @@
         {{- $failedPods := list }}
         {{- range $.KubeGetByLabelsMap $.Namespace "pods" (dict "job-name" .Name) }}
             {{- if eq .Status.phase "Failed" }}
-                {{- $failedPods = append $failedPods . }}
+                {{- $failedPods = $failedPods | append . }}
             {{- end }}
         {{- end }}
         {{- with $failedPods }}
@@ -48,7 +48,7 @@
         {{- $pendingPods := list }}
         {{- range $.KubeGetByLabelsMap $.Namespace "pods" (dict "job-name" .Name) }}
             {{- if eq .Status.phase "Pending" }}
-                {{- $pendingPods = append $pendingPods . }}
+                {{- $pendingPods = $pendingPods | append . }}
             {{- end }}
         {{- end }}
         {{- with $pendingPods }}

--- a/pkg/plugin/templates/Kustomization.tmpl
+++ b/pkg/plugin/templates/Kustomization.tmpl
@@ -53,11 +53,11 @@
                    text, which would otherwise put the whole malformed id in the kind summary. */ -}}
             {{- $kind := ternary (last $parts) "unparsable" (eq (len $parts) 4) }}
             {{- $_ := set $countsByKind $kind (add1 (int ($countsByKind | get $kind))) }}
-            {{- $ids = append $ids (.id | default "" | toString) }}
+            {{- $ids = $ids | append (.id | default "" | toString) }}
         {{- end }}
         {{- $kindSummaries := list }}
         {{- range $kind := keys $countsByKind | sortAlpha }}
-            {{- $kindSummaries = append $kindSummaries (printf "%s×%d" $kind (int ($countsByKind | get $kind))) }}
+            {{- $kindSummaries = $kindSummaries | append (printf "%s×%d" $kind (int ($countsByKind | get $kind))) }}
         {{- end }}
         {{- "Manages" | bold | nindent 2 }} {{ len $entries | toString | cyan }} resources: {{ join ", " $kindSummaries | cyan }}
         {{- /* Sorted by id so the list is stable across reconciliations -- the controller writes

--- a/pkg/plugin/templates/LimitRange.tmpl
+++ b/pkg/plugin/templates/LimitRange.tmpl
@@ -30,18 +30,18 @@
     {{- $resourceNames := list }}
     {{- range $m := list $default $defaultRequest $max $min $ratio }}
         {{- range $name, $_ := $m }}
-            {{- if not (has $name $resourceNames) }}{{ $resourceNames = append $resourceNames $name }}{{ end }}
+            {{- if not (has $name $resourceNames) }}{{ $resourceNames = $resourceNames | append $name }}{{ end }}
         {{- end }}
     {{- end }}
     {{- .type | bold | nindent 4 }}:
     {{- range $resourceNames | sortAlpha }}
         {{- $name := . }}
         {{- $facts := list }}
-        {{- with index $min $name }}{{ $facts = append $facts (printf "min %s" (. | toString | cyan)) }}{{ end }}
-        {{- with index $defaultRequest $name }}{{ $facts = append $facts (printf "default request %s" (. | toString | cyan)) }}{{ end }}
-        {{- with index $default $name }}{{ $facts = append $facts (printf "default limit %s" (. | toString | cyan)) }}{{ end }}
-        {{- with index $max $name }}{{ $facts = append $facts (printf "max %s" (. | toString | cyan)) }}{{ end }}
-        {{- with index $ratio $name }}{{ $facts = append $facts (printf "max limit/request ratio %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $min $name }}{{ $facts = $facts | append (printf "min %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $defaultRequest $name }}{{ $facts = $facts | append (printf "default request %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $default $name }}{{ $facts = $facts | append (printf "default limit %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $max $name }}{{ $facts = $facts | append (printf "max %s" (. | toString | cyan)) }}{{ end }}
+        {{- with index $ratio $name }}{{ $facts = $facts | append (printf "max limit/request ratio %s" (. | toString | cyan)) }}{{ end }}
         {{- printf "%s: %s" $name (join ", " $facts) | nindent 6 }}
     {{- end }}
 {{- end -}}

--- a/pkg/plugin/templates/Namespace.tmpl
+++ b/pkg/plugin/templates/Namespace.tmpl
@@ -19,21 +19,21 @@
             {{- if and $psaEnforceVer (ne $psaEnforceVer "latest") }}
                 {{- $part = printf "%s (%s)" $part ($psaEnforceVer | cyan) }}
             {{- end }}
-            {{- $parts = append $parts $part }}
+            {{- $parts = $parts | append $part }}
         {{- end }}
         {{- if $psaWarn }}
             {{- $part := printf "warns on %s" ($.Include "namespace_psa_level" $psaWarn) }}
             {{- if and $psaWarnVer (ne $psaWarnVer "latest") }}
                 {{- $part = printf "%s (%s)" $part ($psaWarnVer | cyan) }}
             {{- end }}
-            {{- $parts = append $parts $part }}
+            {{- $parts = $parts | append $part }}
         {{- end }}
         {{- if $psaAudit }}
             {{- $part := printf "audits at %s" ($.Include "namespace_psa_level" $psaAudit) }}
             {{- if and $psaAuditVer (ne $psaAuditVer "latest") }}
                 {{- $part = printf "%s (%s)" $part ($psaAuditVer | cyan) }}
             {{- end }}
-            {{- $parts = append $parts $part }}
+            {{- $parts = $parts | append $part }}
         {{- end }}
         {{- "PSA:" | bold | nindent 2 }} {{ join ", " $parts }}
     {{- else }}

--- a/pkg/plugin/templates/Node.tmpl
+++ b/pkg/plugin/templates/Node.tmpl
@@ -95,21 +95,21 @@
            the cpu:/mem:/ephemeral-storage: lines whose numbers they explain. */ -}}
     {{- $kc := .kubeletconfig | default dict }}
     {{- $parts := list }}
-    {{- with .health }}{{ $parts = append $parts (ternary . (. | red | bold) (eq . "ok")) }}{{ end }}
-    {{- with $kc.podPidsLimit }}{{ if ge (. | float64) 0.0 }}{{ $parts = append $parts (printf "podPidsLimit:%s" (. | toString)) }}{{ end }}{{ end }}
-    {{- with $kc.cpuManagerPolicy }}{{ if ne . "none" }}{{ $parts = append $parts (printf "cpuManager:%s" .) }}{{ end }}{{ end }}
-    {{- with $kc.memoryManagerPolicy }}{{ if ne . "None" }}{{ $parts = append $parts (printf "memoryManager:%s" .) }}{{ end }}{{ end }}
-    {{- with $kc.topologyManagerPolicy }}{{ if ne . "none" }}{{ $parts = append $parts (printf "topologyManager:%s" .) }}{{ end }}{{ end }}
+    {{- with .health }}{{ $parts = $parts | append (ternary . (. | red | bold) (eq . "ok")) }}{{ end }}
+    {{- with $kc.podPidsLimit }}{{ if ge (. | float64) 0.0 }}{{ $parts = $parts | append (printf "podPidsLimit:%s" (. | toString)) }}{{ end }}{{ end }}
+    {{- with $kc.cpuManagerPolicy }}{{ if ne . "none" }}{{ $parts = $parts | append (printf "cpuManager:%s" .) }}{{ end }}{{ end }}
+    {{- with $kc.memoryManagerPolicy }}{{ if ne . "None" }}{{ $parts = $parts | append (printf "memoryManager:%s" .) }}{{ end }}{{ end }}
+    {{- with $kc.topologyManagerPolicy }}{{ if ne . "none" }}{{ $parts = $parts | append (printf "topologyManager:%s" .) }}{{ end }}{{ end }}
     {{- with $kc.shutdownGracePeriod }}
         {{- if ne . "0s" }}
             {{- $grace := printf "shutdownGracePeriod:%s" . }}
             {{- with $kc.shutdownGracePeriodCriticalPods }}{{ $grace = printf "%s/%s(critical)" $grace . }}{{ end }}
-            {{- $parts = append $parts $grace }}
+            {{- $parts = $parts | append $grace }}
         {{- end }}
     {{- end }}
     {{- with $kc.containerLogMaxSize }}
         {{- $retained := mulf (. | quantityToFloat64) $kc.containerLogMaxFiles }}
-        {{- $parts = append $parts (printf "container logs: retains up to %s per container (%s x %s files)" ($retained | humanizeSI "B") . ($kc.containerLogMaxFiles | toString)) }}
+        {{- $parts = $parts | append (printf "container logs: retains up to %s per container (%s x %s files)" ($retained | humanizeSI "B") . ($kc.containerLogMaxFiles | toString)) }}
     {{- end }}
     {{- with $parts }}{{ "kubelet" | nindent 2 }} {{ join ", " . }}{{ end }}
 {{- end -}}
@@ -222,7 +222,7 @@
                 {{- end }}
             {{- end }}
             {{- if $podHasMetrics }}
-                {{- $podUsageRows = append $podUsageRows (dict "ref" ($r.Include "resource_ref" (dict "kind" $pod.Kind "name" $pod.Name "namespace" $pod.Namespace))
+                {{- $podUsageRows = $podUsageRows | append (dict "ref" ($r.Include "resource_ref" (dict "kind" $pod.Kind "name" $pod.Name "namespace" $pod.Namespace))
                     "cpuUsage" $podCpuUsage "cpuReq" $podCpuReq "cpuLim" $podCpuLim
                     "memUsage" $podMemUsage "memReq" $podMemReq "memLim" $podMemLim) }}
             {{- end }}
@@ -234,7 +234,7 @@
                 {{- $restarts = $restarts | add ($cs.restartCount | int) }}
             {{- end }}
             {{- if or (ne $pod.Status.phase "Running") (lt $readyContainers $totalContainers) (gt $restarts 0) }}
-                {{- $podsNeedingAttention = append $podsNeedingAttention (dict "key" (printf "%s/%s" $pod.Namespace $pod.Name) "pod" $pod) }}
+                {{- $podsNeedingAttention = $podsNeedingAttention | append (dict "key" (printf "%s/%s" $pod.Namespace $pod.Name) "pod" $pod) }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/NodePool.tmpl
+++ b/pkg/plugin/templates/NodePool.tmpl
@@ -16,7 +16,7 @@
     {{- $relevantKeys := list "node.kubernetes.io/instance-type" "karpenter.k8s.aws/instance-category" "karpenter.k8s.aws/instance-family" "topology.kubernetes.io/zone" "kubernetes.io/arch" "kubernetes.io/os" "karpenter.sh/capacity-type" }}
     {{- $requirements := list }}
     {{- range .Spec.template.spec.requirements }}
-        {{- if has .key $relevantKeys }}{{ $requirements = append $requirements . }}{{ end }}
+        {{- if has .key $relevantKeys }}{{ $requirements = $requirements | append . }}{{ end }}
     {{- end }}
     {{- with $requirements }}
         {{- "Requirements" | bold | nindent 2 }}:
@@ -43,8 +43,8 @@
     {{- $resources := (.Status | default dict).resources }}
     {{- if or (and (kindIs "map" $limits) $limits) (and (kindIs "map" $resources) $resources) }}
         {{- $keys := list }}
-        {{- range keys ($limits | default dict) }}{{ if not (has . $keys) }}{{ $keys = append $keys . }}{{ end }}{{ end }}
-        {{- range keys ($resources | default dict) }}{{ if not (has . $keys) }}{{ $keys = append $keys . }}{{ end }}{{ end }}
+        {{- range keys ($limits | default dict) }}{{ if not (has . $keys) }}{{ $keys = $keys | append . }}{{ end }}{{ end }}
+        {{- range keys ($resources | default dict) }}{{ if not (has . $keys) }}{{ $keys = $keys | append . }}{{ end }}{{ end }}
         {{- "Resources" | bold | nindent 2 }}: (current/limit)
         {{- range ($keys | sortAlpha) }}
             {{- $key := . }}

--- a/pkg/plugin/templates/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/PersistentVolumeClaim.tmpl
@@ -25,7 +25,7 @@
         {{- range $pod.Spec.volumes | default list }}
             {{- if and (. | hasKey "persistentVolumeClaim") (eq .persistentVolumeClaim.claimName $pvcName) }}
                 {{- if not $added }}
-                    {{- $usingPods = append $usingPods $pod }}
+                    {{- $usingPods = $usingPods | append $pod }}
                     {{- $added = true }}
                 {{- end }}
                 {{- if not ($volStats | hasKey "usedBytes") }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -43,7 +43,7 @@
                     {{- $podPullSecretsBroken = true }}
                     {{- if not ($missingPullSecrets | has $secretName) }}
                         {{- "Secret" | bold | nindent 2 }}/{{ $secretName }} {{ "doesn't exist" | red | bold }}, but it's referenced in Pod's imagePullSecrets.
-                        {{- $missingPullSecrets = append $missingPullSecrets $secretName }}
+                        {{- $missingPullSecrets = $missingPullSecrets | append $secretName }}
                     {{- end }}
                 {{- else if not (has $secret.Object.type (list "kubernetes.io/dockerconfigjson" "kubernetes.io/dockercfg")) }}
                     {{- $podPullSecretsBroken = true }}
@@ -116,7 +116,7 @@
             {{- if $nodePools }}
                 {{- $nodePoolReqSets := list }}
                 {{- range $nodePools }}
-                    {{- $nodePoolReqSets = append $nodePoolReqSets (dict "name" .Name "requirements" (.Spec.template.spec.requirements | default list)) }}
+                    {{- $nodePoolReqSets = $nodePoolReqSets | append (dict "name" .Name "requirements" (.Spec.template.spec.requirements | default list)) }}
                 {{- end }}
                 {{- $unsatisfiableKeys := karpenterUnsatisfiableKeys $podRequirements $nodePoolReqSets }}
                 {{- if $unsatisfiableKeys }}
@@ -187,7 +187,7 @@
                            same as conditions_summary in common.tmpl -- flagging the Node as
                            problematic over one would be a false alarm. */ -}}
                     {{- if and (or .type .reason .message) (not (isStatusConditionHealthy .)) }}
-                        {{- $unhealthy = append $unhealthy . }}
+                        {{- $unhealthy = $unhealthy | append . }}
                         {{- if and (eq .type "MemoryPressure") (eq .status "True") }}
                             {{- $memoryPressure = true }}
                         {{- end }}
@@ -346,10 +346,10 @@
         {{- if $pc.Object }}
             {{- $parts := list (printf "value: %s" ($pc.Object.value | toString | cyan)) }}
             {{- if $pc.Object.globalDefault }}
-                {{- $parts = append $parts "global default" }}
+                {{- $parts = $parts | append "global default" }}
             {{- end }}
             {{- if ne ($pc.Object.preemptionPolicy | default "PreemptLowerPriority") "PreemptLowerPriority" }}
-                {{- $parts = append $parts (printf "preemptionPolicy: %s" ($pc.Object.preemptionPolicy | colorKeyword)) }}
+                {{- $parts = $parts | append (printf "preemptionPolicy: %s" ($pc.Object.preemptionPolicy | colorKeyword)) }}
             {{- end }}
             {{- "Priority:" | bold | nindent 2 }} {{ template "resource_ref" (dict "kind" "PriorityClass" "name" .) }} ({{ join ", " $parts }})
         {{- end }}
@@ -372,11 +372,11 @@
                 {{- range $name := keys $podFixed | sortAlpha }}
                     {{- $qty := index $podFixed $name }}
                     {{- if eq $name "cpu" }}
-                        {{- $parts = append $parts (printf "cpu: %s" ($qty | quantityToFloat64 | printf "%.1g" | cyan)) }}
+                        {{- $parts = $parts | append (printf "cpu: %s" ($qty | quantityToFloat64 | printf "%.1g" | cyan)) }}
                     {{- else if eq $name "memory" }}
-                        {{- $parts = append $parts (printf "memory: %s" ($qty | quantityToFloat64 | humanizeSI "B" | cyan)) }}
+                        {{- $parts = $parts | append (printf "memory: %s" ($qty | quantityToFloat64 | humanizeSI "B" | cyan)) }}
                     {{- else }}
-                        {{- $parts = append $parts (printf "%s: %s" $name ($qty | toString | cyan)) }}
+                        {{- $parts = $parts | append (printf "%s: %s" $name ($qty | toString | cyan)) }}
                     {{- end }}
                 {{- end }}
                 {{- "Overhead:" | bold | nindent 2 }} {{ template "resource_ref" (dict "kind" "RuntimeClass" "name" .) }} ({{ join ", " $parts }})
@@ -482,7 +482,7 @@
         {{- $missingKeys := list }}
         {{- range $.items }}
             {{- if not ($keys | has .key) }}
-                {{- $missingKeys = append $missingKeys (.key | quote) }}
+                {{- $missingKeys = $missingKeys | append (.key | quote) }}
             {{- end }}
         {{- end }}
         {{- with $missingKeys }}
@@ -522,17 +522,17 @@
     {{- range $.Spec.volumes }}
         {{- $vol := . }}
         {{- if or (. | hasKey "persistentVolumeClaim") (. | hasKey "hostPath") (. | hasKey "nfs") (. | hasKey "csi") }}
-            {{- $displayVols = append $displayVols . }}
+            {{- $displayVols = $displayVols | append . }}
         {{- else if . | hasKey "emptyDir" }}
             {{- /* show emptyDir only if kubelet has stats for it */ -}}
             {{- with $podStatsSummary.volume | default list | getMatchingItemInMapList (dict "name" $vol.name) }}
-                {{- $displayVols = append $displayVols $vol }}
+                {{- $displayVols = $displayVols | append $vol }}
             {{- end }}
         {{- else if $volProblems | hasKey $vol.name }}
             {{- /* a broken configMap/secret volume must surface even without --include-all-volumes */ -}}
-            {{- $displayVols = append $displayVols . }}
+            {{- $displayVols = $displayVols | append . }}
         {{- else if $.Config.GetBool "include-all-volumes" }}
-            {{- $displayVols = append $displayVols . }}
+            {{- $displayVols = $displayVols | append . }}
         {{- end }}
     {{- end }}
     {{- $deep := $.Config.GetBool "deep" }}
@@ -544,7 +544,7 @@
     {{- $entries := list }}
     {{- if $showEphemeral }}
         {{- $pct := percent (index $ephemeralStorage "usedBytes" | float64) (index $ephemeralStorage "capacityBytes" | float64) }}
-        {{- $entries = append $entries (printf "%s (%s/%s[%s])" ("ephemeral-storage" | bold) (index $ephemeralStorage "usedBytes" | float64 | humanizeSI "B") (index $ephemeralStorage "capacityBytes" | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%")) }}
+        {{- $entries = $entries | append (printf "%s (%s/%s[%s])" ("ephemeral-storage" | bold) (index $ephemeralStorage "usedBytes" | float64 | humanizeSI "B") (index $ephemeralStorage "capacityBytes" | float64 | humanizeSI "B") ($pct | colorPercent "%.0f%%")) }}
     {{- end }}
     {{- range $displayVols }}
         {{- $entry := $.Include "pod_volume_line" (dict "ctx" $ "vol" . "podStatsSummary" $podStatsSummary "problem" (index $volProblems .name)) }}
@@ -554,7 +554,7 @@
                 {{- $entry = printf "%s%s" $entry ($.Include "PersistentVolumeClaim" $pvc | nindent 2) }}
             {{- end }}
         {{- end }}
-        {{- $entries = append $entries $entry }}
+        {{- $entries = $entries | append $entry }}
     {{- end }}
     {{- if $entries }}
         {{- if eq (len $entries) 1 }}
@@ -943,10 +943,10 @@
     {{- with .tcpSocket }}{{ "tcpSocket" | bold }} {{ printf "%s:%v" (.host | default "localhost") .port | cyan }}{{ end -}}
     {{- with .grpc }}{{ "grpc" | bold }} {{ printf ":%v" .port | cyan }}{{ with .service }} {{ . | cyan }}{{ end }}{{ end -}}
     {{- $parts := list -}}
-    {{- with .initialDelaySeconds }}{{ $parts = append $parts (printf "delay %ds" (. | int)) }}{{ end -}}
-    {{- with .periodSeconds }}{{ $parts = append $parts (printf "every %ds" (. | int)) }}{{ end -}}
-    {{- with .timeoutSeconds }}{{ $parts = append $parts (printf "timeout %ds" (. | int)) }}{{ end -}}
-    {{- with .failureThreshold }}{{ $parts = append $parts (printf "fail after %dx" (. | int)) }}{{ end -}}
+    {{- with .initialDelaySeconds }}{{ $parts = $parts | append (printf "delay %ds" (. | int)) }}{{ end -}}
+    {{- with .periodSeconds }}{{ $parts = $parts | append (printf "every %ds" (. | int)) }}{{ end -}}
+    {{- with .timeoutSeconds }}{{ $parts = $parts | append (printf "timeout %ds" (. | int)) }}{{ end -}}
+    {{- with .failureThreshold }}{{ $parts = $parts | append (printf "fail after %dx" (. | int)) }}{{ end -}}
     {{- if $parts }} ({{ join ", " $parts }}){{ end -}}
 {{- end -}}
 

--- a/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
+++ b/pkg/plugin/templates/PriorityLevelConfiguration.tmpl
@@ -47,7 +47,7 @@
                 {{- end }}
             {{- end }}
             {{- if eq $fsPlcName $plcName }}
-                {{- $schemas = append $schemas . }}
+                {{- $schemas = $schemas | append . }}
             {{- end }}
         {{- end }}
         {{- with $schemas }}

--- a/pkg/plugin/templates/ResourceQuota.tmpl
+++ b/pkg/plugin/templates/ResourceQuota.tmpl
@@ -33,7 +33,7 @@
                 {{- $valStr = printf "%s/%s" ($usedVal | printf "%g") ($hardVal | printf "%g") }}
             {{- end }}
             {{- if gt $hardVal 0.0 }}{{- $valStr = printf "%s[%s]" $valStr (percent $usedVal $hardVal | colorPercent "%.0f%%") }}{{- end }}
-            {{- $lines = append $lines (printf "%s: %s" $key $valStr) }}
+            {{- $lines = $lines | append (printf "%s: %s" $key $valStr) }}
         {{- end }}
         {{- if eq (len $lines) 1 }}
             {{- "Quota" | bold | nindent 2 }}: {{ index $lines 0 }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -150,7 +150,7 @@
                 {{- end }}
             {{- end }}
             {{- if $inner }}{{- $entry = printf "%s (%s)" $entry $inner }}{{- end }}
-            {{- $entries = append $entries $entry }}
+            {{- $entries = $entries | append $entry }}
         {{- end }}
         {{- "Volume Claims:" | nindent 2 }} {{ join ", " $entries }}
     {{- end }}
@@ -162,7 +162,7 @@
     {{- range .KubeGetByLabelsMap .Namespace "controllerrevisions" .Labels }}
         {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
         {{- if eq (index .Metadata.ownerReferences 0).name $.Name }}
-            {{- $revisions = append $revisions . }}
+            {{- $revisions = $revisions | append . }}
         {{- end }}
     {{- end }}
     {{- /* creationTimestamp only has second resolution, so ControllerRevisions created within the

--- a/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/VerticalPodAutoscaler.tmpl
@@ -27,10 +27,10 @@
             {{- if eq $mode "Off" }} {{ "Off" | yellow | bold }}
             {{- else }}
                 {{- $parts := list }}
-                {{- with (.minAllowed | default dict).cpu }}{{ $parts = append $parts (printf "min cpu=%s" .) }}{{ end }}
-                {{- with (.minAllowed | default dict).memory }}{{ $parts = append $parts (printf "min mem=%s" .) }}{{ end }}
-                {{- with (.maxAllowed | default dict).cpu }}{{ $parts = append $parts (printf "max cpu=%s" .) }}{{ end }}
-                {{- with (.maxAllowed | default dict).memory }}{{ $parts = append $parts (printf "max mem=%s" .) }}{{ end }}
+                {{- with (.minAllowed | default dict).cpu }}{{ $parts = $parts | append (printf "min cpu=%s" .) }}{{ end }}
+                {{- with (.minAllowed | default dict).memory }}{{ $parts = $parts | append (printf "min mem=%s" .) }}{{ end }}
+                {{- with (.maxAllowed | default dict).cpu }}{{ $parts = $parts | append (printf "max cpu=%s" .) }}{{ end }}
+                {{- with (.maxAllowed | default dict).memory }}{{ $parts = $parts | append (printf "max mem=%s" .) }}{{ end }}
                 {{- " " }}{{ $parts | join ", " | cyan }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates/VirtualService.tmpl
+++ b/pkg/plugin/templates/VirtualService.tmpl
@@ -235,7 +235,7 @@
             {{- $subset := $dest.subset | toString }}
             {{- $namespaces := list $ctx.Namespace }}
             {{- if and $ref.InCluster (ne $ref.Namespace $ctx.Namespace) }}
-                {{- $namespaces = append $namespaces $ref.Namespace }}
+                {{- $namespaces = $namespaces | append $ref.Namespace }}
             {{- end }}
             {{- $pairedName := "" }}
             {{- $pairedNamespace := "" }}
@@ -318,7 +318,7 @@
     {{- with $sourceLabels }}
         {{- if $needsComma }}, {{ end }}{{ "from " }}
         {{- $pairs := list }}
-        {{- range $name := keys . | sortAlpha }}{{ $pairs = append $pairs (printf "%s=%v" $name (index $sourceLabels $name)) }}{{ end }}
+        {{- range $name := keys . | sortAlpha }}{{ $pairs = $pairs | append (printf "%s=%v" $name (index $sourceLabels $name)) }}{{ end }}
         {{- join "," $pairs | cyan }}{{ $needsComma = true }}
     {{- end }}
     {{- with .sourceNamespace }}{{ if $needsComma }}, {{ end }}from namespace {{ . | toString | cyan }}{{ $needsComma = true }}{{ end }}

--- a/pkg/plugin/templates/VolumeSnapshot.tmpl
+++ b/pkg/plugin/templates/VolumeSnapshot.tmpl
@@ -31,7 +31,7 @@
     {{- range $.KubeGet $.Namespace "persistentvolumeclaims" }}
         {{- $ref := .Spec.dataSourceRef | default .Spec.dataSource }}
         {{- if and (kindIs "map" $ref) (eq $ref.kind "VolumeSnapshot") (eq $ref.name $.Name) }}
-            {{- $restoringPVCs = append $restoringPVCs . }}
+            {{- $restoringPVCs = $restoringPVCs | append . }}
         {{- end }}
     {{- end }}
     {{- if $restoringPVCs }}

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -67,7 +67,7 @@
            quota is the workload's own, or that free quota means the Pods will schedule. */ -}}
     {{- $quotaObjects := list }}
     {{- range .KubeGet .Namespace "resourcequotas" }}
-        {{- $quotaObjects = append $quotaObjects .Object }}
+        {{- $quotaObjects = $quotaObjects | append .Object }}
     {{- end }}
     {{- with $quotaObjects }}
         {{- $headroom := quotaRolloutHeadroom . $.Object }}
@@ -223,7 +223,7 @@
         {{- $matching := list }}
         {{- range $ctx.KubeGet "" "VolumeAttachment" }}
             {{- if eq (.Spec.source.persistentVolumeName | default "") $pvName }}
-                {{- $matching = append $matching . }}
+                {{- $matching = $matching | append . }}
             {{- end }}
         {{- end }}
         {{- $attachedCount := 0 }}
@@ -277,9 +277,9 @@
         {{- range .pods }}
             {{- if not (has .Status.phase (list "Succeeded" "Failed")) }}
                 {{- if .Spec.nodeName }}
-                    {{- $scheduled = append $scheduled . }}
+                    {{- $scheduled = $scheduled | append . }}
                 {{- else }}
-                    {{- $pending = append $pending . }}
+                    {{- $pending = $pending | append . }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -518,7 +518,7 @@
     {{- if kindIs "slice" $refs }}
         {{- range $refs }}
             {{- if and (kindIs "map" .) (kindIs "string" .kind) (kindIs "string" .name) }}
-                {{- $validRefs = append $validRefs . }}
+                {{- $validRefs = $validRefs | append . }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -697,7 +697,7 @@
         {{- if .ready }}{{ $ready = add1 $ready }}{{ end }}
         {{- $restarts = $restarts | add (.restartCount | int) }}
         {{- with .state.waiting.reason }}
-            {{- if not ($waitingReasons | has .) }}{{ $waitingReasons = append $waitingReasons . }}{{ end }}
+            {{- if not ($waitingReasons | has .) }}{{ $waitingReasons = $waitingReasons | append . }}{{ end }}
         {{- end }}
     {{- end }}
     {{- if $total }}, {{ if lt $ready $total }}{{ printf "%d/%d" $ready $total | red | bold }}{{ else }}{{ printf "%d/%d" $ready $total | green }}{{ end }} ready{{ end }}
@@ -727,7 +727,7 @@
         {{- $node := .KubeGetFirst "" "Node" $nodeName }}
         {{- if $node.Object }}
             {{- $nodeFlags := list }}
-            {{- if $node.Spec.unschedulable }}{{ $nodeFlags = append $nodeFlags ("cordoned" | red | bold) }}{{ end }}
+            {{- if $node.Spec.unschedulable }}{{ $nodeFlags = $nodeFlags | append ("cordoned" | red | bold) }}{{ end }}
             {{- range $node.StatusConditions }}
                 {{- /* Typeless placeholder entries carry no information to report and would
                        render as a meaningless ":False" flag, so they're skipped here; this whole
@@ -740,18 +740,18 @@
                            "confirmed bad" label, see #173. */ -}}
                     {{- $entry := printf "%s:%s" .type (.status | toString) }}
                     {{- if eq .status "Unknown" }}
-                        {{- $nodeFlags = append $nodeFlags ($entry | yellow | bold) }}
+                        {{- $nodeFlags = $nodeFlags | append ($entry | yellow | bold) }}
                     {{- else }}
-                        {{- $nodeFlags = append $nodeFlags ($entry | red | bold) }}
+                        {{- $nodeFlags = $nodeFlags | append ($entry | red | bold) }}
                     {{- end }}
                 {{- end }}
             {{- end }}
             {{- $flags := list }}
             {{- with $nodeFlags }}
-                {{- $flags = append $flags (printf "node %s" (join " & " .)) }}
+                {{- $flags = $flags | append (printf "node %s" (join " & " .)) }}
             {{- end }}
             {{- if taintsNotToleratedByPod ($node.Spec.taints | default list) (.Spec.tolerations | default list) }}
-                {{- $flags = append $flags ("untolerated node taint" | red | bold) }}
+                {{- $flags = $flags | append ("untolerated node taint" | red | bold) }}
             {{- end }}
             {{- join ", " $flags }}
         {{- end }}
@@ -767,14 +767,14 @@
     {{- $names := list }}
     {{- $ingress := false }}{{- $egress := false }}
     {{- range . }}
-        {{- $names = append $names .Name }}
+        {{- $names = $names | append .Name }}
         {{- $types := networkPolicyPolicyTypes .Spec }}
         {{- if has "Ingress" $types }}{{ $ingress = true }}{{ end }}
         {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
     {{- end }}
     {{- $directions := list }}
-    {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-    {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
+    {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+    {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
     {{- $label := "NetworkPolicy" }}{{ if gt (len .) 1 }}{{ $label = "NetworkPolicies" }}{{ end }}
     {{- printf "selected by %s %s (%s restricted)" $label (join ", " $names | cyan) (join ", " $directions) }}
 {{- end }}
@@ -798,9 +798,9 @@
                 {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
             {{- end }}
             {{- $directions := list }}
-            {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-            {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
-            {{- $flags = append $flags (printf "netpol: %s restricted" (join "+" $directions)) }}
+            {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+            {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
+            {{- $flags = $flags | append (printf "netpol: %s restricted" (join "+" $directions)) }}
         {{- end }}
         {{- $ciliumPolicies := concat (.KubeGetCiliumNetworkPoliciesMatchingPod .Namespace .Labels) (.KubeGetCiliumClusterwideNetworkPoliciesMatchingPod .Labels) }}
         {{- if $ciliumPolicies }}
@@ -811,9 +811,9 @@
                 {{- if has "egress" $directions }}{{ $egress = true }}{{ end }}
             {{- end }}
             {{- $directions := list }}
-            {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-            {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
-            {{- if $directions }}{{ $flags = append $flags (printf "cnp: %s restricted" (join "+" $directions)) }}{{ end }}
+            {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+            {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
+            {{- if $directions }}{{ $flags = $flags | append (printf "cnp: %s restricted" (join "+" $directions)) }}{{ end }}
         {{- end }}
         {{- $calicoPolicies := concat (.KubeGetCalicoNetworkPoliciesMatchingPod .Namespace .Labels) (.KubeGetCalicoGlobalNetworkPoliciesMatchingPod .Namespace .Labels) }}
         {{- if $calicoPolicies }}
@@ -824,9 +824,9 @@
                 {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
             {{- end }}
             {{- $directions := list }}
-            {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-            {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
-            {{- $flags = append $flags (printf "calico: %s restricted" (join "+" $directions)) }}
+            {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+            {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
+            {{- $flags = $flags | append (printf "calico: %s restricted" (join "+" $directions)) }}
         {{- end }}
         {{- join ", " $flags }}
     {{- end }}
@@ -841,14 +841,14 @@
     {{- $names := list }}
     {{- $ingress := false }}{{- $egress := false }}
     {{- range .policies }}
-        {{- $names = append $names .Name }}
+        {{- $names = $names | append .Name }}
         {{- $directions := ciliumPolicyDirections .Object $.labels }}
         {{- if has "ingress" $directions }}{{ $ingress = true }}{{ end }}
         {{- if has "egress" $directions }}{{ $egress = true }}{{ end }}
     {{- end }}
     {{- $directions := list }}
-    {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-    {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
+    {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+    {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
     {{- $label := .kindSingular }}{{ if gt (len .policies) 1 }}{{ $label = .kindPlural }}{{ end }}
     {{- if $directions }}
         {{- printf "selected by %s %s (%s restricted)" $label (join ", " $names | cyan) (join ", " $directions) }}
@@ -868,14 +868,14 @@
     {{- $names := list }}
     {{- $ingress := false }}{{- $egress := false }}
     {{- range .policies }}
-        {{- $names = append $names .Name }}
+        {{- $names = $names | append .Name }}
         {{- $types := calicoPolicyTypes .Spec }}
         {{- if has "Ingress" $types }}{{ $ingress = true }}{{ end }}
         {{- if has "Egress" $types }}{{ $egress = true }}{{ end }}
     {{- end }}
     {{- $directions := list }}
-    {{- if $ingress }}{{ $directions = append $directions "ingress" }}{{ end }}
-    {{- if $egress }}{{ $directions = append $directions "egress" }}{{ end }}
+    {{- if $ingress }}{{ $directions = $directions | append "ingress" }}{{ end }}
+    {{- if $egress }}{{ $directions = $directions | append "egress" }}{{ end }}
     {{- $label := .kindSingular }}{{ if gt (len .policies) 1 }}{{ $label = .kindPlural }}{{ end }}
     {{- printf "selected by %s %s (%s restricted)" $label (join ", " $names | cyan) (join ", " $directions) }}
 {{- end }}
@@ -1169,7 +1169,7 @@
         {{- range $ctx.KubeGet $namespace "HorizontalPodAutoscalers" }}
             {{- $ref := .Spec.scaleTargetRef | default dict }}
             {{- if and (eq (index $ref "kind" | default "") $kind) (eq (index $ref "name" | default "") $name) }}
-                {{- $hpas = append $hpas . }}
+                {{- $hpas = $hpas | append . }}
             {{- end }}
         {{- end }}
         {{- if $hpas }}
@@ -1219,7 +1219,7 @@
         {{- range $ctx.KubeGet $namespace "VerticalPodAutoscalers" }}
             {{- $ref := .Spec.targetRef | default dict }}
             {{- if and (eq (index $ref "kind" | default "") $kind) (eq (index $ref "name" | default "") $name) }}
-                {{- $vpas = append $vpas . }}
+                {{- $vpas = $vpas | append . }}
             {{- end }}
         {{- end }}
         {{- if $vpas }}

--- a/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/gatekeeper_constraint_common.tmpl
@@ -55,7 +55,7 @@
         {{- range . }}
             {{- $action := .action | default "deny" }}
             {{- $points := list }}
-            {{- range .enforcementPoints }}{{ $points = append $points .name }}{{ end }}
+            {{- range .enforcementPoints }}{{ $points = $points | append .name }}{{ end }}
             {{- "" | nindent 4 }}{{ $action | redBoldIf (ne $action "deny") }} at {{ $points | join "," | cyan }}
         {{- end }}
     {{- end }}
@@ -91,12 +91,12 @@
             {{- range $violations }}
                 {{- $key := printf "%s/%s/%s" .kind (.namespace | default "") .name }}
                 {{- if not ($byTarget | hasKey $key) }}
-                    {{- $order = append $order $key }}
+                    {{- $order = $order | append $key }}
                     {{- $_ := $byTarget | set $key (dict "kind" .kind "namespace" .namespace "name" .name "messages" list "actions" list) }}
                 {{- end }}
                 {{- $entry := index $byTarget $key }}
-                {{- $_ := $entry | set "messages" (append $entry.messages .message) }}
-                {{- with .enforcementAction }}{{ $_ := $entry | set "actions" (append $entry.actions .) }}{{ end }}
+                {{- $_ := $entry | set "messages" ($entry.messages | append .message) }}
+                {{- with .enforcementAction }}{{ $_ := $entry | set "actions" ($entry.actions | append .) }}{{ end }}
             {{- end }}
             {{- $shownRaw := 0 }}
             {{- range $i, $key := $order }}

--- a/pkg/plugin/templates/policy_report_common.tmpl
+++ b/pkg/plugin/templates/policy_report_common.tmpl
@@ -95,12 +95,12 @@
             {{- $rule := $r.rule | default "" }}
             {{- $key := printf "%s/%s" $policy $rule }}
             {{- if not ($byKey | hasKey $key) }}
-                {{- $order = append $order $key }}
+                {{- $order = $order | append $key }}
                 {{- $_ := $byKey | set $key (dict "policy" $policy "rule" $rule "messages" list "resourceRef" "" "resourceKeys" list "isError" false "severe" false) }}
             {{- end }}
             {{- $entry := index $byKey $key }}
             {{- with $r.message }}
-                {{- if not (has . $entry.messages) }}{{ $_ := $entry | set "messages" (append $entry.messages .) }}{{ end }}
+                {{- if not (has . $entry.messages) }}{{ $_ := $entry | set "messages" ($entry.messages | append .) }}{{ end }}
             {{- end }}
             {{- if eq ($r.result | default "") "error" }}{{ $_ := $entry | set "isError" true }}{{ end }}
             {{- if has ($r.severity | default "") (list "critical" "high") }}{{ $_ := $entry | set "severe" true }}{{ end }}
@@ -108,7 +108,7 @@
                 {{- $resKey := printf "%s/%s/%s" (.kind | default "") (.namespace | default "") (.name | default "") }}
                 {{- if or (not $scopeKey) (ne $resKey $scopeKey) }}
                     {{- if not (has $resKey $entry.resourceKeys) }}
-                        {{- $_ := $entry | set "resourceKeys" (append $entry.resourceKeys $resKey) }}
+                        {{- $_ := $entry | set "resourceKeys" ($entry.resourceKeys | append $resKey) }}
                         {{- if not $entry.resourceRef }}
                             {{- $_ := $entry | set "resourceRef" ($ctx.Include "resource_ref" (dict "kind" (.kind | default "") "name" (.name | default "") "namespace" .namespace "callerNamespace" $ctx.Namespace)) }}
                         {{- end }}


### PR DESCRIPTION
Part of #688 this PR covers only the append function migration
Per the 5-small-PRs approach you suggested in the issue.

This PR covers only the append function migration.
This is PR 3 of 5:

get ✓
hasKey ✓
append ✓
set
float64 → toFloat64

## Change

Converted all genuine old-order `append $list $v` calls to the new
sprout pipe order `$list | append $v`. Pure argument-order swap, no
logic changes.

119 genuine call sites converted across 27 template files (several
lines contain more than one `append` call, which is why this exceeds
the file count):

common.tmpl (31), Pod.tmpl (19), HelmRelease.tmpl (12),
LimitRange.tmpl (6), Node.tmpl (9), Ingress.tmpl (4),
VerticalPodAutoscaler.tmpl (4), gatekeeper_constraint_common.tmpl (4),
FlowSchema.tmpl (3), Namespace.tmpl (3), NodePool.tmpl (3),
policy_report_common.tmpl (3), Certificate.tmpl (3),
Kustomization.tmpl, Issuer.tmpl, VirtualService.tmpl, Job.tmpl,
StatefulSet.tmpl (2 each), and one each in CronJob.tmpl,
Deployment.tmpl, PersistentVolumeClaim.tmpl,
PriorityLevelConfiguration.tmpl, DaemonSet.tmpl, ResourceQuota.tmpl,
CustomResourceDefinition.tmpl, VolumeSnapshot.tmpl,
DestinationRule.tmpl.

Also includes a one-line fix to CONVENTIONS.md (lines 73-76), updating
a leftover old-style `hasKey` example that was missed by #799 (the
`hasKey` PR) since CONVENTIONS.md isn't a `.tmpl` file and wasn't
covered by that session's template scan. Unrelated to the `append`
migration itself, but small enough not to warrant its own PR.

## Verification

- `go build ./...`
- `make test`
- Confirmed via go-sprout's actual shim source
  (registry/slices/functions.go) how old-vs-new call order is detected
  for `append`, then manually checked every converted call site to
  confirm none appends a slice-kind value (all are strings, scalars,
  or maps).
- Manually confirmed via `-v 3` that the `function=append
  notice=deprecated` warning no longer fires for converted call sites,
  by temporarily disabling the deprecation filter in render_engine.go
  and reverting afterward. Other not-yet-migrated functions still fire
  as expected.