### PR TITLE
Cap VPA e2e burner's CPU with a Limit to stop starving the host

### DIFF
--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -140,6 +140,13 @@ func TestE2EDynamicManifests(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("16Mi"),
 							},
+							// Cap actual usage via CFS quota so "yes > /dev/null" can't peg a
+							// full host core -- comfortably under the VPA's maxAllowed.cpu
+							// (500m) below so it doesn't distort the recommendation, and still
+							// ~30x the request so the recommender has a clear reason to bump it.
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("300m"),
+							},
 						},
 					}}},
 				},


### PR DESCRIPTION
## Summary
- The VPA e2e subtest's burner Deployment (`vpa-burner`, `cmd/e2e_dynamic_test.go`) runs `sh -c "yes > /dev/null"` with only a CPU *request* (`10m`), no *limit* — nothing caps it via cgroups, so it's free to peg an entire host core.
- On minikube's single-node cluster, that starves kube-apiserver/etcd/kubelet sharing the same core budget, and is the leading suspect for kube-apiserver restarts on resource-constrained local minikube runs and CPU-constrained CI runners (the subtest's own comment already documents it starving metrics-server's readiness probe).
- Adds `Limits.cpu: 300m` — comfortably under the VPA's `maxAllowed.cpu` (500m) so it doesn't distort the recommendation, and still ~30x the request so the recommender has a clear reason to bump it.

## Test plan
- [x] `go build ./...` / `go vet ./cmd/...`
- [x] Reproduced the underlying bug live: with the old unlimited burner, `kubectl` against the shared e2e cluster returned `TLS handshake timeout` / `connection refused` for ~3 minutes while the burner ran — confirming real apiserver starvation.
- [x] With the capped burner, no apiserver disruption occurred over the same scenario.
- [ ] Full `make test-e2e-quick RUN='TestE2EDynamicManifests/VerticalPodAutoscaler...'` — attempted but couldn't get a clean pass in this sandbox: its shared minikube node only has 2 real CPUs (host is CPU-constrained) and is already ~90% CPU-committed by other long-lived e2e-suite controllers, leaving too little headroom for VPA's post-eviction request bump to schedule. Confirmed this is pre-existing/environmental, not caused by this change, by reproducing the identical `Insufficient cpu` `FailedScheduling` with the old unlimited-burner code against the same cluster.
- Fixtures (`vpa-workload-reverse-match.regex`, `vpa-standalone.regex`) use `\d+` wildcards for the cpu/mem numbers, so they don't need updating regardless of the exact recommendation value.