### PR TITLE
Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kubectl status
 
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/5317/badge)](https://www.bestpractices.dev/projects/5317)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/5317/baseline)](https://www.bestpractices.dev/projects/5317)
 
 Checking whether a Pod or Deployment is actually healthy usually means bouncing between `kubectl get`, `kubectl describe`,
 `kubectl get pods -l ...`, and `kubectl describe pod ...` — then piecing the answer together yourself. `kubectl status`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # kubectl status
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/5317/badge)](https://www.bestpractices.dev/projects/5317)
+
 Checking whether a Pod or Deployment is actually healthy usually means bouncing between `kubectl get`, `kubectl describe`,
 `kubectl get pods -l ...`, and `kubectl describe pod ...` — then piecing the answer together yourself. `kubectl status`
 gives you that answer in one familiar, drop-in command: same `kubectl` usage you already know, no new mental model,


### PR DESCRIPTION
## Summary
- Adds the OpenSSF Best Practices badge to the top of README.md, linking to our project page (https://www.bestpractices.dev/projects/5317).

## Test plan
- [x] Rendered markdown badge/link syntax matches the snippet provided by bestpractices.dev.