### PR TITLE
Migrate set template calls off deprecated sprig-compat signature (#688)

### DIFF
--- a/pkg/plugin/templates/Deployment.tmpl
+++ b/pkg/plugin/templates/Deployment.tmpl
@@ -7,11 +7,11 @@
     {{- template "observed_generation_summary" . }}
     {{- template "application_details" . }}
     {{- $injectedStatus := .Status | default dict }}
-    {{- $_ := set $injectedStatus "replicas" ( $injectedStatus.replicas | default 0 ) }}
-    {{- $_ := set $injectedStatus "readyReplicas" ( $injectedStatus.readyReplicas | default 0) }}
-    {{- $_ := set $injectedStatus "availableReplicas" ( $injectedStatus.availableReplicas | default 0 ) }}
-    {{- $_ := set $injectedStatus "updatedReplicas" ( $injectedStatus.updatedReplicas | default 0 ) }}
-    {{- $_ := set .Object "status" $injectedStatus }}
+    {{- $_ := $injectedStatus | set "replicas" ( $injectedStatus.replicas | default 0 ) }}
+    {{- $_ := $injectedStatus | set "readyReplicas" ( $injectedStatus.readyReplicas | default 0) }}
+    {{- $_ := $injectedStatus | set "availableReplicas" ( $injectedStatus.availableReplicas | default 0 ) }}
+    {{- $_ := $injectedStatus | set "updatedReplicas" ( $injectedStatus.updatedReplicas | default 0 ) }}
+    {{- $_ := .Object | set "status" $injectedStatus }}
     {{- template "replicas_status" . }}
     {{- with .Spec.strategy }}{{ if ne (.type | default "RollingUpdate") "RollingUpdate" }}
         {{- "Strategy" | bold | nindent 2 }}: {{ .type | yellow }}

--- a/pkg/plugin/templates/Kustomization.tmpl
+++ b/pkg/plugin/templates/Kustomization.tmpl
@@ -52,7 +52,7 @@
             {{- /* An id that doesn't split into four is bucketed rather than counted under its own
                    text, which would otherwise put the whole malformed id in the kind summary. */ -}}
             {{- $kind := ternary (last $parts) "unparsable" (eq (len $parts) 4) }}
-            {{- $_ := set $countsByKind $kind (add1 (int ($countsByKind | get $kind))) }}
+            {{- $_ := $countsByKind | set $kind (add1 (int ($countsByKind | get $kind))) }}
             {{- $ids = $ids | append (.id | default "" | toString) }}
         {{- end }}
         {{- $kindSummaries := list }}

--- a/pkg/plugin/templates/Pod.tmpl
+++ b/pkg/plugin/templates/Pod.tmpl
@@ -509,11 +509,11 @@
             {{- if . | hasKey "configMap" }}
                 {{- $cm := .configMap }}
                 {{- $problem := $.Include "pod_volume_configmap_secret_problem" (dict "kind" "ConfigMap" "ctx" $ "name" $cm.name "optional" ($cm.optional | default false) "items" ($cm.items | default list)) }}
-                {{- if $problem }}{{ $volProblems = set $volProblems .name $problem }}{{ end }}
+                {{- if $problem }}{{ $volProblems = $volProblems | set .name $problem }}{{ end }}
             {{- else if . | hasKey "secret" }}
                 {{- $sec := .secret }}
                 {{- $problem := $.Include "pod_volume_configmap_secret_problem" (dict "kind" "Secret" "ctx" $ "name" $sec.secretName "optional" ($sec.optional | default false) "items" ($sec.items | default list)) }}
-                {{- if $problem }}{{ $volProblems = set $volProblems .name $problem }}{{ end }}
+                {{- if $problem }}{{ $volProblems = $volProblems | set .name $problem }}{{ end }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/ReplicaSet.tmpl
@@ -13,12 +13,12 @@
            and apparantly the numbers are parsed as float 64, so used 0.0 rather then 0 */ -}}
     {{- $injectedStatus := .Status }}
     {{- if not (.Status | hasKey "readyReplicas") }}
-        {{- $injectedStatus := set $injectedStatus "readyReplicas" 0.0 }}
+        {{- $injectedStatus := $injectedStatus | set "readyReplicas" 0.0 }}
     {{- end }}
     {{- if not (.Status | hasKey "availableReplicas") }}
-        {{- $injectedStatus := set $injectedStatus "availableReplicas" 0.0 }}
+        {{- $injectedStatus := $injectedStatus | set "availableReplicas" 0.0 }}
     {{- end }}
-    {{- $injectedManifest := set .Object "status" $injectedStatus }}
+    {{- $injectedManifest := .Object | set "status" $injectedStatus }}
     {{- template "replicas_status" $injectedManifest }}
     {{- template "conditions_summary" . }}
     {{- if and .Spec.replicas (or (not .Status.replicas) (not .Status.readyReplicas)) }}

--- a/pkg/plugin/templates/StatefulSet.tmpl
+++ b/pkg/plugin/templates/StatefulSet.tmpl
@@ -12,9 +12,9 @@
     {{- template "service_account_summary" (dict "ctx" . "namespace" .Namespace "serviceAccountName" ($podTemplate.spec | default dict).serviceAccountName) }}
     {{- /* When there is no readyReplicas, STS may not have related fields at all */ -}}
     {{- $status := .Status }}
-    {{- $_ := set $status "readyReplicas" ($status.readyReplicas | default 0) }}
-    {{- $_ := set $status "currentReplicas" ($status.replicas | default 0) }}
-    {{- $_ := set .Object "status" $status }}
+    {{- $_ := $status | set "readyReplicas" ($status.readyReplicas | default 0) }}
+    {{- $_ := $status | set "currentReplicas" ($status.replicas | default 0) }}
+    {{- $_ := .Object | set "status" $status }}
     {{- template "replicas_status" . }}
     {{- template "suspended" . }}
     {{- template "conditions_summary" . }}


### PR DESCRIPTION
Part of #688 this PR covers only the set function migration
Per the 5-small-PRs approach you suggested in the issue.

This PR covers only the append function migration.
This is PR 4 of 5:

get ✓
hasKey ✓
append ✓
set ✓
float64 → toFloat64


## Change

Converted all genuine old-order `set $dict "key" $val` calls to the
new sprout pipe order `$dict | set "key" $val`. Pure argument-order
swap, no logic changes.

14 genuine call sites converted across 5 files:
- Deployment.tmpl — 5 ($injectedStatus/.Object field sets)
- StatefulSet.tmpl — 3 (same pattern)
- ReplicaSet.tmpl — 3
- Kustomization.tmpl — 1 ($countsByKind bucket increment)
- Pod.tmpl — 2 ($volProblems accumulation)

## False positives skipped

- VirtualService.tmpl:234 — `subset $ref.Key` matched the grep only
  because "subset" ends in "set"; not a function call.
- gatekeeper_constraint_common.tmpl:126,129,130 and
  policy_report_common.tmpl:99,103,105,106,111,113 — these already use
  the new pipe form (`$dict | set "key" val`) from earlier PRs.
  Confirmed against go-sprout's actual `Set` implementation
  (registry/maps/functions.go, vendored go-sprout@v1.0.3) that the new
  signature is `Set(key, value, dict)` with dict piped last — these
  were already correct and untouched.
- Various prose hits ("not yet set", "PSA: no labels set", doc
  comments) — plain English, not calls.

## Verification

- `go build ./...`
- `make test`
- Confirmed via `-v 3` against Deployment/StatefulSet/ReplicaSet/
  Kustomization/Pod fixtures (--local --shallow) that the
  `function=set notice=deprecated` warning no longer fires post-fix.
  Also validated the test methodology itself: stashed just the
  Deployment.tmpl fix and re-ran, confirming the warning reappears
  pre-fix (5 occurrences)

## Verified against a live cluster

The two Pod.tmpl call sites (volume config-map/secret problem
detection) only execute when `LiveQueriesDisabled()` is false, which
requires a real cluster — exercised by `cmd/e2e_pod_volume_test.go`
under `make e2e`, not the offline golden-fixture suite. Verified
manually against a live minikube cluster across three scenarios:

- Pod referencing a non-existent ConfigMap volume → correctly reports
  `Volumes: config-vol (ConfigMap/log-config) doesn't exist`
- Pod referencing a non-existent Secret volume → correctly reports
  `Volumes: secret-vol (Secret/missing-secret) doesn't exist`
- Same ConfigMap pod, after creating the referenced ConfigMap →
  Running/Ready with no false-positive problem text

`kubectl status pod <name> -v 3 | grep function=set` returned no
output in all three cases, confirming the deprecation warning is
gone on this path too.