### PR TITLE
Add --short flag to print each resource's one-line health summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,14 @@ without an entry here.
 
 ### Breaking template API changes
 
-_None yet._
+- `callerNamespace` on `Deployment.summary`, `StatefulSet.summary`, `DaemonSet.summary`,
+  `ReplicaSet.summary`, `Job.summary`, `Ingress.summary`, `Service.summary`,
+  `PodDisruptionBudget.summary`, `HorizontalPodAutoscaler.summary`,
+  `VerticalPodAutoscaler.summary`, and
+  `HTTPRoute.summary`/`GRPCRoute.summary`/`TCPRoute.summary`/`UDPRoute.summary`/`TLSRoute.summary`
+  was previously accepted but silently ignored (documented as "unused, kept for the uniform
+  contract"); it is now honored the same way every other `"<Kind>.summary"` template already
+  honors it — passed through to `resource_ref` so the object's own namespace is dropped from the
+  one-line summary only when it equals `callerNamespace`. A `~/.kubectl-status/templates/*.tmpl`
+  override of any of these `.summary` names that relied on the namespace always being omitted
+  should pass its own namespace as `callerNamespace` explicitly if it wants that behavior back.

--- a/cmd/local_test.go
+++ b/cmd/local_test.go
@@ -178,3 +178,29 @@ func TestAllArtifactsLocalWithAbsoluteTime(t *testing.T) {
 		})
 	}
 }
+
+// TestAllArtifactsLocalShort covers the --short flag (cmd/main.go/pkg/plugin/plugin.go's
+// processObjShort): one "<Kind>.summary" line per matching resource instead of the full view, with
+// no blank-line spacing around/between them. multiple-2-pods-docs.yaml is the case that matters
+// most here -- two resources from one -f render, each on its own line with no separating blank
+// line, which the full (non---short) view always inserts between resources (see processObj).
+func TestAllArtifactsLocalShort(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/dev/null")
+	opts := combineOpts(testHackOpts(t), viperTestHackOpts())
+	artifacts := []string{
+		"../tests/artifacts/deployment-healthy.yaml",
+		"../tests/artifacts/multiple-2-pods-docs.yaml",
+	}
+	for _, artifact := range artifacts {
+		artifact := artifact
+		name := strings.Replace(artifact, "../tests/", "", 1)
+		name = strings.Replace(name, ".yaml", "", 1)
+		t.Run(name, func(t *testing.T) {
+			test := cmdTest{
+				args:            []string{"-f", artifact, "--local", "--short"},
+				stdoutEqualPath: name + ".short.out",
+			}
+			test.assert(t, nil, opts...)
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -248,6 +248,8 @@ func addRenderFlags(flags *pflag.FlagSet) {
 		"Set all --include-* flags to true and let user selectively disable them.")
 	flags.BoolP("watch", "w", false,
 		"After listing/getting the requested object, watch for changes.")
+	flags.Bool("short", false,
+		"Print only each matching resource's one-line health summary (its \"<Kind>.summary\" template) instead of the full view, one line per resource.")
 	flags.Bool("help-all", false,
 		"Show all available flags.")
 	flags.String("color", "auto",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -104,7 +104,6 @@ func runWatch(results *resource.Result, engine *renderEngine, repo *input.Resour
 
 func processObj(obj runtime.Object, engine *renderEngine, repo *input.ResourceRepo) {
 	streams := engine.ioStreams
-	_, _ = fmt.Fprintf(streams.Out, "\n")
 	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		errorPrintf(streams.ErrOut, "Failed to decode obj=%s: %s", obj, err)
@@ -112,6 +111,11 @@ func processObj(obj runtime.Object, engine *renderEngine, repo *input.ResourceRe
 	}
 	engine.renderedUIDs = make(uidSet)
 	r := newRenderableObject(out, engine, repo)
+	if engine.cfg.Viper.GetBool("short") {
+		processObjShort(r, streams)
+		return
+	}
+	_, _ = fmt.Fprintf(streams.Out, "\n")
 	err = r.render(streams.Out)
 	if err != nil {
 		_, _ = fmt.Fprintf(streams.ErrOut, "\n")
@@ -119,4 +123,19 @@ func processObj(obj runtime.Object, engine *renderEngine, repo *input.ResourceRe
 		return
 	}
 	_, _ = fmt.Fprintf(streams.Out, "\n")
+}
+
+// processObjShort prints r's compact one-line health summary (its own "<Kind>.summary" template,
+// see RenderableObject.HealthSummary) rather than the full view -- one line per matching resource,
+// with no blank-line spacing, so --short output stays grep/pipe friendly. callerNamespace is left
+// empty (rather than the current --namespace) so the summary's "-n ns" clause always shows: unlike
+// the full view (one resource at a time, namespace already in the surrounding context), --short's
+// output is a flat list that may span namespaces (e.g. under --all-namespaces).
+func processObjShort(r RenderableObject, streams genericiooptions.IOStreams) {
+	summary, err := r.HealthSummary("")
+	if err != nil {
+		errorPrintf(streams.ErrOut, "Failed to render: %s", err)
+		return
+	}
+	_, _ = fmt.Fprintln(streams.Out, summary)
 }

--- a/pkg/plugin/templates/core/Ingress.tmpl
+++ b/pkg/plugin/templates/core/Ingress.tmpl
@@ -32,7 +32,7 @@
                     {{- if not $portDefinedInSvc }}
                         {{- "Service port doesnt exist" | red | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" "Service" "name" $ingSvcName) }}:{{ $ingSvcPort }} referenced in ingress, but Service doesn't have that port defined.
                     {{- else if not ($shownSvcs | has $ingSvcName) }}
-                        {{- $.Include "Service.summary" (dict "obj" $svc) | nindent 2 }}
+                        {{- $.Include "Service.summary" (dict "obj" $svc "callerNamespace" $.Namespace) | nindent 2 }}
                         {{- $shownSvcs = $shownSvcs | append $ingSvcName }}
                     {{- end }}
                 {{- end }}
@@ -89,11 +89,11 @@
 
 {{- define "Ingress.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (Ingress RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (Ingress RenderableObject) "callerNamespace" (optional -- forwarded
+           to resource_ref so obj's own namespace is dropped from the summary when it's redundant,
+           same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with $obj.Spec.rules }}, {{ range $index, $rule := . }}{{ if $index }}, {{ end }}{{ $rule.host | cyan }}{{ end }}{{ end }}
     {{- with $obj.Status.loadBalancer.ingress }}

--- a/pkg/plugin/templates/core/Service.tmpl
+++ b/pkg/plugin/templates/core/Service.tmpl
@@ -71,11 +71,11 @@
 
 {{- define "Service.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (Service RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (Service RenderableObject) "callerNamespace" (optional -- forwarded
+           to resource_ref so obj's own namespace is dropped from the summary when it's redundant,
+           same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with $obj.Spec }}{{ with .type }}, {{ if eq . "NodePort" }}{{ . | yellow | bold }}{{ else }}{{ . | colorKeyword }}{{ end }}{{ end }}{{ end }}
     {{- $slices := $obj.KubeGetEndpointSlicesForService $obj.Namespace $obj.Name }}
@@ -149,7 +149,7 @@
             {{- if $.Config.GetBool "deep" }}
                 {{- $.IncludeRenderableObject $ing | nindent 4 }}
             {{- else }}
-                {{- $.Include "Ingress.summary" (dict "obj" $ing) | nindent 4 }}
+                {{- $.Include "Ingress.summary" (dict "obj" $ing "callerNamespace" $.Namespace) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -165,7 +165,7 @@
             {{- if $.Config.GetBool "deep" }}
                 {{- $.IncludeRenderableObject $route | nindent 4 }}
             {{- else }}
-                {{- $.Include "route_health_summary" $route | nindent 4 }}
+                {{- $.Include "route_health_summary" (dict "obj" $route "callerNamespace" $.Namespace) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/GRPCRoute.tmpl
@@ -53,9 +53,9 @@
 
 {{- define "GRPCRoute.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (GRPCRoute RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
-           by all five Gateway API route kinds. */ -}}
-    {{- template "route_health_summary" .obj }}
+    {{- /* Expects dict "obj" (GRPCRoute RenderableObject) "callerNamespace" (optional -- forwarded
+           to route_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). route_health_summary (gatewayapi_common.tmpl)
+           is shared by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/HTTPRoute.tmpl
@@ -100,9 +100,9 @@
 
 {{- define "HTTPRoute.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (HTTPRoute RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
-           by all five Gateway API route kinds. */ -}}
-    {{- template "route_health_summary" .obj }}
+    {{- /* Expects dict "obj" (HTTPRoute RenderableObject) "callerNamespace" (optional -- forwarded
+           to route_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). route_health_summary (gatewayapi_common.tmpl)
+           is shared by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TCPRoute.tmpl
@@ -35,9 +35,9 @@
 
 {{- define "TCPRoute.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (TCPRoute RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
-           by all five Gateway API route kinds. */ -}}
-    {{- template "route_health_summary" .obj }}
+    {{- /* Expects dict "obj" (TCPRoute RenderableObject) "callerNamespace" (optional -- forwarded
+           to route_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). route_health_summary (gatewayapi_common.tmpl)
+           is shared by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/TLSRoute.tmpl
@@ -40,9 +40,9 @@
 
 {{- define "TLSRoute.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (TLSRoute RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
-           by all five Gateway API route kinds. */ -}}
-    {{- template "route_health_summary" .obj }}
+    {{- /* Expects dict "obj" (TLSRoute RenderableObject) "callerNamespace" (optional -- forwarded
+           to route_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). route_health_summary (gatewayapi_common.tmpl)
+           is shared by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
+++ b/pkg/plugin/templates/gatewayapi/UDPRoute.tmpl
@@ -11,9 +11,9 @@
 
 {{- define "UDPRoute.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (UDPRoute RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). route_health_summary (gatewayapi_common.tmpl) is shared
-           by all five Gateway API route kinds. */ -}}
-    {{- template "route_health_summary" .obj }}
+    {{- /* Expects dict "obj" (UDPRoute RenderableObject) "callerNamespace" (optional -- forwarded
+           to route_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). route_health_summary (gatewayapi_common.tmpl)
+           is shared by all five Gateway API route kinds. */ -}}
+    {{- template "route_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
+++ b/pkg/plugin/templates/gatewayapi/gatewayapi_common.tmpl
@@ -1,14 +1,16 @@
 {{- define "route_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Shared compact summary for HTTPRoute, GRPCRoute, TCPRoute, UDPRoute and TLSRoute --
-           takes the route RenderableObject directly (not the dict "obj"/"callerNamespace" shape
-           the "<Kind>.summary" entry points use) since matching_routes in core/Service.tmpl calls
-           it directly today; each route kind's own "<Kind>.summary" (in its own <Kind>.tmpl) is a
-           thin wrapper around this. */ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- with .Spec.hostnames }}, {{ join ", " . | cyan }}{{ end }}
-    {{- with $.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
+    {{- /* Shared compact summary for HTTPRoute, GRPCRoute, TCPRoute, UDPRoute and TLSRoute.
+           Expects dict "obj" (route RenderableObject) "callerNamespace" (optional -- forwarded to
+           resource_ref so obj's own namespace is dropped from the summary when it's redundant,
+           same contract every "<Kind>.summary" template uses). Each route kind's own
+           "<Kind>.summary" (in its own <Kind>.tmpl) is a thin wrapper around this; matching_routes
+           in core/Service.tmpl also calls it directly. */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- with $obj.Spec.hostnames }}, {{ join ", " . | cyan }}{{ end }}
+    {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ end }}
 {{- end -}}
 
 {{- define "gwapi_backend_ref" }}

--- a/pkg/plugin/templates/workloads/CronJob.tmpl
+++ b/pkg/plugin/templates/workloads/CronJob.tmpl
@@ -34,7 +34,7 @@
             {{- if $.Config.GetBool "deep" }}
                 {{- $.IncludeRenderableObject . | nindent 4 }}
             {{- else }}
-                {{- $.Include "Job.summary" (dict "obj" .) | nindent 4 }}
+                {{- $.Include "Job.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/workloads/DaemonSet.tmpl
+++ b/pkg/plugin/templates/workloads/DaemonSet.tmpl
@@ -95,9 +95,9 @@
 
 {{- define "DaemonSet.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (DaemonSet RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
-           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
-    {{- template "workload_health_summary" .obj }}
+    {{- /* Expects dict "obj" (DaemonSet RenderableObject) "callerNamespace" (optional -- forwarded
+           to workload_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). workload_health_summary (workloads_common.tmpl)
+           is shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/workloads/Deployment.tmpl
+++ b/pkg/plugin/templates/workloads/Deployment.tmpl
@@ -118,9 +118,9 @@
 
 {{- define "Deployment.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (Deployment RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
-           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
-    {{- template "workload_health_summary" .obj }}
+    {{- /* Expects dict "obj" (Deployment RenderableObject) "callerNamespace" (optional -- forwarded
+           to workload_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). workload_health_summary (workloads_common.tmpl)
+           is shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
@@ -89,11 +89,11 @@
 
 {{- define "HorizontalPodAutoscaler.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (HorizontalPodAutoscaler RenderableObject) "callerNamespace" (unused,
-           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
-           template shares -- see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (HorizontalPodAutoscaler RenderableObject) "callerNamespace" (optional
+           -- forwarded to resource_ref so obj's own namespace is dropped from the summary when
+           it's redundant, same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- $minReplicas := 1 }}{{- if $obj.Spec | hasKey "minReplicas" }}{{- $minReplicas = $obj.Spec.minReplicas | int }}{{- end }}
     {{- $current := $obj.Status.currentReplicas | default 0 | int }}
     {{- $desired := $obj.Status.desiredReplicas | default 0 | int }}

--- a/pkg/plugin/templates/workloads/Job.tmpl
+++ b/pkg/plugin/templates/workloads/Job.tmpl
@@ -77,11 +77,11 @@
 
 {{- define "Job.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (Job RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (Job RenderableObject) "callerNamespace" (optional -- forwarded to
+           resource_ref so obj's own namespace is dropped from the summary when it's redundant,
+           same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- if $obj.Status.active }}, {{ "Active" | yellow | bold }}{{ end }}
     {{- if $obj.Status.succeeded }}, {{ "Succeeded" | green }}{{ end }}

--- a/pkg/plugin/templates/workloads/PodDisruptionBudget.tmpl
+++ b/pkg/plugin/templates/workloads/PodDisruptionBudget.tmpl
@@ -39,17 +39,17 @@
                 {{- $daemonsets := $.KubeGetByLabelsMap $.Namespace "daemonsets" $matchLabels }}
                 {{- $statefulsets := $.KubeGetByLabelsMap $.Namespace "statefulsets" $matchLabels }}
                 {{- range $svcs }}
-                    {{- $.Include "Service.summary" (dict "obj" .) | nindent 4 }}
+                    {{- $.Include "Service.summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                 {{- end }}
                 {{- if or $deploys $daemonsets $statefulsets }}
                     {{- range $deploys }}
-                        {{- $.Include "workload_health_summary" . | nindent 4 }}
+                        {{- $.Include "workload_health_summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                     {{- end }}
                     {{- range $daemonsets }}
-                        {{- $.Include "workload_health_summary" . | nindent 4 }}
+                        {{- $.Include "workload_health_summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                     {{- end }}
                     {{- range $statefulsets }}
-                        {{- $.Include "workload_health_summary" . | nindent 4 }}
+                        {{- $.Include "workload_health_summary" (dict "obj" . "callerNamespace" $.Namespace) | nindent 4 }}
                     {{- end }}
                 {{- else }}
                     {{- range $.KubeGetByLabelsMap $.Namespace "pods" $matchLabels }}
@@ -87,11 +87,11 @@
 
 {{- define "PodDisruptionBudget.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (PodDisruptionBudget RenderableObject) "callerNamespace" (unused,
-           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
-           template shares -- see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (PodDisruptionBudget RenderableObject) "callerNamespace" (optional --
+           forwarded to resource_ref so obj's own namespace is dropped from the summary when it's
+           redundant, same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- $budgetViolated := lt ($obj.Status.currentHealthy | int) ($obj.Status.desiredHealthy | int) }}
     {{- $noDisruptions := and ($obj.Status | hasKey "disruptionsAllowed") (eq ($obj.Status.disruptionsAllowed | int) 0) }}

--- a/pkg/plugin/templates/workloads/ReplicaSet.tmpl
+++ b/pkg/plugin/templates/workloads/ReplicaSet.tmpl
@@ -53,9 +53,9 @@
 
 {{- define "ReplicaSet.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (ReplicaSet RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
-           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
-    {{- template "workload_health_summary" .obj }}
+    {{- /* Expects dict "obj" (ReplicaSet RenderableObject) "callerNamespace" (optional -- forwarded
+           to workload_health_summary/resource_ref, same contract every "<Kind>.summary" template
+           shares -- see resource_health_summary). workload_health_summary (workloads_common.tmpl)
+           is shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/workloads/StatefulSet.tmpl
+++ b/pkg/plugin/templates/workloads/StatefulSet.tmpl
@@ -188,9 +188,9 @@
 
 {{- define "StatefulSet.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (StatefulSet RenderableObject) "callerNamespace" (unused, kept for the
-           uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary" template shares --
-           see resource_health_summary). workload_health_summary (workloads_common.tmpl) is
-           shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
-    {{- template "workload_health_summary" .obj }}
+    {{- /* Expects dict "obj" (StatefulSet RenderableObject) "callerNamespace" (optional --
+           forwarded to workload_health_summary/resource_ref, same contract every "<Kind>.summary"
+           template shares -- see resource_health_summary). workload_health_summary
+           (workloads_common.tmpl) is shared by Deployment/StatefulSet/DaemonSet/ReplicaSet. */ -}}
+    {{- template "workload_health_summary" . }}
 {{- end -}}

--- a/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
@@ -55,11 +55,11 @@
 
 {{- define "VerticalPodAutoscaler.summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- /* Expects dict "obj" (VerticalPodAutoscaler RenderableObject) "callerNamespace" (unused,
-           kept for the uniform dict "obj"/"callerNamespace" contract every "<Kind>.summary"
-           template shares -- see resource_health_summary). */ -}}
+    {{- /* Expects dict "obj" (VerticalPodAutoscaler RenderableObject) "callerNamespace" (optional
+           -- forwarded to resource_ref so obj's own namespace is dropped from the summary when
+           it's redundant, same contract every "<Kind>.summary" template uses). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
     {{- $updateMode := ($obj.Spec.updatePolicy | default dict).updateMode | default "Auto" }}
     {{- if ne $updateMode "Auto" }}, {{ $updateMode | cyan }}{{ end }}
     {{- range ($obj.Status.recommendation | default dict).containerRecommendations }}

--- a/pkg/plugin/templates/workloads/workloads_common.tmpl
+++ b/pkg/plugin/templates/workloads/workloads_common.tmpl
@@ -340,11 +340,11 @@
                 {{- $ctx.Include "Service" . | nindent 4 }}
             {{- end }}
         {{- else if eq (len .) 1 }}
-            {{- "Services:" | bold | nindent 2 }} {{ $ctx.Include "Service.summary" (dict "obj" (index . 0)) }}
+            {{- "Services:" | bold | nindent 2 }} {{ $ctx.Include "Service.summary" (dict "obj" (index . 0) "callerNamespace" $ctx.Namespace) }}
         {{- else }}
             {{- "Services:" | bold | nindent 2 }}
             {{- range . }}
-                {{- $ctx.Include "Service.summary" (dict "obj" .) | nindent 4 }}
+                {{- $ctx.Include "Service.summary" (dict "obj" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}
@@ -364,11 +364,11 @@
                     {{- $ctx.Include "PodDisruptionBudget" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $pdbs) 1 }}
-                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $ctx.Include "PodDisruptionBudget.summary" (dict "obj" (index $pdbs 0)) }}
+                {{- "PodDisruptionBudgets:" | bold | nindent 2 }} {{ $ctx.Include "PodDisruptionBudget.summary" (dict "obj" (index $pdbs 0) "callerNamespace" $ctx.Namespace) }}
             {{- else }}
                 {{- "PodDisruptionBudgets:" | bold | nindent 2 }}
                 {{- range $pdbs }}
-                    {{- $ctx.Include "PodDisruptionBudget.summary" (dict "obj" .) | nindent 4 }}
+                    {{- $ctx.Include "PodDisruptionBudget.summary" (dict "obj" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -488,11 +488,11 @@
                     {{- $ctx.Include "HorizontalPodAutoscaler" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $hpas) 1 }}
-                {{- "HorizontalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" (index $hpas 0)) }}
+                {{- "HorizontalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" (index $hpas 0) "callerNamespace" $ctx.Namespace) }}
             {{- else }}
                 {{- "HorizontalPodAutoscalers:" | bold | nindent 2 }}
                 {{- range $hpas }}
-                    {{- $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" .) | nindent 4 }}
+                    {{- $ctx.Include "HorizontalPodAutoscaler.summary" (dict "obj" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -525,11 +525,11 @@
                     {{- $ctx.Include "VerticalPodAutoscaler" . | nindent 4 }}
                 {{- end }}
             {{- else if eq (len $vpas) 1 }}
-                {{- "VerticalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" (index $vpas 0)) }}
+                {{- "VerticalPodAutoscaler:" | bold | nindent 2 }} {{ $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" (index $vpas 0) "callerNamespace" $ctx.Namespace) }}
             {{- else }}
                 {{- "VerticalPodAutoscalers:" | bold | nindent 2 }}
                 {{- range $vpas }}
-                    {{- $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" .) | nindent 4 }}
+                    {{- $ctx.Include "VerticalPodAutoscaler.summary" (dict "obj" . "callerNamespace" $ctx.Namespace) | nindent 4 }}
                 {{- end }}
             {{- end }}
         {{- end }}
@@ -576,16 +576,22 @@
 
 {{- define "workload_health_summary" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
-    {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
-    {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
-    {{- if eq .Kind "DaemonSet" }}
-        {{- $desired := .Status.desiredNumberScheduled | int }}
-        {{- $ready := .Status.numberReady | default 0 | int }}
+    {{- /* Expects dict "obj" (Deployment/StatefulSet/DaemonSet/ReplicaSet RenderableObject)
+           "callerNamespace" (optional -- forwarded to resource_ref so obj's own namespace is
+           dropped from the summary when it's redundant, same contract every "<Kind>.summary"
+           template uses). Shared by Deployment.summary/StatefulSet.summary/DaemonSet.summary/
+           ReplicaSet.summary and PodDisruptionBudget's matching-workloads listing. */ -}}
+    {{- $obj := .obj }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
+    {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
+    {{- if eq $obj.Kind "DaemonSet" }}
+        {{- $desired := $obj.Status.desiredNumberScheduled | int }}
+        {{- $ready := $obj.Status.numberReady | default 0 | int }}
         {{- if lt $ready $desired }}{{ printf ", %d/%d" $ready $desired | red | bold }}{{ else }}{{ printf ", %d/%d" $ready $desired | green }}{{ end }} scheduled
     {{- else }}
-        {{- $desired := 1 }}{{ if .Spec | hasKey "replicas" }}{{ $desired = .Spec.replicas | int }}{{ end }}
-        {{- $ready := .Status.readyReplicas | default 0 | int }}
+        {{- $desired := 1 }}{{ if $obj.Spec | hasKey "replicas" }}{{ $desired = $obj.Spec.replicas | int }}{{ end }}
+        {{- $ready := $obj.Status.readyReplicas | default 0 | int }}
         {{- if lt $ready $desired }}{{ printf ", %d/%d" $ready $desired | red | bold }}{{ else }}{{ printf ", %d/%d" $ready $desired | green }}{{ end }} ready
-        {{- with .RolloutStatus . }}{{ if not .done }}, {{ "rolling out" | yellow }}{{ end }}{{ end }}
+        {{- with $obj.RolloutStatus $obj }}{{ if not .done }}, {{ "rolling out" | yellow }}{{ end }}{{ end }}
     {{- end }}
 {{- end }}

--- a/pkg/plugin/templates_common_test.go
+++ b/pkg/plugin/templates_common_test.go
@@ -1686,6 +1686,67 @@ func TestSummaryTemplatesRenderOneLine(t *testing.T) {
 	}
 }
 
+// TestSummaryTemplatesRespectCallerNamespace guards the fix that accompanied the `--short` CLI
+// flag (cmd/main.go's processObjShort renders a "<Kind>.summary" standalone, one per matching
+// resource). Every "<Kind>.summary" template documents a `dict "obj" "callerNamespace"(opt)`
+// contract where the object's namespace is dropped from the one-line summary only when it equals
+// callerNamespace (see resource_ref) -- but the wrappers around workload_health_summary/
+// route_health_summary, plus Job.summary/Ingress.summary/Service.summary, used to accept
+// callerNamespace and silently ignore it, always omitting the namespace regardless of what was
+// passed. That was invisible to every caller before --short: they all render these nested under
+// something already in the same namespace, so the omitted namespace was never wrong -- merely
+// unconditional instead of conditional. --short is the first caller to render "<Kind>.summary"
+// standalone for a flat, possibly multi-namespace list, where an unconditionally omitted
+// namespace becomes ambiguous. This renders every "<Kind>.summary" template twice -- once with
+// callerNamespace equal to the object's own namespace (must omit "-n"), once with a different one
+// (must include "-n <objNamespace>") -- via the same enumeration TestSummaryTemplatesRenderOneLine
+// uses, so a newly added "<Kind>.summary" is covered automatically.
+func TestSummaryTemplatesRespectCallerNamespace(t *testing.T) {
+	v := viper.New()
+	cfg := NewRenderConfig(v)
+	ts, err := getTemplate(cfg)
+	if err != nil {
+		t.Fatalf("getTemplate() error = %v", err)
+	}
+	var names []string
+	for _, tmpl := range ts.embedded.Templates() {
+		if strings.HasSuffix(tmpl.Name(), ".summary") {
+			names = append(names, tmpl.Name())
+		}
+	}
+	if len(names) == 0 {
+		t.Fatal("no \"<Kind>.summary\" templates found -- did the naming convention change?")
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			kind := strings.SplitN(name, ".", 2)[0]
+			extra := summaryTemplateFixtures[kind]
+			obj := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       kind,
+				"metadata":   map[string]interface{}{"name": "fixture", "namespace": "test"},
+			}
+			for k, v := range extra {
+				obj[k] = v
+			}
+			sameNS, err := renderObjHealthSummary(t, name, obj, "test")
+			if err != nil {
+				t.Fatalf("renderTemplate(%q) error = %v", name, err)
+			}
+			if strings.Contains(sameNS, " -n ") {
+				t.Errorf("%s with callerNamespace == obj namespace: got %q, want no \" -n \" clause", name, sameNS)
+			}
+			otherNS, err := renderObjHealthSummary(t, name, obj, "other")
+			if err != nil {
+				t.Fatalf("renderTemplate(%q) error = %v", name, err)
+			}
+			if !strings.Contains(otherNS, " -n test") {
+				t.Errorf("%s with callerNamespace != obj namespace: got %q, want it to contain \" -n test\"", name, otherNS)
+			}
+		})
+	}
+}
+
 // TestQuotaHeadroomTemplate covers the rendered form of the quota headroom warning (issue #658):
 // the numbers come from quotaRolloutHeadroom's own tests, what's asserted here is that the section
 // reaches the reader with the ResourceQuota named, and with the two caveats the figures need --

--- a/tests/artifacts/deployment-healthy.short.out
+++ b/tests/artifacts/deployment-healthy.short.out
@@ -1,0 +1,1 @@
+Deployment/httpbin-deployment -n test1, created 1m ago, 3/3 ready

--- a/tests/artifacts/multiple-2-pods-docs.short.out
+++ b/tests/artifacts/multiple-2-pods-docs.short.out
@@ -1,0 +1,2 @@
+Pod/etcd-minikube -n kube-system, created 1m ago Running, 1/1 ready restarts:9
+Pod/storage-provisioner -n kube-system, created 1m ago Running, 1/1 ready restarts:16


### PR DESCRIPTION
## Summary

- Adds `--short`: prints each matching resource's one-line `"<Kind>.summary"` health summary instead of the full view — one line per resource, no blank-line spacing, works with `--watch` for free (reuses the existing per-object render loop).
- Fixes a latent bug the new flag surfaced: `Deployment.summary`/`StatefulSet.summary`/`DaemonSet.summary`/`ReplicaSet.summary`/`Job.summary`/`Ingress.summary`/`Service.summary`/`PodDisruptionBudget.summary`/`HorizontalPodAutoscaler.summary`/`VerticalPodAutoscaler.summary` and the five Gateway API route `.summary` templates accepted a `callerNamespace` parameter (documented in TEMPLATE-API.md as part of every `"<Kind>.summary"` template's contract) but silently ignored it, always omitting the namespace. Invisible everywhere these were previously rendered — always nested under something already in the same namespace — until `--short` became the first caller to render them standalone in a flat, possibly multi-namespace list.
- Adds a `CHANGELOG.md` entry per the project's own policy, since this changes a documented `dict` argument's meaning.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `make staticcheck`
- [x] New `TestSummaryTemplatesRespectCallerNamespace` in `pkg/plugin/templates_common_test.go` — renders every `"<Kind>.summary"` template with matching/differing `callerNamespace` and asserts the `-n ns` clause is dropped/shown accordingly (same enumeration `TestSummaryTemplatesRenderOneLine` already uses, so a new `.summary` template is covered automatically).
- [x] New `TestAllArtifactsLocalShort` in `cmd/local_test.go` against two golden fixtures (`deployment-healthy.short.out`, `multiple-2-pods-docs.short.out`) — the second proves two resources render as two lines with no blank-line separator.
- [x] Manually verified `--short` against fixtures with `--local`, including a synthetic multi-namespace file, confirming each line correctly shows/omits `-n ns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)