### PR TITLE
Cut CHANGELOG [Unreleased] over to v0.7.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ without an entry here.
 
 ## [Unreleased]
 
+## [v0.7.24] - 2026-08-11
+
 ### Breaking template API changes
 
 - `callerNamespace` on `Deployment.summary`, `StatefulSet.summary`, `DaemonSet.summary`,


### PR DESCRIPTION
## Summary
- Renames the `## [Unreleased]` section in CHANGELOG.md to `## [v0.7.24] - 2026-08-11`, cutting over the pending breaking-template-API entry (`callerNamespace` on `.summary` templates) into the upcoming release, and adds a fresh empty `[Unreleased]` section above it.
- Prep step for tagging `v0.7.24` (patch bump, following this project's established versioning pattern — see `TEMPLATE-API.md#versioning-policy`).

## Test plan
- N/A — documentation-only change.