### PR TITLE
Formalize health-summary dispatch as a discoverable "<Kind>.summary" convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -120,14 +120,17 @@ Any template section that fetches related resources must respect the three rende
 
 Note: `--local` runs without a live cluster, so `KubeGetFirst` calls fail to find anything there too — templates don't need to check for `--local` explicitly, they just need to handle the "not found" case (typically falling back to `resource_ref`), which the `--shallow` handling above already requires.
 
-**default** — compact single-line summaries using shared sub-templates from `common.tmpl`:
+**default** — compact single-line summaries, one `"<Kind>.summary"` template per Kind (defined
+alongside that Kind's own `<Kind>.tmpl`), reached via `resource_health_summary`/`generic_health_summary`
+in `common.tmpl` — see [TEMPLATE-API.md's Health-summary family](TEMPLATE-API.md#health-summary-family)
+for the full list and the discovery mechanism:
 
-| Sub-template | Example output |
+| `<Kind>.summary` | Example output |
 |---|---|
-| `pod_health_summary` | `Pod/name -n ns, 2/2 ready` |
-| `service_health_summary` | `Service/name -n ns, 3 ready, 1 not ready` |
-| `workload_health_summary` | `Deployment/name -n ns, 2/2 ready` |
-| `job_health_summary` | `Job/name -n ns, Active, started 5m ago` |
+| `Pod.summary` | `Pod/name -n ns, 2/2 ready` |
+| `Service.summary` | `Service/name -n ns, 3 ready, 1 not ready` |
+| `Deployment.summary` (also Stateful/DaemonSet/ReplicaSet) | `Deployment/name -n ns, 2/2 ready` |
+| `Job.summary` | `Job/name -n ns, Active, started 5m ago` |
 
 **`--deep`** — full inline render with `$.IncludeRenderableObject . | nindent 4`.
 

--- a/TEMPLATE-API.md
+++ b/TEMPLATE-API.md
@@ -84,6 +84,13 @@ template to inline-render a nested object under `--deep` (e.g. `matching_service
 still safe for a user override to replace, since `Include`/`$.Include` always resolves the name
 currently registered in the template set, override or not.
 
+Sixteen of these also pair their `<Kind>.tmpl` with a `"<Kind>.summary"` define (or
+`"<Kind>.<group>.summary"` for a Kind name that collides across API groups) — the compact
+one-line view `resource_health_summary` dispatches to for that Kind, found by the identical
+lookup used above rather than a hand-maintained list. See the
+[Health-summary family](#health-summary-family) section below for the full set and the
+discovery mechanism; the same "override applies wherever it's referenced" guarantee holds.
+
 ## Shared render helpers (stable)
 
 These are `{{define}}` blocks — almost all in `pkg/plugin/templates/common.tmpl`, three in
@@ -145,30 +152,44 @@ implementing the `--shallow`/default/`--deep` pattern.
 
 ### Health-summary family
 
-One-line, kind-specific compact summaries, documented as a table in
-[CONVENTIONS.md § Rendering depth](CONVENTIONS.md#rendering-depth) (`pod_health_summary`,
-`service_health_summary`, `workload_health_summary`, `job_health_summary`) and extended here with the
-others that follow the identical pattern. Each is `.` = the object itself unless noted, and each
-starts with `resource_ref` then appends kind-specific health signals.
+One-line, kind-specific compact summaries. Each Kind that wants one defines a
+`"<Kind>.summary"` template alongside its own `<Kind>.tmpl` — the same file, same discovery
+mechanism as the Kind templates above, just with a `.summary` suffix instead of a bare Kind
+name (and, for a Kind name that collides across API groups, `"<Kind>.<group>.summary"` mirrors
+`"<Kind>.<group>"`). Because it's a lookup rather than a hand-maintained dispatch table, a
+custom template for a CRD kind — or a user override of a built-in one — picks up its own
+`"<Kind>.summary"` automatically; see `RenderableObject.HealthSummary`
+(`pkg/plugin/renderable.go`) and `templateSet.findSummaryTemplateName`
+(`pkg/plugin/render_engine.go`). Every `"<Kind>.summary"` template takes the same
+`dict "obj" "callerNamespace"(opt)` shape and starts with `resource_ref` then appends
+kind-specific health signals.
 
 | Name | Covers |
 |---|---|
-| `pod_health_summary` | `dict "pod" "callerNamespace"(opt)`. `ready` count, restart count, waiting reasons, plus compact Node-problem and NetworkPolicy-restriction flags (`pod_node_problem_flags`/`pod_network_policy_flags`, internal). |
-| `service_health_summary` | A Service: type, endpoint ready/not-ready counts, ports. |
-| `workload_health_summary` | A Deployment/StatefulSet/DaemonSet/ReplicaSet: ready/desired count plus rollout-in-progress flag. |
-| `job_health_summary` | A Job: active/succeeded/failed counts, run duration. |
-| `ingress_health_summary` | An Ingress: rule hosts, LoadBalancer address, kstatus. |
-| `route_health_summary` | Any of HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute: hostnames, kstatus. |
-| `pdb_health_summary` | A PodDisruptionBudget: min/max available, current budget state. |
-| `hpa_health_summary` | A HorizontalPodAutoscaler: current/desired vs. min-max range. |
-| `vpa_health_summary` | A VerticalPodAutoscaler: update mode, per-container target recommendation. |
-| `generic_health_summary` | `dict "obj" "callerNamespace"(opt)`. Fallback for any kind without a dedicated summary above — kstatus, a bare `status.ready` bool, observedGeneration mismatch. Reasonable to call directly for a mixed list of your own CRD kinds. |
-| `resource_health_summary` | `dict "obj" "callerNamespace"(opt)`. Dispatches to whichever of the above matches `obj.Kind`, falling back to `generic_health_summary`. This is what `managed_resource_line` calls internally; call it directly when you have a mixed-kind list and don't want to dispatch yourself. |
+| `Pod.summary` (`Pod.tmpl`) | `ready` count, restart count, waiting reasons, plus compact Node-problem and NetworkPolicy-restriction flags (`pod_node_problem_flags`/`pod_network_policy_flags`, internal). |
+| `Service.summary` (`Service.tmpl`) | A Service: type, endpoint ready/not-ready counts, ports. |
+| `Deployment.summary`/`StatefulSet.summary`/`DaemonSet.summary`/`ReplicaSet.summary` (each Kind's own `.tmpl`, all four thin wrappers around the shared `workload_health_summary` in `workloads_common.tmpl`) | ready/desired count plus rollout-in-progress flag. |
+| `Job.summary` (`Job.tmpl`) | A Job: active/succeeded/failed counts, run duration. |
+| `Ingress.summary` (`Ingress.tmpl`) | An Ingress: rule hosts, LoadBalancer address, kstatus. |
+| `HTTPRoute.summary`/`GRPCRoute.summary`/`TCPRoute.summary`/`UDPRoute.summary`/`TLSRoute.summary` (each Kind's own `.tmpl`, all five thin wrappers around the shared `route_health_summary` in `gatewayapi_common.tmpl`) | hostnames, kstatus. |
+| `PodDisruptionBudget.summary` (`PodDisruptionBudget.tmpl`) | A PodDisruptionBudget: min/max available, current budget state. |
+| `HorizontalPodAutoscaler.summary` (`HorizontalPodAutoscaler.tmpl`) | A HorizontalPodAutoscaler: current/desired vs. min-max range. |
+| `VerticalPodAutoscaler.summary` (`VerticalPodAutoscaler.tmpl`) | A VerticalPodAutoscaler: update mode, per-container target recommendation. |
+| `generic_health_summary` | `dict "obj" "callerNamespace"(opt)`. Fallback for any kind without its own `"<Kind>.summary"` — kstatus, a bare `status.ready` bool, observedGeneration mismatch. Reasonable to call directly for a mixed list of your own CRD kinds. |
+| `resource_health_summary` | `dict "obj" "callerNamespace"(opt)`. Dispatches to `obj`'s own `"<Kind>.summary"`/`"<Kind>.<group>.summary"` if one is defined (via `RenderableObject.HealthSummary`), falling back to `generic_health_summary`. This is what `managed_resource_line` calls internally; call it directly when you have a mixed-kind list and don't want to dispatch yourself. |
 
 `selector_with_health_summary` (`.` = the object with `.Spec.selector`) renders the `Selector: ...`
-line plus each matching Pod via `pod_health_summary` (or full inline under `--deep`) — the pattern
+line plus each matching Pod via `Pod.summary` (or full inline under `--deep`) — the pattern
 [CONVENTIONS.md](CONVENTIONS.md#label-selectors) calls out by name for any `LabelSelector` field
 targeting Pods.
+
+Every `"<Kind>.summary"` template is covered by a static check
+(`TestSummaryTemplatesRenderOneLine` in `templates_common_test.go`) that renders it and fails if
+the output contains a newline — the family's whole point is a summary that stays on one line
+wherever a list renders one entry per row (`managed_resource_line`, `matching_services`,
+`crossplane_composed_resources`, ...). A new `"<Kind>.summary"` is picked up automatically; add
+a `summaryTemplateFixtures` entry only if the default empty-object fixture isn't enough for it
+to render without error.
 
 ### Workload-family bundle
 
@@ -436,9 +457,10 @@ reference (not a call contract — names here can be renamed, split, or merged f
   `gatekeeper_constraint_fallback`, `flux_object_management`, `flux_revision`,
   `custom_application_details` (special — see [above](#the-user-override-point-custom_application_details)),
   `network_policy_selection_summary`, `cilium_policy_selection_summary`, `calico_policy_selection_summary`,
-  `pod_node_problem_flags`, `pod_network_policy_flags`, `hpa_health_summary`'s sibling `matching_hpas`,
-  `vpa_health_summary`'s sibling `matching_vpas`, `pdb_health_summary`'s sibling `pdb_conflict_warning`,
-  `volumeattachment_diagnosis`, `rwop_holder_diagnosis`.
+  `pod_node_problem_flags`, `pod_network_policy_flags`, `HorizontalPodAutoscaler.summary`'s sibling
+  `matching_hpas`, `VerticalPodAutoscaler.summary`'s sibling `matching_vpas`,
+  `PodDisruptionBudget.summary`'s sibling `pdb_conflict_warning`, `volumeattachment_diagnosis`,
+  `rwop_holder_diagnosis`.
 - **`policy_report_common.tmpl`**: `policy_report_findings`, `policy_report_finding_line`.
 - **`Pod.tmpl`** (26): `pod_status_summary_line`, `pod_placement_constraints`,
   `pod_karpenter_compatibility`, `pod_topology_constraints`, `pod_node_problems`,
@@ -485,11 +507,12 @@ enforcement/tree-separation work (tracked separately from this document) doesn't
 2. **`gatekeeper_constraint_fallback`** — one caller (`DefaultResource`, a different file), but it's
    the sole routing point for every dynamically-generated Gatekeeper Constraint Kind that has no
    dedicated `<Kind>.tmpl`. Treat as load-bearing infrastructure even though it's marked internal.
-3. **`hpa_health_summary`/`matching_hpas`, `vpa_health_summary`/`matching_vpas`,
-   `pdb_health_summary`/`pdb_conflict_warning`, `network_policy_selection_summary`/
+3. **`matching_hpas`, `matching_vpas`, `pdb_conflict_warning`, `network_policy_selection_summary`/
    `cilium_policy_selection_summary`/`calico_policy_selection_summary`,
    `pod_node_problem_flags`/`pod_network_policy_flags`** — each is one hop from a stable Category B
-   helper (called only by it). Free to rename in isolation, but check the caller when doing so.
+   helper (`HorizontalPodAutoscaler.summary`, `VerticalPodAutoscaler.summary`,
+   `PodDisruptionBudget.summary`, `Pod.summary`, called only by it). Free to rename in isolation,
+   but check the caller when doing so.
 4. **`resource_health_summary`/`generic_health_summary`** — technically one-hop-from-B by caller
    count, but their own doc comments describe them as meant for general reuse in mixed-kind lists;
    promoted to Category B above rather than left internal.

--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -352,6 +352,28 @@ func (ts *templateSet) findTemplateName(kind, group string) (tree *template.Temp
 	return ts.treeFor("DefaultResource"), "DefaultResource"
 }
 
+// findSummaryTemplateName picks the compact one-line summary template for a Kind, following the
+// same "<Kind>.<group>" (for a Kind name that collides across API groups) then bare "<Kind>"
+// preference findTemplateName uses for the full view -- just with a ".summary" suffix, e.g.
+// "Job.summary" or, for a colliding Kind, "Gateway.networking.istio.io.summary". Checked against
+// both embedded and the user overlay (ts.userDefinedNames), so a user override or a template
+// shipped only for a custom CRD kind is discovered exactly like a "<Kind>.tmpl" override is.
+//
+// Unlike findTemplateName, there is no generic fallback name here -- ok is false when neither
+// form is defined, and the caller (RenderableObject.HealthSummary) falls back to
+// generic_health_summary itself. See https://github.com/bergerx/kubectl-status/issues/826.
+func (ts *templateSet) findSummaryTemplateName(kind, group string) (name string, ok bool) {
+	if group != "" {
+		if qualified := kind + "." + group + ".summary"; ts.embedded.Lookup(qualified) != nil || ts.userDefinedNames[qualified] {
+			return qualified, true
+		}
+	}
+	if plain := kind + ".summary"; ts.embedded.Lookup(plain) != nil || ts.userDefinedNames[plain] {
+		return plain, true
+	}
+	return "", false
+}
+
 // resolveIncludeTree decides which tree an explicit `.Include name data` call (or the
 // IncludeRenderableObject primitive, via its own fresh render()) should execute name against,
 // given current -- the tree the calling template's own top-level render already dispatched to
@@ -361,7 +383,11 @@ func (ts *templateSet) findTemplateName(kind, group string) (tree *template.Temp
 // they're referenced, matching findTemplateName and the handful of built-in
 // `{{ $.Include "<Kind>" $obj }}` calls documented in TEMPLATE-API.md (e.g. matching_services'
 // `Include "Service"`) -- a user's Service.tmpl override is expected to apply even when invoked
-// from an unrelated built-in template.
+// from an unrelated built-in template. A "<Kind>.summary"/"<Kind>.<group>.summary" name (see
+// findSummaryTemplateName, #826) gets the same treatment for the same reason:
+// resource_health_summary is itself a built-in template executing in embedded, and needs to
+// reach a user-provided summary for a Kind it has never heard of (e.g. a custom CRD listed by
+// crossplane_composed_resources) exactly as readily as a built-in one.
 //
 // Every other name (the internal shared-partial names, plus anything a user's own override
 // defines purely for its own use) resolves strictly within current. This is what keeps a user
@@ -371,7 +397,7 @@ func (ts *templateSet) findTemplateName(kind, group string) (tree *template.Temp
 // tree (i.e. the user's own Kind override, or something it itself Includes) can ever observe
 // the user's own redefinition.
 func (ts *templateSet) resolveIncludeTree(name string, current *template.Template) *template.Template {
-	if ts.kindNames[name] {
+	if ts.kindNames[name] || strings.HasSuffix(name, ".summary") {
 		return ts.treeFor(name)
 	}
 	if current != nil {

--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -164,6 +164,21 @@ func (r RenderableObject) renderString() (string, error) {
 	return buffer.String(), err
 }
 
+// HealthSummary renders this object's compact one-line summary: its own paired
+// "<Kind>.summary"/"<Kind>.<group>.summary" template if one is defined -- built-in (living
+// alongside that Kind's own <Kind>.tmpl) or a user override/CRD-author-provided one, discovered
+// the same way a "<Kind>.tmpl" full view already is -- falling back to generic_health_summary
+// otherwise. This is what resource_health_summary calls; see
+// https://github.com/bergerx/kubectl-status/issues/826 for why it's a lookup rather than a
+// hand-maintained per-Kind chain.
+func (r RenderableObject) HealthSummary(callerNamespace string) (string, error) {
+	data := map[string]interface{}{"obj": r, "callerNamespace": callerNamespace}
+	if name, ok := r.engine.templateSet.findSummaryTemplateName(r.Kind(), r.GroupVersionKind().Group); ok {
+		return r.renderTemplate(name, data)
+	}
+	return r.renderTemplate("generic_health_summary", data)
+}
+
 func (r RenderableObject) renderTemplate(templateName string, data interface{}) (string, error) {
 	var buffer bytes.Buffer
 	klog.V(5).InfoS("called renderTemplate, calling ExecuteTemplate",

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -287,65 +287,6 @@
     {{- /* Can be overridden through ~/.kubectl-status/templates/*.tmpl files to inject user-specific data */ -}}
 {{- end -}}
 
-{{- define "pod_health_summary" }}
-    {{- /* Expects dict "pod" (Pod RenderableObject) "callerNamespace" (optional -- the namespace
-           of the object this summary is rendered under, e.g. a Job/PVC/PodDisruptionBudget;
-           passed through to resource_ref so the pod's own namespace is dropped from the summary
-           when it's redundant). */ -}}
-    {{- $pod := .pod }}
-    {{- template "resource_ref" (dict "kind" $pod.Kind "name" $pod.Name "namespace" $pod.Namespace "callerNamespace" .callerNamespace) }}
-    {{- with $pod.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- with $pod.Status.phase }} {{ . | colorKeyword }}{{ end }}
-    {{- $total := 0 }}{{ $ready := 0 }}{{ $restarts := 0 }}{{ $waitingReasons := list }}
-    {{- range $pod.Status.containerStatuses }}
-        {{- $total = add1 $total }}
-        {{- if .ready }}{{ $ready = add1 $ready }}{{ end }}
-        {{- $restarts = $restarts | add (.restartCount | int) }}
-        {{- with .state.waiting.reason }}
-            {{- if not ($waitingReasons | has .) }}{{ $waitingReasons = $waitingReasons | append . }}{{ end }}
-        {{- end }}
-    {{- end }}
-    {{- if $total }}, {{ if lt $ready $total }}{{ printf "%d/%d" $ready $total | red | bold }}{{ else }}{{ printf "%d/%d" $ready $total | green }}{{ end }} ready{{ end }}
-    {{- /* A Running/Ready pod with a past restart is still worth flagging here -- restart count
-           is a signal worth an operator's attention even once the pod has recovered, just a
-           milder one than being stuck waiting (see #178). */ -}}
-    {{- with $waitingReasons }} {{ . | join "," | red | bold }}{{ end }}
-    {{- if gt $restarts 0 }} restarts:{{ $restarts | toString | yellow | bold }}{{ end }}
-    {{- $nodeProblems := $pod.Include "pod_node_problem_flags" $pod }}
-    {{- with $nodeProblems }}, {{ . }}{{ end }}
-    {{- $netpolFlag := $pod.Include "pod_network_policy_flags" $pod }}
-    {{- with $netpolFlag }}, {{ . }}{{ end }}
-{{- end }}
-
-{{- define "service_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- with .Spec }}{{ with .type }}, {{ if eq . "NodePort" }}{{ . | yellow | bold }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}{{ end }}
-    {{- $slices := .KubeGetEndpointSlicesForService .Namespace .Name }}
-    {{- $ready := 0 }}{{ $notReady := 0 }}
-    {{- range $slices }}
-        {{- range (.Object.endpoints | default list) }}
-            {{- if or (not ((.conditions | default dict) | hasKey "ready")) .conditions.ready }}{{ $ready = add1 $ready }}{{ else }}{{ $notReady = add1 $notReady }}{{ end }}
-        {{- end }}
-    {{- end }}
-    {{- if not $slices }}
-        {{- ", " }}{{ "no endpoints" | red | bold }}
-    {{- else if or $ready $notReady }}
-        {{- if $ready }}, {{ $ready | toString | green }} ready{{ end }}
-        {{- if $notReady }}, {{ $notReady | toString | red | bold }} not ready{{ end }}
-    {{- else }}
-        {{- ", " }}{{ "no matching pods" | red | bold }}
-    {{- end }}
-    {{- with .Spec }}{{ with .ports }}
-        {{- range . }}
-            {{- ", " }}
-            {{- if .name }}{{ printf "%s(%d/%s)" .name (.port | int) (.protocol | default "TCP") | cyan }}{{ else }}{{ printf "%d/%s" (.port | int) (.protocol | default "TCP") | cyan }}{{ end }}
-            {{- with .nodePort }}{{ printf "→%d" (. | int) | yellow | bold }}{{ end }}
-        {{- end }}
-    {{- end }}{{ end }}
-{{- end }}
-
 {{- define "generic_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* Expects dict "obj" (RenderableObject of any kind) "callerNamespace" (optional, forwarded
@@ -383,33 +324,14 @@
 {{- define "resource_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- /* Expects dict "obj" (RenderableObject of any kind) "callerNamespace" (optional, forwarded
-           through to pod_health_summary/generic_health_summary). Dispatches to the same compact
-           one-line summary the caller would reach for if it knew obj's kind ahead of time, falling
-           back to generic_health_summary for anything else. For use where a list mixes resources
-           of a kind that isn't known ahead of time, e.g. crossplane_composed_resources. */ -}}
-    {{- $obj := .obj }}
-    {{- $callerNamespace := .callerNamespace }}
-    {{- if eq $obj.Kind "Pod" }}
-        {{- template "pod_health_summary" (dict "pod" $obj "callerNamespace" $callerNamespace) }}
-    {{- else if eq $obj.Kind "Service" }}
-        {{- template "service_health_summary" $obj }}
-    {{- else if eq $obj.Kind "Ingress" }}
-        {{- template "ingress_health_summary" $obj }}
-    {{- else if has $obj.Kind (list "HTTPRoute" "GRPCRoute" "TCPRoute" "UDPRoute" "TLSRoute") }}
-        {{- template "route_health_summary" $obj }}
-    {{- else if eq $obj.Kind "Job" }}
-        {{- template "job_health_summary" $obj }}
-    {{- else if eq $obj.Kind "PodDisruptionBudget" }}
-        {{- template "pdb_health_summary" $obj }}
-    {{- else if has $obj.Kind (list "Deployment" "StatefulSet" "DaemonSet" "ReplicaSet") }}
-        {{- template "workload_health_summary" $obj }}
-    {{- else if eq $obj.Kind "HorizontalPodAutoscaler" }}
-        {{- template "hpa_health_summary" $obj }}
-    {{- else if eq $obj.Kind "VerticalPodAutoscaler" }}
-        {{- template "vpa_health_summary" $obj }}
-    {{- else }}
-        {{- template "generic_health_summary" (dict "obj" $obj "callerNamespace" $callerNamespace) }}
-    {{- end }}
+           through to obj's own summary template / generic_health_summary). Dispatches to obj's own
+           "<Kind>.summary" (or "<Kind>.<group>.summary" for a Kind name that collides across API
+           groups) template if one is defined -- built-in, alongside that Kind's own <Kind>.tmpl, or
+           a user override/CRD-author-provided one -- falling back to generic_health_summary
+           otherwise. See TEMPLATE-API.md's Health-summary family section and #826. For use where a
+           list mixes resources of a kind that isn't known ahead of time, e.g.
+           crossplane_composed_resources. */ -}}
+    {{- .obj.HealthSummary .callerNamespace }}
 {{- end }}
 
 {{- define "flux_object_management" }}

--- a/pkg/plugin/templates/core/Ingress.tmpl
+++ b/pkg/plugin/templates/core/Ingress.tmpl
@@ -32,7 +32,7 @@
                     {{- if not $portDefinedInSvc }}
                         {{- "Service port doesnt exist" | red | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Service" "name" $ingSvcName) }}:{{ $ingSvcPort }} referenced in ingress, but Service doesn't have that port defined.
                     {{- else if not ($shownSvcs | has $ingSvcName) }}
-                        {{- $.Include "service_health_summary" $svc | nindent 2 }}
+                        {{- $.Include "Service.summary" (dict "obj" $svc) | nindent 2 }}
                         {{- $shownSvcs = $shownSvcs | append $ingSvcName }}
                     {{- end }}
                 {{- end }}
@@ -85,6 +85,24 @@
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
+{{- end -}}
+
+{{- define "Ingress.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (Ingress RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with $obj.Spec.rules }}, {{ range $index, $rule := . }}{{ if $index }}, {{ end }}{{ $rule.host | cyan }}{{ end }}{{ end }}
+    {{- with $obj.Status.loadBalancer.ingress }}
+        {{- with (index . 0).hostname }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
+        {{- with (index . 0).ip }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
+    {{- else }}
+        {{- ", " }}{{ "Pending LoadBalancer" | red | bold }}
+    {{- end }}
+    {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
 {{- end -}}
 
 {{- define "load_balancer_ingress" }}

--- a/pkg/plugin/templates/core/PersistentVolumeClaim.tmpl
+++ b/pkg/plugin/templates/core/PersistentVolumeClaim.tmpl
@@ -67,7 +67,7 @@
     {{- if $usingPods }}
         {{- "Pods" | bold | nindent 2 }}:
         {{- range $usingPods }}
-            {{- $.Include "pod_health_summary" (dict "pod" . "callerNamespace" $.Namespace) | nindent 4 }}
+            {{- $.Include "Pod.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
         {{- end }}
     {{- end }}
     {{- $.Include "rwop_holder_diagnosis" (dict "ctx" $ "pods" $usingPods "accessModes" (.Spec.accessModes | default list)) }}

--- a/pkg/plugin/templates/core/Service.tmpl
+++ b/pkg/plugin/templates/core/Service.tmpl
@@ -69,6 +69,39 @@
     {{- template "owners" . }}
 {{- end -}}
 
+{{- define "Service.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (Service RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with $obj.Spec }}{{ with .type }}, {{ if eq . "NodePort" }}{{ . | yellow | bold }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}{{ end }}
+    {{- $slices := $obj.KubeGetEndpointSlicesForService $obj.Namespace $obj.Name }}
+    {{- $ready := 0 }}{{ $notReady := 0 }}
+    {{- range $slices }}
+        {{- range (.Object.endpoints | default list) }}
+            {{- if or (not ((.conditions | default dict) | hasKey "ready")) .conditions.ready }}{{ $ready = add1 $ready }}{{ else }}{{ $notReady = add1 $notReady }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- if not $slices }}
+        {{- ", " }}{{ "no endpoints" | red | bold }}
+    {{- else if or $ready $notReady }}
+        {{- if $ready }}, {{ $ready | toString | green }} ready{{ end }}
+        {{- if $notReady }}, {{ $notReady | toString | red | bold }} not ready{{ end }}
+    {{- else }}
+        {{- ", " }}{{ "no matching pods" | red | bold }}
+    {{- end }}
+    {{- with $obj.Spec }}{{ with .ports }}
+        {{- range . }}
+            {{- ", " }}
+            {{- if .name }}{{ printf "%s(%d/%s)" .name (.port | int) (.protocol | default "TCP") | cyan }}{{ else }}{{ printf "%d/%s" (.port | int) (.protocol | default "TCP") | cyan }}{{ end }}
+            {{- with .nodePort }}{{ printf "→%d" (. | int) | yellow | bold }}{{ end }}
+        {{- end }}
+    {{- end }}{{ end }}
+{{- end }}
+
 {{- define "service_traffic_config" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- $etp := .Spec.externalTrafficPolicy | default "Cluster" }}
@@ -116,7 +149,7 @@
             {{- if $.Config.GetBool "deep" }}
                 {{- $.IncludeRenderableObject $ing | nindent 4 }}
             {{- else }}
-                {{- $.Include "ingress_health_summary" $ing | nindent 4 }}
+                {{- $.Include "Ingress.summary" (dict "obj" $ing) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/core/core_common.tmpl
+++ b/pkg/plugin/templates/core/core_common.tmpl
@@ -122,12 +122,12 @@
         {{- if gt (len $scheduled) 1 }}
             {{- "RWOP" | bold | nindent 2 }}: {{ "conflict" | red | bold }}: more than one non-terminal Pod is scheduled against this ReadWriteOncePod claim:
             {{- range $scheduled }}
-                {{- $ctx.Include "pod_health_summary" (dict "pod" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
+                {{- $ctx.Include "Pod.summary" (dict "obj" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
                 {{- with .Spec.nodeName }}, node {{ $ctx.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
             {{- end }}
         {{- else if eq (len $scheduled) 1 }}
             {{- $holder := index $scheduled 0 }}
-            {{- "RWOP holder" | bold | nindent 2 }}: {{ $ctx.Include "pod_health_summary" (dict "pod" $holder "callerNamespace" $ctx.Namespace) }}
+            {{- "RWOP holder" | bold | nindent 2 }}: {{ $ctx.Include "Pod.summary" (dict "obj" $holder "callerNamespace" $ctx.Namespace) }}
             {{- with $holder.Spec.nodeName }}, node {{ $ctx.Include "resource_ref" (dict "kind" "Node" "name" .) }}{{ end }}
         {{- end }}
         {{- /* Checked independently of the holder/conflict branches above: a Pod can be Pending
@@ -137,32 +137,10 @@
             {{- $pod := . }}
             {{- with $pod.StatusConditions | getMatchingItemInMapList (dict "type" "PodScheduled") }}
                 {{- if and (eq .status "False") (contains "ReadWriteOncePod" (.message | default "")) }}
-                    {{- "RWOP" | bold | nindent 2 }}: {{ $ctx.Include "pod_health_summary" (dict "pod" $pod "callerNamespace" $ctx.Namespace) }}, {{ "blocked" | red | bold }}: {{ .message }}
+                    {{- "RWOP" | bold | nindent 2 }}: {{ $ctx.Include "Pod.summary" (dict "obj" $pod "callerNamespace" $ctx.Namespace) }}, {{ "blocked" | red | bold }}: {{ .message }}
                 {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
 {{- end -}}
 
-{{- define "ingress_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- with .Spec.rules }}, {{ range $index, $rule := . }}{{ if $index }}, {{ end }}{{ $rule.host | cyan }}{{ end }}{{ end }}
-    {{- with .Status.loadBalancer.ingress }}
-        {{- with (index . 0).hostname }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
-        {{- with (index . 0).ip }}, {{ "LoadBalancer" | green }}:{{ . | cyan }}{{ end }}
-    {{- else }}
-        {{- ", " }}{{ "Pending LoadBalancer" | red | bold }}
-    {{- end }}
-    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
-{{- end -}}
-
-{{- define "route_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Shared compact summary for HTTPRoute, GRPCRoute, TCPRoute, UDPRoute and TLSRoute. */ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- with .Spec.hostnames }}, {{ join ", " . | cyan }}{{ end }}
-    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
-{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
@@ -50,3 +50,12 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "GRPCRoute.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (GRPCRoute RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
+           by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
@@ -97,3 +97,12 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "HTTPRoute.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (HTTPRoute RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
+           by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
@@ -32,3 +32,12 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "TCPRoute.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (TCPRoute RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
+           by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
@@ -37,3 +37,12 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "TLSRoute.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (TLSRoute RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
+           by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
@@ -8,3 +8,12 @@
            though the object's own kind is UDPRoute, not TCPRoute. */ -}}
     {{- template "TCPRoute" . }}
 {{- end -}}
+
+{{- define "UDPRoute.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (UDPRoute RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
+           by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
+++ b/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
@@ -1,3 +1,16 @@
+{{- define "route_health_summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Shared compact summary for HTTPRoute, GRPCRoute, TCPRoute, UDPRoute and TLSRoute --
+           takes the route RenderableObject directly (not the dict "obj"/"callerNamespace" shape
+           the "<Kind>.summary" entry points use) since matching_routes in core/Service.tmpl calls
+           it directly today; each route kind's own "<Kind>.summary" (in its own <Kind>.tmpl) is a
+           thin wrapper around this. */ -}}
+    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
+    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with .Spec.hostnames }}, {{ join ", " . | cyan }}{{ end }}
+    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
+{{- end -}}
+
 {{- define "gwapi_backend_ref" }}
     {{- /* dict "ctx" (RenderableObject, used for Include/Namespace) "ref" (one
            spec.rules[].backendRefs[] entry) "colorize" (optional bool -- HTTPRoute renders the

--- a/pkg/plugin/templates/istio/DestinationRule.tmpl
+++ b/pkg/plugin/templates/istio/DestinationRule.tmpl
@@ -70,7 +70,7 @@
                     {{- ", " }}{{ "no pods" | red | bold }}
                 {{- else if $.Config.GetBool "deep" }}
                     {{- range $pods }}
-                        {{- $.Include "pod_health_summary" (dict "pod" . "callerNamespace" $.Namespace) | nindent 6 }}
+                        {{- $.Include "Pod.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 6 }}
                     {{- end }}
                 {{- else }}
                     {{- ", " }}{{ len $pods | toString | cyan }} pod{{ if ne (len $pods) 1 }}s{{ end }}

--- a/pkg/plugin/templates/workloads/CronJob.tmpl
+++ b/pkg/plugin/templates/workloads/CronJob.tmpl
@@ -34,7 +34,7 @@
             {{- if $.Config.GetBool "deep" }}
                 {{- $.IncludeRenderableObject . | nindent 4 }}
             {{- else }}
-                {{- $.Include "job_health_summary" . | nindent 4 }}
+                {{- $.Include "Job.summary" (dict "obj" .) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/workloads/DaemonSet.tmpl
+++ b/pkg/plugin/templates/workloads/DaemonSet.tmpl
@@ -92,3 +92,12 @@
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{- define "DaemonSet.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (DaemonSet RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
+           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/Deployment.tmpl
+++ b/pkg/plugin/templates/workloads/Deployment.tmpl
@@ -115,3 +115,12 @@
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{- define "Deployment.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (Deployment RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
+           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
@@ -86,3 +86,17 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "HorizontalPodAutoscaler.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (HorizontalPodAutoscaler RenderableObject) "callerNamespace" (unused,
+           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
+           template shares -- see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- $minReplicas := 1 }}{{- if $obj.Spec | hasKey "minReplicas" }}{{- $minReplicas = $obj.Spec.minReplicas | int }}{{- end }}
+    {{- $current := $obj.Status.currentReplicas | default 0 | int }}
+    {{- $desired := $obj.Status.desiredReplicas | default 0 | int }}
+    {{- printf ", %d" $current | redBoldIf (ne $current $desired) }}/{{ printf "%d-%d" $minReplicas ($obj.Spec.maxReplicas | int) }}
+    {{- if ne $current $desired }}, {{ "desired" | yellow | bold }}: {{ printf "%d" $desired | yellow }}{{ end }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/Job.tmpl
+++ b/pkg/plugin/templates/workloads/Job.tmpl
@@ -43,7 +43,7 @@
     {{- end }}
     {{- if and .Status.active (not ($.LiveQueriesDisabled)) }}
         {{- /* A Job's own status has no signal for "why hasn't this started" -- only its Pods do.
-               pod_health_summary carries the Node-side hint (cordoned/tainted/unhealthy node),
+               Pod.summary carries the Node-side hint (cordoned/tainted/unhealthy node),
                which is usually the answer for a Pod stuck Pending. */ -}}
         {{- $pendingPods := list }}
         {{- range $.KubeGetByLabelsMap $.Namespace "pods" (dict "job-name" .Name) }}
@@ -57,7 +57,7 @@
                 {{- if $.Config.GetBool "deep" }}
                     {{- $.IncludeRenderableObject . | nindent 4 }}
                 {{- else }}
-                    {{- $.Include "pod_health_summary" (dict "pod" . "callerNamespace" $.Namespace) | nindent 4 }}
+                    {{- $.Include "Pod.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -73,6 +73,25 @@
     {{- template "recent_updates" . }}
     {{- template "events" . }}
     {{- template "owners" . }}
+{{- end -}}
+
+{{- define "Job.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (Job RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- if $obj.Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
+    {{- if $obj.Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
+    {{- if $obj.Status.failed }}, {{ printf "Failed: %d" ($obj.Status.failed | int) | red | bold }}{{ end }}
+    {{- if $obj.Status.startTime }}, started {{ $obj.Status.startTime | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- if and $obj.Status.startTime $obj.Status.completionTime }}
+        {{- $started := $obj.Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- $completed := $obj.Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
+        {{- ", ran for " }}{{ $completed.Sub $started | colorDuration }}
+    {{- end }}
 {{- end -}}
 
 {{- define "job_failed_pod_summary" }}

--- a/pkg/plugin/templates/workloads/Node.tmpl
+++ b/pkg/plugin/templates/workloads/Node.tmpl
@@ -332,7 +332,7 @@
                Pending/NotReady. */ -}}
         {{- "pods needing attention" | bold | nindent 2 }}:
         {{- range . | sortMapListByKeysValue "key" }}
-            {{- "" | nindent 4 }}{{ template "pod_health_summary" (dict "pod" .pod) }}
+            {{- "" | nindent 4 }}{{ template "Pod.summary" (dict "obj" .pod) }}
         {{- end }}
     {{- end }}
     {{- /* Only ever non-empty when the pod loop above ran and found per-pod metrics, so this needs

--- a/pkg/plugin/templates/workloads/Pod.tmpl
+++ b/pkg/plugin/templates/workloads/Pod.tmpl
@@ -70,6 +70,37 @@
     {{- template "owners" . }}
 {{- end }}
 
+{{- define "Pod.summary" }}
+    {{- /* Expects dict "obj" (Pod RenderableObject) "callerNamespace" (optional -- the namespace
+           of the object this summary is rendered under, e.g. a Job/PVC/PodDisruptionBudget;
+           passed through to resource_ref so the pod's own namespace is dropped from the summary
+           when it's redundant). Same dict "obj"/"callerNamespace" contract every "<Kind>.summary"
+           template uses -- see resource_health_summary. */ -}}
+    {{- $pod := .obj }}
+    {{- template "resource_ref" (dict "kind" $pod.Kind "name" $pod.Name "namespace" $pod.Namespace "callerNamespace" .callerNamespace) }}
+    {{- with $pod.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with $pod.Status.phase }} {{ . | colorKeyword }}{{ end }}
+    {{- $total := 0 }}{{ $ready := 0 }}{{ $restarts := 0 }}{{ $waitingReasons := list }}
+    {{- range $pod.Status.containerStatuses }}
+        {{- $total = add1 $total }}
+        {{- if .ready }}{{ $ready = add1 $ready }}{{ end }}
+        {{- $restarts = $restarts | add (.restartCount | int) }}
+        {{- with .state.waiting.reason }}
+            {{- if not ($waitingReasons | has .) }}{{ $waitingReasons = $waitingReasons | append . }}{{ end }}
+        {{- end }}
+    {{- end }}
+    {{- if $total }}, {{ if lt $ready $total }}{{ printf "%d/%d" $ready $total | red | bold }}{{ else }}{{ printf "%d/%d" $ready $total | green }}{{ end }} ready{{ end }}
+    {{- /* A Running/Ready pod with a past restart is still worth flagging here -- restart count
+           is a signal worth an operator's attention even once the pod has recovered, just a
+           milder one than being stuck waiting (see #178). */ -}}
+    {{- with $waitingReasons }} {{ . | join "," | red | bold }}{{ end }}
+    {{- if gt $restarts 0 }} restarts:{{ $restarts | toString | yellow | bold }}{{ end }}
+    {{- $nodeProblems := $pod.Include "pod_node_problem_flags" $pod }}
+    {{- with $nodeProblems }}, {{ . }}{{ end }}
+    {{- $netpolFlag := $pod.Include "pod_network_policy_flags" $pod }}
+    {{- with $netpolFlag }}, {{ . }}{{ end }}
+{{- end }}
+
 {{- define "pod_status_summary_line" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
     {{- template "status_summary_line" . }}

--- a/pkg/plugin/templates/workloads/PodDisruptionBudget.tmpl
+++ b/pkg/plugin/templates/workloads/PodDisruptionBudget.tmpl
@@ -39,7 +39,7 @@
                 {{- $daemonsets := $.KubeGetByLabelsMap $.Namespace "daemonsets" $matchLabels }}
                 {{- $statefulsets := $.KubeGetByLabelsMap $.Namespace "statefulsets" $matchLabels }}
                 {{- range $svcs }}
-                    {{- $.Include "service_health_summary" . | nindent 4 }}
+                    {{- $.Include "Service.summary" (dict "obj" .) | nindent 4 }}
                 {{- end }}
                 {{- if or $deploys $daemonsets $statefulsets }}
                     {{- range $deploys }}
@@ -53,7 +53,7 @@
                     {{- end }}
                 {{- else }}
                     {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                        {{- $.Include "pod_health_summary" (dict "pod" . "callerNamespace" $.Namespace) | nindent 4 }}
+                        {{- $.Include "Pod.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                     {{- end }}
                 {{- end }}
             {{- end }}
@@ -84,3 +84,29 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end }}
+
+{{- define "PodDisruptionBudget.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (PodDisruptionBudget RenderableObject) "callerNamespace" (unused,
+           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
+           template shares -- see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- $budgetViolated := lt ($obj.Status.currentHealthy | int) ($obj.Status.desiredHealthy | int) }}
+    {{- $noDisruptions := and ($obj.Status | hasKey "disruptionsAllowed") (eq ($obj.Status.disruptionsAllowed | int) 0) }}
+    {{- $noOp := and ($obj.Status | hasKey "expectedPods") (eq ($obj.Status.expectedPods | int) 0) }}
+    {{- with $obj.Spec.minAvailable }}, min available={{ . | toString | cyan }}{{ end }}
+    {{- with $obj.Spec.maxUnavailable }}, max unavailable={{ . | toString | cyan }}{{ end }}
+    {{- if $obj.Status | hasKey "currentHealthy" }}
+        {{- if $noOp }}
+            {{- ", selector matches no pods (no-op)" | yellow }}
+        {{- else if $budgetViolated }}
+            {{- printf ", budget violated (%d/%d healthy, %d required)" ($obj.Status.currentHealthy | int) ($obj.Status.expectedPods | int) ($obj.Status.desiredHealthy | int) | red | bold }}
+        {{- else if $noDisruptions }}
+            {{- ", evictions/drains currently blocked" | yellow }}
+        {{- else }}
+            {{- ", " }}{{ "disruptions allowed" | green }}
+        {{- end }}
+    {{- end }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/workloads/ReplicaSet.tmpl
@@ -50,3 +50,12 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end }}
+
+{{- define "ReplicaSet.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (ReplicaSet RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
+           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/StatefulSet.tmpl
+++ b/pkg/plugin/templates/workloads/StatefulSet.tmpl
@@ -185,3 +185,12 @@
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{- define "StatefulSet.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (StatefulSet RenderableObject) "callerNamespace" (unused, kept for the
+           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
+           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
+           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" .obj }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
@@ -52,3 +52,20 @@
     {{- template "events" . }}
     {{- template "owners" . }}
 {{- end -}}
+
+{{- define "VerticalPodAutoscaler.summary" }}
+    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Expects dict "obj" (VerticalPodAutoscaler RenderableObject) "callerNamespace" (unused,
+           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
+           template shares -- see resource_health_summary). */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- $updateMode := ($obj.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
+    {{- if ne $updateMode "Auto" }}, {{ $updateMode | cyan }}{{ end }}
+    {{- range ($obj.Status.recommendation | default dict).containerRecommendations }}
+        {{- $t := .target | default dict }}
+        {{- printf ", %s:" .containerName }}
+        {{- with $t.cpu }} cpu={{ . | cyan }}{{ end }}
+        {{- with $t.memory }} mem={{ . | cyan }}{{ end }}
+    {{- end }}
+{{- end -}}

--- a/pkg/plugin/templates/workloads/workloads_common.tmpl
+++ b/pkg/plugin/templates/workloads/workloads_common.tmpl
@@ -288,43 +288,6 @@
     {{- printf "selected by %s %s (%s restricted)" $label (join ", " $names | cyan) (join ", " $directions) }}
 {{- end }}
 
-{{- define "job_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- if .Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
-    {{- if .Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}
-    {{- if .Status.failed }}, {{ printf "Failed: %d" (.Status.failed | int) | red | bold }}{{ end }}
-    {{- if .Status.startTime }}, started {{ .Status.startTime | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- if and .Status.startTime .Status.completionTime }}
-        {{- $started := .Status.startTime | toDate "2006-01-02T15:04:05Z" -}}
-        {{- $completed := .Status.completionTime | toDate "2006-01-02T15:04:05Z" -}}
-        {{- ", ran for " }}{{ $completed.Sub $started | colorDuration }}
-    {{- end }}
-{{- end -}}
-
-{{- define "pdb_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- $budgetViolated := lt (.Status.currentHealthy | int) (.Status.desiredHealthy | int) }}
-    {{- $noDisruptions := and (.Status | hasKey "disruptionsAllowed") (eq (.Status.disruptionsAllowed | int) 0) }}
-    {{- $noOp := and (.Status | hasKey "expectedPods") (eq (.Status.expectedPods | int) 0) }}
-    {{- with .Spec.minAvailable }}, min available={{ . | toString | cyan }}{{ end }}
-    {{- with .Spec.maxUnavailable }}, max unavailable={{ . | toString | cyan }}{{ end }}
-    {{- if .Status | hasKey "currentHealthy" }}
-        {{- if $noOp }}
-            {{- ", selector matches no pods (no-op)" | yellow }}
-        {{- else if $budgetViolated }}
-            {{- printf ", budget violated (%d/%d healthy, %d required)" (.Status.currentHealthy | int) (.Status.expectedPods | int) (.Status.desiredHealthy | int) | red | bold }}
-        {{- else if $noDisruptions }}
-            {{- ", evictions/drains currently blocked" | yellow }}
-        {{- else }}
-            {{- ", " }}{{ "disruptions allowed" | green }}
-        {{- end }}
-    {{- end }}
-{{- end -}}
-
 {{- define "pdb_conflict_warning" }}
     {{- /* Expects a slice of matched PodDisruptionBudget RenderableObjects. Kubernetes doesn't
            support a pod being covered by more than one PDB -- eviction requests for such pods
@@ -356,7 +319,7 @@
                 {{- end }}
             {{- else }}
                 {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
-                    {{- $.Include "pod_health_summary" (dict "pod" . "callerNamespace" $.Namespace) | nindent 4 }}
+                    {{- $.Include "Pod.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -377,11 +340,11 @@
                 {{- $ctx.Include "Service" . | nindent 4 }}
             {{- end }}
         {{- else if eq (len .) 1 }}
-            {{- "Services:" | bold | nindent 2 }} {{ $ctx.Include "service_health_summary" (index . 0) }}
+            {{- "Services:" | bold | nindent 2 }} {{ $ctx.Include "Service.summary" (dict "obj" (index . 0)) }}
         {{- else }}
             {{- "Services:" | bold | nindent 2 }}
             {{- range . }}
-                {{- $ctx.Include "service_health_summary" . | nindent 4 }}
+                {{- $ctx.Include "Service.summary" (dict "obj" .) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -401,11 +364,11 @@
                     {{- $ctx.Include "PodDisruptionBudget" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $pdbs) 1 }}
-                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $ctx.Include "pdb_health_summary" (index $pdbs 0) }}
+                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $ctx.Include "PodDisruptionBudget.summary" (dict "obj" (index $pdbs 0)) }}
             {{- else }}
                 {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
                 {{- range $pdbs }}
-                    {{- $ctx.Include "pdb_health_summary" . | nindent 4 }}
+                    {{- $ctx.Include "PodDisruptionBudget.summary" (dict "obj" .) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -497,16 +460,6 @@
     {{- end }}
 {{- end }}
 
-{{- define "hpa_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- $minReplicas := 1 }}{{- if .Spec | hasKey "minReplicas" }}{{- $minReplicas = .Spec.minReplicas | int }}{{- end }}
-    {{- $current := .Status.currentReplicas | default 0 | int }}
-    {{- $desired := .Status.desiredReplicas | default 0 | int }}
-    {{- printf ", %d" $current | redBoldIf (ne $current $desired) }}/{{ printf "%d-%d" $minReplicas (.Spec.maxReplicas | int) }}
-    {{- if ne $current $desired }}, {{ "desired" | yellow | bold }}: {{ printf "%d" $desired | yellow }}{{ end }}
-{{- end -}}
-
 {{- define "matching_hpas" }}
     {{- /* Expects dict "ctx" (RenderableObject) "namespace" "kind" "name" (this workload's own
            identity). HorizontalPodAutoscaler doesn't get discovered via labels -- it names its
@@ -535,29 +488,16 @@
                     {{- $ctx.Include "HorizontalPodAutoscaler" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $hpas) 1 }}
-                {{- "HorizontalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "hpa_health_summary" (index $hpas 0) }}
+                {{- "HorizontalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" (index $hpas 0)) }}
             {{- else }}
                 {{- "HorizontalPodAutoscalers:" | bold | nindent 2 }}
                 {{- range $hpas }}
-                    {{- $ctx.Include "hpa_health_summary" . | nindent 4 }}
+                    {{- $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" .) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
     {{- end }}
 {{- end }}
-
-{{- define "vpa_health_summary" }}
-    {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- $updateMode := (.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
-    {{- if ne $updateMode "Auto" }}, {{ $updateMode | cyan }}{{ end }}
-    {{- range (.Status.recommendation | default dict).containerRecommendations }}
-        {{- $t := .target | default dict }}
-        {{- printf ", %s:" .containerName }}
-        {{- with $t.cpu }} cpu={{ . | cyan }}{{ end }}
-        {{- with $t.memory }} mem={{ . | cyan }}{{ end }}
-    {{- end }}
-{{- end -}}
 
 {{- define "matching_vpas" }}
     {{- /* Expects dict "ctx" (RenderableObject) "namespace" "kind" "name" (this workload's own
@@ -585,11 +525,11 @@
                     {{- $ctx.Include "VerticalPodAutoscaler" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $vpas) 1 }}
-                {{- "VerticalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "vpa_health_summary" (index $vpas 0) }}
+                {{- "VerticalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" (index $vpas 0)) }}
             {{- else }}
                 {{- "VerticalPodAutoscalers:" | bold | nindent 2 }}
                 {{- range $vpas }}
-                    {{- $ctx.Include "vpa_health_summary" . | nindent 4 }}
+                    {{- $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" .) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -234,18 +234,18 @@ func TestPodNodeProblemFlags(t *testing.T) {
 			if strings.TrimSpace(got) != tt.want {
 				t.Errorf("pod_node_problem_flags got = %q, want %q", got, tt.want)
 			}
-			// pod_health_summary is where those flags actually reach a reader (it renders one
+			// Pod.summary is where those flags actually reach a reader (it renders one
 			// line per Pod under a Job/ReplicaSet/PDB/...), so it's asserted on directly rather
 			// than trusted to pass the fragment through unchanged.
-			summary, err := pod.renderTemplate("pod_health_summary", map[string]interface{}{"pod": pod})
+			summary, err := pod.renderTemplate("Pod.summary", map[string]interface{}{"obj": pod})
 			if err != nil {
 				t.Fatalf("renderTemplate() error = %v", err)
 			}
 			if tt.want == "" && strings.Contains(summary, "node ") {
-				t.Errorf("pod_health_summary got = %q, want no node problems reported", summary)
+				t.Errorf("Pod.summary got = %q, want no node problems reported", summary)
 			}
 			if tt.want != "" && !strings.Contains(summary, tt.want) {
-				t.Errorf("pod_health_summary got = %q, should contain %q", summary, tt.want)
+				t.Errorf("Pod.summary got = %q, should contain %q", summary, tt.want)
 			}
 		})
 	}
@@ -1578,6 +1578,111 @@ func TestResourceHealthSummaryTemplate_FallsBackToGenericForUnknownKind(t *testi
 	}
 	if !strings.Contains(got, "Current: Resource is Ready") {
 		t.Errorf("got = %q, want the generic_health_summary fallback", got)
+	}
+}
+
+// summaryTemplateFixture is a minimal object for a Kind that defines "<Kind>.summary", just
+// enough for the summary template's own field reads to not hit a template execution error (a
+// missing map key is safe in text/template, but e.g. an `| int` conversion on a wrong-shaped
+// value is not). Anything not listed here renders against an empty object, which every
+// "<Kind>.summary" template must also already tolerate -- it's exactly what a freshly-created
+// object of that Kind (no status yet) looks like.
+var summaryTemplateFixtures = map[string]map[string]interface{}{
+	"Pod": {
+		"status": map[string]interface{}{
+			"phase": "Running",
+			"containerStatuses": []interface{}{
+				map[string]interface{}{"ready": true, "restartCount": int64(0)},
+			},
+		},
+	},
+	"Service": {
+		"spec": map[string]interface{}{"type": "ClusterIP"},
+	},
+	"Ingress": {
+		"spec":   map[string]interface{}{"rules": []interface{}{map[string]interface{}{"host": "example.com"}}},
+		"status": map[string]interface{}{"loadBalancer": map[string]interface{}{"ingress": []interface{}{map[string]interface{}{"ip": "1.2.3.4"}}}},
+	},
+	"HTTPRoute": {"spec": map[string]interface{}{"hostnames": []interface{}{"example.com"}}},
+	"GRPCRoute": {"spec": map[string]interface{}{"hostnames": []interface{}{"example.com"}}},
+	"TCPRoute":  {"spec": map[string]interface{}{"hostnames": []interface{}{"example.com"}}},
+	"UDPRoute":  {"spec": map[string]interface{}{"hostnames": []interface{}{"example.com"}}},
+	"TLSRoute":  {"spec": map[string]interface{}{"hostnames": []interface{}{"example.com"}}},
+	"Job": {
+		"status": map[string]interface{}{
+			"active": int64(1), "succeeded": int64(0), "failed": int64(0),
+			"startTime": "2026-06-01T00:00:00Z", "completionTime": "2026-06-01T00:05:00Z",
+		},
+	},
+	"PodDisruptionBudget": {
+		"spec": map[string]interface{}{"minAvailable": "1"},
+		"status": map[string]interface{}{
+			"currentHealthy": int64(1), "desiredHealthy": int64(1),
+			"expectedPods": int64(1), "disruptionsAllowed": int64(1),
+		},
+	},
+	"Deployment":  {"spec": map[string]interface{}{"replicas": int64(2)}, "status": map[string]interface{}{"readyReplicas": int64(2)}},
+	"StatefulSet": {"spec": map[string]interface{}{"replicas": int64(2)}, "status": map[string]interface{}{"readyReplicas": int64(2)}},
+	"DaemonSet":   {"status": map[string]interface{}{"desiredNumberScheduled": int64(2), "numberReady": int64(2)}},
+	"ReplicaSet":  {"spec": map[string]interface{}{"replicas": int64(2)}, "status": map[string]interface{}{"readyReplicas": int64(2)}},
+	"HorizontalPodAutoscaler": {
+		"spec":   map[string]interface{}{"minReplicas": int64(1), "maxReplicas": int64(5)},
+		"status": map[string]interface{}{"currentReplicas": int64(2), "desiredReplicas": int64(2)},
+	},
+	"VerticalPodAutoscaler": {
+		"spec": map[string]interface{}{"updatePolicy": map[string]interface{}{"updateMode": "Auto"}},
+		"status": map[string]interface{}{"recommendation": map[string]interface{}{"containerRecommendations": []interface{}{
+			map[string]interface{}{"containerName": "app", "target": map[string]interface{}{"cpu": "100m", "memory": "128Mi"}},
+		}}},
+	},
+}
+
+// TestSummaryTemplatesRenderOneLine is the static check #826 asks for: every embedded
+// "<Kind>.summary"/"<Kind>.<group>.summary" template (the convention resource_health_summary
+// dispatches to via RenderableObject.HealthSummary, see findSummaryTemplateName) is documented
+// as a *compact one-line* summary -- used anywhere a list renders one entry per row
+// (managed_resource_line, matching_services, crossplane_composed_resources, ...). A future
+// "<Kind>.summary" (built-in or a user override) that picks up a stray newline would silently
+// break every list that renders it, one row at a time, with nothing today to catch it. This
+// enumerates every such define the same way kindTemplateNames enumerates "<Kind>.tmpl" files, so
+// a newly added "<Kind>.summary" is covered automatically, without a test author needing to
+// remember to add a case.
+func TestSummaryTemplatesRenderOneLine(t *testing.T) {
+	v := viper.New()
+	cfg := NewRenderConfig(v)
+	ts, err := getTemplate(cfg)
+	if err != nil {
+		t.Fatalf("getTemplate() error = %v", err)
+	}
+	var names []string
+	for _, tmpl := range ts.embedded.Templates() {
+		if strings.HasSuffix(tmpl.Name(), ".summary") {
+			names = append(names, tmpl.Name())
+		}
+	}
+	if len(names) == 0 {
+		t.Fatal("no \"<Kind>.summary\" templates found -- did the naming convention change?")
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			kind := strings.SplitN(name, ".", 2)[0]
+			extra := summaryTemplateFixtures[kind]
+			obj := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       kind,
+				"metadata":   map[string]interface{}{"name": "fixture", "namespace": "test"},
+			}
+			for k, v := range extra {
+				obj[k] = v
+			}
+			got, err := renderObjHealthSummary(t, name, obj, "test")
+			if err != nil {
+				t.Fatalf("renderTemplate(%q) error = %v", name, err)
+			}
+			if strings.Contains(got, "\n") {
+				t.Errorf("%s rendered %d lines, want exactly one: %q", name, strings.Count(got, "\n")+1, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `resource_health_summary` (`common.tmpl`) was a hand-maintained if/else chain over ~14 Kinds. Replaces it with `RenderableObject.HealthSummary`, which looks up `"<Kind>.summary"` (or `"<Kind>.<group>.summary"` for a Kind name that collides across API groups, e.g. Gateway API vs. Istio `Gateway`) via `templateSet.findSummaryTemplateName` — the same `"<Kind>.<group>"`/`"<Kind>"` preference `findTemplateName` already uses for full Kind views, just with a `.summary` suffix — falling back to `generic_health_summary`.
- Each Kind's own `"<Kind>.summary"` now lives alongside its `<Kind>.tmpl` (moved out of `common.tmpl`/`*_common.tmpl`), and is discovered automatically — a user override or a template shipped for a custom CRD kind participates in `resource_health_summary` (e.g. `crossplane_composed_resources`' mixed-kind lists) just by defining `"<Kind>.summary"`, without touching `common.tmpl`.
- `route_health_summary` (5 Gateway API route kinds) and `workload_health_summary` (Deployment/StatefulSet/DaemonSet/ReplicaSet) stay as shared bodies since they're genuinely multi-Kind; each owning Kind gets a one-line `"<Kind>.summary"` wrapper around the shared body.
- Adds `TestSummaryTemplatesRenderOneLine`, a static check enumerating every embedded `"<Kind>.summary"` define and asserting it renders to a single line — the whole contract of a list rendering one entry per row (`managed_resource_line`, `matching_services`, `crossplane_composed_resources`, ...). A newly added `"<Kind>.summary"` is covered automatically.
- Updates `TEMPLATE-API.md`'s Health-summary family / Kind templates sections and `CONVENTIONS.md`'s Rendering depth table for the new names.

Fixes #826.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `make staticcheck`
- [x] `go test ./...` (unit tests, including the new `TestSummaryTemplatesRenderOneLine`)
- [x] `go test ./cmd/... -v` (all local/regex artifact fixtures, `TestAllArtifactsLocal*`)
- [x] Manually verified the new static check catches a regression (injected a stray newline into `Job.summary`, confirmed the test fails, reverted)