### PR TITLE
Dedup Gateway API route templates

### DIFF
--- a/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
@@ -9,6 +9,7 @@
     {{- with .Spec.hostnames }}
         {{- "Hostnames" | bold | nindent 2 }}: {{ join ", " . | cyan }}
     {{- end }}
+    {{- $routeHostnames := .Spec.hostnames | default (list) }}
     {{- with .Spec.parentRefs }}
         {{- "Parents" | bold | nindent 2 }}:
         {{- range . }}
@@ -19,54 +20,7 @@
             {{- else }}
                 {{- $.Include "resource_ref" (dict "kind" (.kind | default "Gateway") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
-                {{- if not ($.LiveQueriesDisabled) }}
-                    {{- if eq (.kind | default "Gateway") "Gateway" }}
-                        {{- $parentRef := . }}
-                        {{- $gwNs := coalesce .namespace $.Namespace }}
-                        {{- $gw := $.KubeGetFirst $gwNs (qualifyKind "Gateway" (.group | default "gateway.networking.k8s.io")) .name }}
-                        {{- if $gw.Object }}
-                            {{- $routeHostnames := $.Spec.hostnames | default (list) }}
-                            {{- range $gw.Spec.listeners }}
-                                {{- /* See the HTTPRoute template for what this intersection means. */ -}}
-                                {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
-                                {{- $isMatch := false }}
-                                {{- if $parentRef.sectionName }}
-                                    {{- if eq .name $parentRef.sectionName }}{{ $isMatch = true }}{{ end }}
-                                    {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
-                                {{- else if eq .protocol "HTTPS" }}
-                                    {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $isMatch = true }}{{ end }}
-                                {{- end }}
-                                {{- if $isMatch }}
-                                    {{- with .tls }}
-                                        {{- range .certificateRefs }}
-                                            {{- $refKind := .kind | default "Secret" }}
-                                            {{- if eq $refKind "Secret" }}
-                                                {{- $refNs := coalesce .namespace $gwNs }}
-                                                {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
-                                                {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
-                                                {{- if not $secret.Object }}
-                                                    {{- " doesn't exist" | red | bold }}
-                                                {{- else }}
-                                                    {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
-                                                    {{- if $cert.WrongType }}
-                                                        {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
-                                                    {{- else if $cert.MissingKeys }}
-                                                        {{- printf ", missing keys:%s" (join "," $cert.MissingKeys) | red | bold }}
-                                                    {{- else if $cert.ParseError }}
-                                                        {{- printf ", parse error:%s" $cert.ParseError | red | bold }}
-                                                    {{- else }}
-                                                        {{- if $cert.SelfSigned }}{{ ", self-signed" | yellow }}{{ end }}
-                                                        {{- if not $cert.MatchesHostname }}{{ ", hostname mismatch" | red | bold }}{{ end }}
-                                                    {{- end }}
-                                                {{- end }}
-                                            {{- end }}
-                                        {{- end }}
-                                    {{- end }}
-                                {{- end }}
-                            {{- end }}
-                        {{- end }}
-                    {{- end }}
-                {{- end }}
+                {{- template "gwapi_listener_tls_cert_check" (dict "ctx" $ "parentRef" . "routeHostnames" $routeHostnames "protocol" "HTTPS") }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -86,24 +40,12 @@
             {{- end }}
             {{- with .backendRefs }}
                 {{- range . }}
-                    {{- "→ " | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "Service") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) }}
-                    {{- with .port }}:{{ . }}{{ end }}
-                    {{- if and (. | hasKey "weight") (ne (.weight | int) 1) }}, weight:{{ .weight }}{{ end }}
+                    {{- template "gwapi_backend_ref" (dict "ctx" $ "ref" .) }}
                 {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- with .Status.parents }}
-        {{- "Status" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
-            {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
-            {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions | sortMapListByKeysValue "type" }}
-                {{- $.Include "condition_summary" . | nindent 6 }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "gwapi_status_parents" (dict "ctx" $ "parents" .Status.parents) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
@@ -34,60 +34,7 @@
             {{- else }}
                 {{- $.Include "resource_ref" (dict "kind" (.kind | default "Gateway") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
-                {{- if and (eq (.kind | default "Gateway") "Gateway") (not ($.LiveQueriesDisabled)) }}
-                    {{- $ns := coalesce .namespace $.Namespace }}
-                    {{- $gw := $.KubeGetFirst $ns (qualifyKind "Gateway" (.group | default "gateway.networking.k8s.io")) .name }}
-                    {{- if $gw.Object }}
-                        {{- $sectionName := .sectionName }}
-                        {{- range $gw.Spec.listeners }}
-                            {{- /* The hostnames this listener and this route serve together, which
-                                   are the ones the listener's certificate has to cover -- either
-                                   side may be a wildcard, so this is an intersection rather than
-                                   an equality test. Empty means the route pins no hostname (or,
-                                   for a listener that isn't pinned by sectionName below, that the
-                                   two are disjoint and the route doesn't attach here). */ -}}
-                            {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
-                            {{- $matches := false }}
-                            {{- if $sectionName }}
-                                {{- if eq .name $sectionName }}{{ $matches = true }}{{ end }}
-                                {{- /* sectionName attaches the route to this listener whatever its
-                                       hostname, so a disjoint pair is a real problem: fall back to
-                                       the route's hostnames to report it rather than staying
-                                       silent. */ -}}
-                                {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
-                            {{- else if eq .protocol "HTTPS" }}
-                                {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $matches = true }}{{ end }}
-                            {{- end }}
-                            {{- if $matches }}
-                                {{- with .tls }}
-                                    {{- range .certificateRefs }}
-                                        {{- $refKind := .kind | default "Secret" }}
-                                        {{- if eq $refKind "Secret" }}
-                                            {{- $refNs := coalesce .namespace $ns }}
-                                            {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
-                                            {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
-                                            {{- if not $secret.Object }}
-                                                {{- " doesn't exist" | red | bold }}
-                                            {{- else }}
-                                                {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
-                                                {{- if $cert.WrongType }}
-                                                    {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
-                                                {{- else if $cert.MissingKeys }}
-                                                    {{- printf ", missing keys:%s" (join "," $cert.MissingKeys) | red | bold }}
-                                                {{- else if $cert.ParseError }}
-                                                    {{- printf ", parse error:%s" $cert.ParseError | red | bold }}
-                                                {{- else }}
-                                                    {{- if $cert.SelfSigned }}{{ ", self-signed" | yellow }}{{ end }}
-                                                    {{- if not $cert.MatchesHostname }}{{ ", hostname mismatch" | red | bold }}{{ end }}
-                                                {{- end }}
-                                            {{- end }}
-                                        {{- end }}
-                                    {{- end }}
-                                {{- end }}
-                            {{- end }}
-                        {{- end }}
-                    {{- end }}
-                {{- end }}
+                {{- template "gwapi_listener_tls_cert_check" (dict "ctx" $ "parentRef" . "routeHostnames" $routeHostnames "protocol" "HTTPS") }}
             {{- end }}
             {{- with $statusEntry.controllerName }}
                 {{- "controller" | nindent 6 }}: {{ . | cyan }}
@@ -140,9 +87,7 @@
                     {{- end }}
                 {{- else }}
                     {{- range . }}
-                        {{- "→" | nindent 4 }} {{ $.Include "resource_ref" (dict "kind" (.kind | default "Service") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) }}
-                        {{- with .port }}:{{ . | toString | cyan }}{{ end }}
-                        {{- if and (. | hasKey "weight") (ne (.weight | int) 1) }}, weight:{{ .weight | toString | cyan }}{{ end }}
+                        {{- template "gwapi_backend_ref" (dict "ctx" $ "ref" . "colorize" true) }}
                     {{- end }}
                 {{- end }}
             {{- end }}

--- a/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
@@ -23,23 +23,11 @@
         {{- "Rules" | bold | nindent 2 }}:
         {{- range . }}
             {{- range .backendRefs }}
-                {{- "→ " | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "Service") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) }}
-                {{- with .port }}:{{ . }}{{ end }}
-                {{- if and (. | hasKey "weight") (ne (.weight | int) 1) }}, weight:{{ .weight }}{{ end }}
+                {{- template "gwapi_backend_ref" (dict "ctx" $ "ref" .) }}
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- with .Status.parents }}
-        {{- "Status" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
-            {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
-            {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions | sortMapListByKeysValue "type" }}
-                {{- $.Include "condition_summary" . | nindent 6 }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "gwapi_status_parents" (dict "ctx" $ "parents" .Status.parents) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
@@ -9,8 +9,8 @@
     {{- with .Spec.hostnames }}
         {{- "Hostnames" | bold | nindent 2 }}: {{ join ", " . | cyan }}
     {{- end }}
+    {{- $routeHostnames := .Spec.hostnames | default (list) }}
     {{- with .Spec.parentRefs }}
-        {{- $routeHostnames := $.Spec.hostnames | default (list) }}
         {{- "Parents" | bold | nindent 2 }}:
         {{- range . }}
             {{- if $.Config.GetBool "deep" }}
@@ -20,56 +20,7 @@
             {{- else }}
                 {{- $.Include "resource_ref" (dict "kind" (.kind | default "Gateway") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
-                {{- $parentRef := . }}
-                {{- if and (not ($.LiveQueriesDisabled)) (or (not $parentRef.kind) (eq $parentRef.kind "Gateway")) }}
-                    {{- $gwNs := coalesce $parentRef.namespace $.Namespace }}
-                    {{- $gw := $.KubeGetFirst $gwNs (qualifyKind (coalesce $parentRef.kind "Gateway") (coalesce $parentRef.group "gateway.networking.k8s.io")) $parentRef.name }}
-                    {{- if $gw.Object }}
-                        {{- range $gw.Spec.listeners }}
-                            {{- /* See the HTTPRoute template for what this intersection means. Without
-                                   it an unpinned route reported every TLS listener on the Gateway,
-                                   flagging certificates on listeners whose own hostname means they
-                                   never serve this route. */ -}}
-                            {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
-                            {{- $listenerMatches := false }}
-                            {{- if $parentRef.sectionName }}
-                                {{- if eq .name $parentRef.sectionName }}{{ $listenerMatches = true }}{{ end }}
-                                {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
-                            {{- else if eq .protocol "TLS" }}
-                                {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $listenerMatches = true }}{{ end }}
-                            {{- end }}
-                            {{- if $listenerMatches }}
-                                {{- with .tls }}
-                                    {{- if eq (.mode | default "Terminate") "Terminate" }}
-                                        {{- range .certificateRefs }}
-                                            {{- $refKind := .kind | default "Secret" }}
-                                            {{- if eq $refKind "Secret" }}
-                                                {{- $refNs := coalesce .namespace $gwNs }}
-                                                {{- $secret := $.KubeGetFirst $refNs "Secret" .name }}
-                                                {{- "cert:" | nindent 6 }}{{ $.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $.Namespace) }}
-                                                {{- if $secret.Object }}
-                                                    {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
-                                                    {{- if $cert.WrongType }}
-                                                        {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
-                                                    {{- else if $cert.MissingKeys }}
-                                                        {{- printf ", missing keys:%s" (join "," $cert.MissingKeys) | red | bold }}
-                                                    {{- else if $cert.ParseError }}
-                                                        {{- printf ", parse error:%s" $cert.ParseError | red | bold }}
-                                                    {{- else }}
-                                                        {{- if $cert.SelfSigned }}{{ ", self-signed" | yellow }}{{ end }}
-                                                        {{- if not $cert.MatchesHostname }}{{ ", hostname mismatch" | red | bold }}{{ end }}
-                                                    {{- end }}
-                                                {{- else }}
-                                                    {{- " doesn't exist" | red | bold }}
-                                                {{- end }}
-                                            {{- end }}
-                                        {{- end }}
-                                    {{- end }}
-                                {{- end }}
-                            {{- end }}
-                        {{- end }}
-                    {{- end }}
-                {{- end }}
+                {{- template "gwapi_listener_tls_cert_check" (dict "ctx" $ "parentRef" . "routeHostnames" $routeHostnames "protocol" "TLS" "checkTerminateMode" true) }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -77,23 +28,11 @@
         {{- "Rules" | bold | nindent 2 }}:
         {{- range . }}
             {{- range .backendRefs }}
-                {{- "→ " | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "Service") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) }}
-                {{- with .port }}:{{ . }}{{ end }}
-                {{- if and (. | hasKey "weight") (ne (.weight | int) 1) }}, weight:{{ .weight }}{{ end }}
+                {{- template "gwapi_backend_ref" (dict "ctx" $ "ref" .) }}
             {{- end }}
         {{- end }}
     {{- end }}
-    {{- with .Status.parents }}
-        {{- "Status" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
-            {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
-            {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions | sortMapListByKeysValue "type" }}
-                {{- $.Include "condition_summary" . | nindent 6 }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
+    {{- template "gwapi_status_parents" (dict "ctx" $ "parents" .Status.parents) }}
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}

--- a/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
@@ -1,46 +1,10 @@
 {{- define "UDPRoute" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* GVK: gateway.networking.k8s.io/v1alpha2, Kind=UDPRoute */ -}}
-    {{- template "status_summary_line" . }}
-    {{- template "kstatus_summary" . }}
-    {{- template "finalizer_details_on_termination" . }}
-    {{- template "observed_generation_summary" . }}
-    {{- template "application_details" . }}
-    {{- with .Spec.parentRefs }}
-        {{- "Parents" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- if $.Config.GetBool "deep" }}
-                {{- $ns := coalesce .namespace $.Namespace }}
-                {{- $obj := $.KubeGetFirst $ns (qualifyKind (.kind | default "Gateway") (.group | default "gateway.networking.k8s.io")) .name }}
-                {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 4 }}{{ end }}
-            {{- else }}
-                {{- $.Include "resource_ref" (dict "kind" (.kind | default "Gateway") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) | nindent 4 }}
-                {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- with .Spec.rules }}
-        {{- "Rules" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- range .backendRefs }}
-                {{- "→ " | nindent 4 }}{{ $.Include "resource_ref" (dict "kind" (.kind | default "Service") "name" .name "namespace" .namespace "callerNamespace" $.Namespace) }}
-                {{- with .port }}:{{ . }}{{ end }}
-                {{- if and (. | hasKey "weight") (ne (.weight | int) 1) }}, weight:{{ .weight }}{{ end }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- with .Status.parents }}
-        {{- "Status" | bold | nindent 2 }}:
-        {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
-            {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
-            {{- with .controllerName }} ({{ . }}){{ end }}
-            {{- range .conditions | sortMapListByKeysValue "type" }}
-                {{- $.Include "condition_summary" . | nindent 6 }}
-            {{- end }}
-        {{- end }}
-    {{- end }}
-    {{- template "recent_updates" . }}
-    {{- template "events" . }}
-    {{- template "owners" . }}
+    {{- /* GVK: gateway.networking.k8s.io/v1alpha2, Kind=UDPRoute. Rendering is identical to
+           TCPRoute -- both are a bare list of parentRefs/backendRefs/status.parents with no
+           protocol-specific fields -- so this simply aliases that define rather than duplicating
+           it. .Kind()/.APIVersion() and everything else status_summary_line etc. print still come
+           from the actual object data, not from which define rendered it, so this is safe even
+           though the object's own kind is UDPRoute, not TCPRoute. */ -}}
+    {{- template "TCPRoute" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
+++ b/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
@@ -1,0 +1,112 @@
+{{- define "gwapi_backend_ref" }}
+    {{- /* dict "ctx" (RenderableObject, used for Include/Namespace) "ref" (one
+           spec.rules[].backendRefs[] entry) "colorize" (optional bool -- HTTPRoute renders the
+           port/weight in cyan since it already colors its Rules section heavily; the other route
+           kinds render them plain, so this defaults to false to keep their output unchanged).
+           Renders the "-> resource_ref[:port][, weight:N]" line shared by every Gateway API route
+           kind's Rules section. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $ref := .ref }}
+    {{- "→ " | nindent 4 }}{{ $ctx.Include "resource_ref" (dict "kind" ($ref.kind | default "Service") "name" $ref.name "namespace" $ref.namespace "callerNamespace" $ctx.Namespace) }}
+    {{- if .colorize }}
+        {{- with $ref.port }}:{{ . | toString | cyan }}{{ end }}
+        {{- if and ($ref | hasKey "weight") (ne ($ref.weight | int) 1) }}, weight:{{ $ref.weight | toString | cyan }}{{ end }}
+    {{- else }}
+        {{- with $ref.port }}:{{ . }}{{ end }}
+        {{- if and ($ref | hasKey "weight") (ne ($ref.weight | int) 1) }}, weight:{{ $ref.weight }}{{ end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "gwapi_listener_tls_cert_check" }}
+    {{- /* dict "ctx" (RenderableObject) "parentRef" (one spec.parentRefs[] entry) "routeHostnames"
+           (this route's spec.hostnames, defaulted to an empty list) "protocol" (the Gateway
+           listener protocol this route kind attaches through -- "HTTPS" for GRPCRoute/HTTPRoute,
+           "TLS" for TLSRoute) "checkTerminateMode" (optional bool -- TLSRoute sets this since a
+           Passthrough-mode TLS listener has no certificateRefs to check; GRPCRoute/HTTPRoute leave
+           it unset since an HTTPS listener always terminates).
+
+           Only meaningful for a Gateway parent and only when live queries are allowed (the deep
+           render already inlines the whole Gateway, certificateRefs included, so this is skipped
+           in that branch by the caller). Fetches the parent Gateway, finds the listener(s) this
+           route actually attaches to -- matched by sectionName when set, otherwise by protocol and
+           a hostname intersection -- and for each of that listener's TLS certificateRefs reports
+           whether the referenced Secret exists, is the right type, and matches the intersected
+           hostnames. */ -}}
+    {{- $ctx := .ctx }}
+    {{- $parentRef := .parentRef }}
+    {{- $routeHostnames := .routeHostnames }}
+    {{- $protocol := .protocol }}
+    {{- if and (not ($ctx.LiveQueriesDisabled)) (eq ($parentRef.kind | default "Gateway") "Gateway") }}
+        {{- $gwNs := coalesce $parentRef.namespace $ctx.Namespace }}
+        {{- $gw := $ctx.KubeGetFirst $gwNs (qualifyKind "Gateway" ($parentRef.group | default "gateway.networking.k8s.io")) $parentRef.name }}
+        {{- if $gw.Object }}
+            {{- range $gw.Spec.listeners }}
+                {{- /* The hostnames this listener and this route serve together, which are the
+                       ones the listener's certificate has to cover -- either side may be a
+                       wildcard, so this is an intersection rather than an equality test. Empty
+                       means the route pins no hostname (or, for a listener that isn't pinned by
+                       sectionName below, that the two are disjoint and the route doesn't attach
+                       here). */ -}}
+                {{- $certHostnames := hostnameIntersections (.hostname | default "") $routeHostnames }}
+                {{- $isMatch := false }}
+                {{- if $parentRef.sectionName }}
+                    {{- if eq .name $parentRef.sectionName }}{{ $isMatch = true }}{{ end }}
+                    {{- /* sectionName attaches the route to this listener whatever its hostname,
+                           so a disjoint pair is a real problem: fall back to the route's hostnames
+                           to report it rather than staying silent. */ -}}
+                    {{- if not $certHostnames }}{{ $certHostnames = $routeHostnames }}{{ end }}
+                {{- else if eq .protocol $protocol }}
+                    {{- if or (not $routeHostnames) (not .hostname) $certHostnames }}{{ $isMatch = true }}{{ end }}
+                {{- end }}
+                {{- if $isMatch }}
+                    {{- with .tls }}
+                        {{- if or (not $.checkTerminateMode) (eq (.mode | default "Terminate") "Terminate") }}
+                            {{- range .certificateRefs }}
+                                {{- $refKind := .kind | default "Secret" }}
+                                {{- if eq $refKind "Secret" }}
+                                    {{- $refNs := coalesce .namespace $gwNs }}
+                                    {{- $secret := $ctx.KubeGetFirst $refNs "Secret" .name }}
+                                    {{- "cert:" | nindent 6 }}{{ $ctx.Include "resource_ref" (dict "kind" $refKind "name" .name "namespace" $refNs "callerNamespace" $ctx.Namespace) }}
+                                    {{- if not $secret.Object }}
+                                        {{- " doesn't exist" | red | bold }}
+                                    {{- else }}
+                                        {{- $cert := parseTLSSecretCertificate $secret $certHostnames }}
+                                        {{- if $cert.WrongType }}
+                                            {{- printf ", wrong type:%s" $cert.ActualType | red | bold }}
+                                        {{- else if $cert.MissingKeys }}
+                                            {{- printf ", missing keys:%s" (join "," $cert.MissingKeys) | red | bold }}
+                                        {{- else if $cert.ParseError }}
+                                            {{- printf ", parse error:%s" $cert.ParseError | red | bold }}
+                                        {{- else }}
+                                            {{- if $cert.SelfSigned }}{{ ", self-signed" | yellow }}{{ end }}
+                                            {{- if not $cert.MatchesHostname }}{{ ", hostname mismatch" | red | bold }}{{ end }}
+                                        {{- end }}
+                                    {{- end }}
+                                {{- end }}
+                            {{- end }}
+                        {{- end }}
+                    {{- end }}
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}
+
+{{- define "gwapi_status_parents" }}
+    {{- /* dict "ctx" (RenderableObject) "parents" (status.parents from a TCPRoute/UDPRoute/
+           GRPCRoute/TLSRoute -- not used by HTTPRoute, which correlates each status.parents entry
+           with its matching spec.parentRefs entry inline instead of listing them separately).
+           Renders the "Status:" section: one resource_ref per parent plus its conditions. */ -}}
+    {{- $ctx := .ctx }}
+    {{- with .parents }}
+        {{- "Status" | bold | nindent 2 }}:
+        {{- range . }}
+            {{- $ctx.Include "resource_ref" (dict "kind" (.parentRef.kind | default "Gateway") "name" .parentRef.name "namespace" .parentRef.namespace "callerNamespace" $ctx.Namespace) | nindent 4 }}
+            {{- with .parentRef.sectionName }} [{{ . }}]{{ end }}
+            {{- with .controllerName }} ({{ . }}){{ end }}
+            {{- range .conditions | sortMapListByKeysValue "type" }}
+                {{- $ctx.Include "condition_summary" . | nindent 6 }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end -}}


### PR DESCRIPTION
Closes #808

Built on top of #824's directory regroup (already merged).

## Summary

The five Gateway API route templates (`GRPCRoute`, `HTTPRoute`, `TCPRoute`, `TLSRoute`, `UDPRoute`) shared large amounts of duplicated logic, verified directly by diffing them:

1. `TCPRoute.tmpl`/`UDPRoute.tmpl` were byte-identical (46/46 lines) except for the `{{define}}` name and the `GVK:` comment — confirmed with `diff`.
2. The Gateway-listener TLS-certificate-matching block (hostname intersection via `hostnameIntersections`, walking `certificateRefs`, classifying wrong-type/missing-keys/parse-error/self-signed/hostname-mismatch) was copy-pasted with variable-name drift (`$isMatch`/`$matches`/`$listenerMatches`, `$ns`/`$gwNs`) across `GRPCRoute.tmpl`, `HTTPRoute.tmpl`, `TLSRoute.tmpl`.
3. The `backendRefs` → `resource_ref`/weight rendering was duplicated near-verbatim across all 5 route files.
4. The `Status.parents`/conditions rendering block was duplicated byte-for-byte across `TCPRoute.tmpl`, `UDPRoute.tmpl`, `TLSRoute.tmpl`, `GRPCRoute.tmpl` (HTTPRoute correlates status entries per-parentRef differently, so it doesn't use this one).

Added `pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl` (per #807's directory regroup, matching the `workloads_common.tmpl`/`policy_report_common.tmpl` convention) with three shared defines:

- **`gwapi_backend_ref`** — the backendRef → resource_ref/port/weight one-liner. Takes `dict "ctx" "ref" "colorize"(optional)`. `colorize` exists because HTTPRoute already colors its Rules section heavily and rendered port/weight in cyan, while the other four route kinds render them plain — preserved that difference exactly rather than flattening it.
- **`gwapi_listener_tls_cert_check`** — the Gateway-listener TLS cert-matching block. Takes `dict "ctx" "parentRef" "routeHostnames" "protocol" "checkTerminateMode"(optional)`. `protocol` is `"HTTPS"` for GRPCRoute/HTTPRoute and `"TLS"` for TLSRoute. `checkTerminateMode` is a genuine (not just cosmetic) difference I found while diffing the three call sites: TLSRoute additionally skips a listener whose `tls.mode` isn't `"Terminate"` (a Passthrough-mode TLS listener has no certificateRefs to check), which GRPCRoute/HTTPRoute don't need since an HTTPS listener always terminates. Preserved as an opt-in flag rather than silently dropped.
- **`gwapi_status_parents`** — the `Status.parents`/conditions block, used by TCPRoute/UDPRoute/GRPCRoute/TLSRoute (not HTTPRoute, which inlines the equivalent correlation per-parentRef).

## UDPRoute vs TCPRoute judgment call

Went with the **alias one-liner** (`{{- template "TCPRoute" . }}`) rather than a shared parameterized `gwapi_l4_route` define: after diffing the two files, there is zero kind-specific rendering logic in either one (no protocol-specific fields, no differing sections) — the only difference was the define name and a code comment. A parameterized shared define would just be threading a `kindName` string through for a comment, so the alias is simpler and there's nothing on the visible horizon that would need TCP/UDP to diverge. Kept the `UDPRoute` GVK comment (rather than dropping it) to note the file is intentionally an alias, so a future reader isn't confused about why the file is only 10 lines.

## Other judgment calls

- Standardized a cosmetic difference in the Secret-existence check order between TLSRoute (`if secret exists {...} else {doesn't exist}`) and GRPCRoute/HTTPRoute (`if not exists {doesn't exist} else {...}`) on the latter's structure — purely a code-organization choice with no behavior change (verified via the local golden-file tests and the live e2e TLS-validation fixtures, both byte-for-byte/regex-anchored).
- `TEMPLATE-API.md` (from #812/#818) hasn't been merged into this branch's stack yet (it landed on master separately, and this branch is stacked on #824/#807, not master) — read it directly from `origin/master` to confirm the stable define/funcMap surface and to double-check none of the five Kind-dispatch define names (`GRPCRoute`/`HTTPRoute`/`TCPRoute`/`TLSRoute`/`UDPRoute`) were touched. Didn't introduce the doc file on this branch since it doesn't belong here yet; the new `gwapi_*` shared helpers would be worth adding to its "Shared render helpers" section once the branches converge, but that's out of scope for this PR.
- Verified none of the three new define names (`gwapi_backend_ref`, `gwapi_listener_tls_cert_check`, `gwapi_status_parents`) collide with any of the 196 existing `{{define}}` names across `pkg/plugin/templates/`.

## Test plan

- [x] `make test` — all unit tests pass, including `TestAllArtifactsLocal`'s exact byte-for-byte comparison against golden `.out` files covering `tcproute-accepted`, `udproute-accepted`, `grpcroute-tls-healthy/-problems`, `httproute-tls-healthy/-problems/-no-hostnames/-prometheus`, `tlsroute-tls-healthy/-problems`, `backendtlspolicy-accepted` — none needed regenerating.
- [x] `make test-e2e` — full run hit a shared-minikube-cluster outage partway through (connection-refused cascading across unrelated suites: kyverno, gatekeeper, istio, flux, node metrics, pod volumes, rollouts — not related to this change). Re-ran the three subtests that actually exercise the changed code in isolation against the (recovered) shared cluster and all pass: `tls-validation` (covers the live Gateway-listener cert-check path for GRPCRoute/HTTPRoute/TLSRoute, checked against exact-anchored regex fixtures), `udproute-with-gateway`, `tcproute-with-gateway`.
- [x] Golden-output check: the local artifact tests are exact-equality (not just "passes"), so any rendering difference from the refactor would have failed them outright; the e2e regex fixtures are `\A`...`\z`-anchored (full-output pins), so the same holds for the live listener-cert-check path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
