### PR TITLE
Promote 6 eligible TestE2EDynamicManifests subtests into TestE2EParallel's pool

### DIFF
--- a/cmd/e2e_crossplane_test.go
+++ b/cmd/e2e_crossplane_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/bergerx/kubectl-status/pkg/plugin"
+)
+
+func runCrossplaneSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
+	t.Run("Crossplane XR composes namespaced children and surfaces their health", func(t *testing.T) {
+		t.Parallel()
+		// Crossplane core plus the two Composition Functions it needs must actually reconcile
+		// to produce the XR's composed children, same "controller must actually run" reasoning
+		// as the Flux scenario (runFluxSubtests, cmd/e2e_flux_test.go): the installer is a
+		// shared onceInstaller serialized by installMu, so ensureCrossplane is safe from inside
+		// a t.Parallel() subtest.
+		ensureCrossplane(t)
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-crossplane-xr"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		applyManifest(t, "e2e-artifacts/crossplane-xstatusprobe.yaml")
+		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Established",
+			"xrd/xstatusprobes.tests.kubectl-status.io", "--timeout=60s").Run())
+		applyManifestInNamespace(t, "e2e-artifacts/crossplane-xr.yaml", ns)
+		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Synced", ns)
+		// The Deployment child is deliberately unschedulable (a nodeSelector no node can match),
+		// so the XR itself never reaches Ready -- wait on the field kubectl-status actually reads
+		// instead of a condition that will never flip.
+		waitForCrossplaneComposedRefs(t, ns, "probe-a", 2)
+		// Synced/resourceRefs land as soon as the render step runs, but the XR's own Responsive
+		// condition and the composed Deployment's Progressing/Available conditions populate
+		// slightly later via separate reconciles -- wait for all of them so the fixtures below
+		// pin a stable message instead of racing a transient "Replicas: 0/1" kstatus summary.
+		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Responsive", ns)
+		waitForInNamespace(t, "deployment/probe-a-blocked", "condition=Progressing", ns)
+		require.NoError(t, exec.Command("kubectl", "wait", "-n", ns,
+			"--for=condition=PodScheduled=false", "pod", "-l", "app=probe-a-blocked", "--timeout=2m").Run())
+		// kstatus (sigs.k8s.io/cli-utils/pkg/kstatus/status.ScheduleWindow) gives a Pod 15s from
+		// its creationTimestamp before reporting Unschedulable as Failed rather than InProgress --
+		// wait that out so the fixtures below pin the stable "Failed: Pod could not be scheduled"
+		// message instead of racing the transient one.
+		waitForPodScheduleWindow(t, ns, "app=probe-a-blocked")
+
+		// Only the live-query-dependent branches belong here: default mode's KubeGetFirst lookup
+		// (populating each composed child's compact health) and --deep's IncludeRenderableObject
+		// inline. Shallow rendering and Composition.tmpl make no live queries at all -- both are
+		// already covered by the offline artifacts (tests/artifacts/crossplane-*).
+		cmdTest{
+			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/crossplane-xr.regex",
+		}.assert(t, nil, opts...)
+		cmdTest{
+			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/crossplane-xr-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+}

--- a/cmd/e2e_dynamic_test.go
+++ b/cmd/e2e_dynamic_test.go
@@ -2,11 +2,7 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
 	"os/exec"
 	"testing"
 
@@ -20,29 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// buildHelmReleaseSecretData encodes release the same way Helm's own storage driver does for its
-// Secret backend (base64(gzip(JSON)), see encodeRelease in
-// https://github.com/helm/helm/blob/main/pkg/storage/driver/util.go) -- this single explicit
-// encoding, plus the outer base64 the Kubernetes API/dynamic client applies automatically to every
-// []byte Secret data value on the wire, reproduces the double-base64 layering
-// parseHelmReleaseSecret (pkg/plugin/template_functions_static.go) decodes.
-func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []byte {
-	t.Helper()
-	b, err := json.Marshal(release)
-	require.NoError(t, err)
-	var buf bytes.Buffer
-	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
-	require.NoError(t, err)
-	_, err = gw.Write(b)
-	require.NoError(t, err)
-	require.NoError(t, gw.Close())
-	return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
-}
-
 // TestE2EDynamicManifests holds the scenarios that have a specific, stated reason not to be in
 // TestE2EParallel's pool. It is the exception, not the default: a new subtest belongs in the pool
 // (cmd/main_test.go) unless it trips one of that function's two criteria, and the reason goes in a
-// comment on the subtest -- every one below has one.
+// comment on the subtest.
 //
 // The reasons that actually qualify are narrow, and all of them are about what the subtest does
 // *to* its neighbours:
@@ -51,7 +28,9 @@ func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []
 //   - it starves a shared dependency (the VPA subtest pegs a full CPU to give the recommender
 //     something to act on, which on a single-node cluster takes metrics-server's readiness probe
 //     down with it),
-//   - it can't be given a namespace or generated name of its own.
+//   - it pins kube-scheduler's exact "0/N nodes are available" message (the PV-zone and
+//     Karpenter-nodeSelector subtests below), which would drift if run alongside
+//     TestE2EParallel's createBadNode-based subtests changing the node count.
 //
 // Several things that look disqualifying aren't. Needing a live cluster interaction the offline
 // artifacts can't reach ($.KubeGetFirst, $.IncludeRenderableObject/$.Include) doesn't -- most of the
@@ -65,6 +44,14 @@ func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []
 //
 // See #784, where the Flux scenario went from a standalone top-level test to a subtest here before
 // anyone checked it against the pool's criteria -- which it met.
+//
+// See #832, where auditing this function's subtests against the criteria above found six with no
+// actual reason to be here -- promoted to runStorageSubtests (cmd/e2e_storage_test.go),
+// runCrossplaneSubtests (cmd/e2e_crossplane_test.go), and runHelmReleaseSubtests
+// (cmd/e2e_helm_test.go). The PersistentVolumeClaim RWOP-holder subtest and the
+// WaitForFirstConsumer-topologies subtest below weren't part of that audit's named list and haven't
+// been individually confirmed against the pool's criteria -- don't assume they're exceptions for a
+// stated reason the way the ones above are.
 //
 // The other two entry points exist for reasons this one can't absorb: TestE2EParallel owns the
 // concurrent pool and the single e2eClients() setup its subtests share (see #719), and
@@ -206,147 +193,6 @@ func TestE2EDynamicManifests(t *testing.T) {
 			stdoutRegexPath: "e2e-artifacts/vpa-standalone.regex",
 		}.assert(t, nil, opts...)
 	})
-	t.Run("Crossplane XR composes namespaced children and surfaces their health", func(t *testing.T) {
-		// Crossplane core plus the two Composition Functions it needs must actually reconcile
-		// to produce the XR's composed children, same "controller must actually run" reasoning
-		// as the VPA subtest above.
-		ensureCrossplane(t)
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		ns := "e2e-crossplane-xr"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		applyManifest(t, "e2e-artifacts/crossplane-xstatusprobe.yaml")
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Established",
-			"xrd/xstatusprobes.tests.kubectl-status.io", "--timeout=60s").Run())
-		applyManifestInNamespace(t, "e2e-artifacts/crossplane-xr.yaml", ns)
-		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Synced", ns)
-		// The Deployment child is deliberately unschedulable (a nodeSelector no node can match),
-		// so the XR itself never reaches Ready -- wait on the field kubectl-status actually reads
-		// instead of a condition that will never flip.
-		waitForCrossplaneComposedRefs(t, ns, "probe-a", 2)
-		// Synced/resourceRefs land as soon as the render step runs, but the XR's own Responsive
-		// condition and the composed Deployment's Progressing/Available conditions populate
-		// slightly later via separate reconciles -- wait for all of them so the fixtures below
-		// pin a stable message instead of racing a transient "Replicas: 0/1" kstatus summary.
-		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Responsive", ns)
-		waitForInNamespace(t, "deployment/probe-a-blocked", "condition=Progressing", ns)
-		require.NoError(t, exec.Command("kubectl", "wait", "-n", ns,
-			"--for=condition=PodScheduled=false", "pod", "-l", "app=probe-a-blocked", "--timeout=2m").Run())
-		// kstatus (sigs.k8s.io/cli-utils/pkg/kstatus/status.ScheduleWindow) gives a Pod 15s from
-		// its creationTimestamp before reporting Unschedulable as Failed rather than InProgress --
-		// wait that out so the fixtures below pin the stable "Failed: Pod could not be scheduled"
-		// message instead of racing the transient one.
-		waitForPodScheduleWindow(t, ns, "app=probe-a-blocked")
-
-		// Only the live-query-dependent branches belong here: default mode's KubeGetFirst lookup
-		// (populating each composed child's compact health) and --deep's IncludeRenderableObject
-		// inline. Shallow rendering and Composition.tmpl make no live queries at all -- both are
-		// already covered by the offline artifacts (tests/artifacts/crossplane-*).
-		cmdTest{
-			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/crossplane-xr.regex",
-		}.assert(t, nil, opts...)
-		cmdTest{
-			args:            []string{"xstatusprobe/probe-a", "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/crossplane-xr-deep.regex",
-		}.assert(t, nil, opts...)
-	})
-	t.Run("PersistentVolumeClaim fetches its StorageClass and surfaces a non-default binding mode and volume expansion", func(t *testing.T) {
-		// Issue #669: PersistentVolumeClaim.tmpl previously only printed the storage class name
-		// as a string, never fetching the object -- so provisioning-relevant fields like
-		// volumeBindingMode (which explains a claim staying Pending until a Pod is scheduled)
-		// were invisible. This exercises the live KubeGetFirst fetch, which --shallow/--local
-		// (and thus every offline artifact test) makes a no-op.
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		ns := "e2e-storageclass"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.NotEmpty(t, storageClasses.Items, "expected minikube's default storage-provisioner addon to have registered a StorageClass")
-		provisioner := storageClasses.Items[0].Provisioner
-
-		scName := "e2e-wait-for-first-consumer"
-		bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
-		allowExpansion := true
-		_, err = clientset.StorageV1().StorageClasses().Create(context.TODO(), &storagev1.StorageClass{
-			ObjectMeta:           metav1.ObjectMeta{Name: scName},
-			Provisioner:          provisioner,
-			VolumeBindingMode:    &bindingMode,
-			AllowVolumeExpansion: &allowExpansion,
-			// Issue #738: this is the only e2e path that renders storageclass_summary (used by
-			// PersistentVolumeClaim.tmpl below) against a live class, so allowedTopologies is
-			// added here rather than to a separate StorageClass -- a dedicated fixture would only
-			// exercise the already-covered standalone StorageClass.tmpl render, not this compact
-			// partial's new branch.
-			AllowedTopologies: []corev1.TopologySelectorTerm{{
-				MatchLabelExpressions: []corev1.TopologySelectorLabelRequirement{{
-					Key:    "topology.kubernetes.io/zone",
-					Values: []string{"e2e-zone-a", "e2e-zone-b"},
-				}},
-			}},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.StorageV1().StorageClasses().Delete(context.TODO(), scName, metav1.DeleteOptions{})
-		})
-
-		// WaitForFirstConsumer keeps the claim Pending with no consuming Pod -- exactly the
-		// "unbound/late-bound claim" case the issue asks for, and it needs no wait: the claim
-		// is Pending as soon as it's created.
-		pvcName := "e2e-wfc-pvc"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				StorageClassName: &scName,
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		cmdTest{
-			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex",
-		}.assert(t, nil, opts...)
-		// --deep inlines the fetched StorageClass in full -- offline artifact tests can't reach
-		// this branch either, since --shallow/--local (which every offline test uses) makes the
-		// KubeGetFirst behind it a no-op, so this is the only tier that verifies it renders.
-		cmdTest{
-			args:            []string{"pvc/" + pvcName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex",
-		}.assert(t, nil, opts...)
-
-		// A claim referencing a StorageClass that doesn't exist can't be told apart from one that
-		// simply wasn't fetched (--shallow/--local) by any offline artifact -- only a live fetch
-		// that comes back empty proves the "not found" warning path.
-		missingSCPVCName := "e2e-missing-sc-pvc"
-		missingSCName := "e2e-no-such-storageclass"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: missingSCPVCName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				StorageClassName: &missingSCName,
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		cmdTest{
-			args:            []string{"pvc/" + missingSCPVCName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-missing.regex",
-		}.assert(t, nil, opts...)
-	})
 	t.Run("PersistentVolumeClaim surfaces its ReadWriteOncePod holder and a scheduling conflict", func(t *testing.T) {
 		// Issue #669: a ReadWriteOncePod claim allows only one non-terminal Pod to use it at a
 		// time -- enforced by the kube-scheduler's built-in VolumeRestrictions plugin, no CSI
@@ -426,281 +272,6 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pvc-rwop-blocked.regex",
-		}.assert(t, nil, opts...)
-	})
-	t.Run("PersistentVolumeClaim renders an explicit conflict when two non-terminal Pods are scheduled against one ReadWriteOncePod claim", func(t *testing.T) {
-		// Issue #669: rwop_holder_diagnosis must never pick one Pod arbitrarily when more than
-		// one non-terminal Pod is scheduled against the same RWOP claim -- it has to render an
-		// explicit conflict instead. The kube-scheduler's VolumeRestrictions plugin normally
-		// prevents this from happening for real (see the subtest above), so to exercise the
-		// conflict branch deterministically we set spec.nodeName at Pod creation time, which
-		// skips the scheduler (and its RWOP check) entirely -- same "create it directly against
-		// the API" trick the VolumeAttachment subtest below uses to bypass needing a real CSI
-		// driver behind it. Pointed at a node name that doesn't exist rather than a real one: no
-		// kubelet ever claims the Pod, so phase stays Pending with no containerStatuses forever,
-		// instead of racing a real kubelet's admission/scheduling of the render against the
-		// test -- which flipped phase and readiness between runs when tried against a real node.
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		ns := "e2e-rwop-conflict"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		const nodeName = "e2e-rwop-conflict-no-such-node"
-
-		pvcName := "e2e-rwop-conflict-pvc"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
-
-		for _, name := range []string{"e2e-rwop-conflict-a", "e2e-rwop-conflict-b"} {
-			_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: name},
-				Spec: corev1.PodSpec{
-					NodeName: nodeName,
-					Containers: []corev1.Container{{
-						Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
-						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
-					}},
-					Volumes: []corev1.Volume{{
-						Name: "data",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
-						},
-					}},
-				},
-			}, metav1.CreateOptions{})
-			require.NoError(t, err)
-			podName := name
-			t.Cleanup(func() {
-				clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
-			})
-		}
-
-		cmdTest{
-			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pvc-rwop-conflict.regex",
-		}.assert(t, nil, opts...)
-	})
-	t.Run("PersistentVolume surfaces a VolumeAttachment attach error", func(t *testing.T) {
-		// Issue #669: VolumeAttachment has zero references anywhere in the templates today, so a
-		// PV/PVC pair can render fully Bound while the actual CSI attach/detach is stuck or
-		// erroring -- invisible from both the Pod and PVC/PV views. minikube's own
-		// storage-provisioner addon isn't a real CSI driver (hostpath needs no attacher), so it
-		// never creates VolumeAttachment objects itself -- there's nothing to wait on
-		// deterministically. Instead we create the VolumeAttachment object directly against the
-		// API (same trick as the StorageClass subtest above): the apiserver only validates the
-		// object's shape, not that a driver is actually behind it, so this is fully
-		// deterministic and not flaky.
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		// Its own namespace, not the "e2e-storageclass" one the subtest above uses: reusing it
-		// raced against that subtest's own namespace deletion still being in flight ("unable to
-		// create new content ... because it is being terminated") when both ran in the same
-		// process.
-		ns := "e2e-volumeattachment"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		require.NoError(t, err)
-		require.NotEmpty(t, nodes.Items)
-		nodeName := nodes.Items[0].Name
-
-		// No storageClassName -- picks up the cluster's default class (Immediate binding), so
-		// this actually provisions and binds a real PV to attach the fake VolumeAttachment to.
-		pvcName := "e2e-attach-error-pvc"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
-
-		pvc, err := clientset.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
-		require.NoError(t, err)
-		pvName := pvc.Spec.VolumeName
-		require.NotEmpty(t, pvName)
-
-		vaName := "e2e-fake-attach-error"
-		va := &storagev1.VolumeAttachment{
-			ObjectMeta: metav1.ObjectMeta{Name: vaName},
-			Spec: storagev1.VolumeAttachmentSpec{
-				Attacher: "fake.csi.kubectl-status.io",
-				NodeName: nodeName,
-				Source:   storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvName},
-			},
-		}
-		created, err := clientset.StorageV1().VolumeAttachments().Create(context.TODO(), va, metav1.CreateOptions{})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			clientset.StorageV1().VolumeAttachments().Delete(context.TODO(), vaName, metav1.DeleteOptions{})
-		})
-		created.Status = storagev1.VolumeAttachmentStatus{
-			Attached: false,
-			AttachError: &storagev1.VolumeError{
-				Time:    metav1.Now(),
-				Message: "rpc error: code = Internal desc = fake attach failure for e2e test",
-			},
-		}
-		_, err = clientset.StorageV1().VolumeAttachments().UpdateStatus(context.TODO(), created, metav1.UpdateOptions{})
-		require.NoError(t, err)
-
-		cmdTest{
-			args:            []string{"pv/" + pvName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error.regex",
-		}.assert(t, nil, opts...)
-		// --deep inlines the matching VolumeAttachment in full -- offline artifact tests can't
-		// reach this branch either, since --shallow/--local (used by every offline test) makes
-		// the KubeGet behind it a no-op.
-		cmdTest{
-			args:            []string{"pv/" + pvName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error-deep.regex",
-		}.assert(t, nil, opts...)
-	})
-	t.Run("VolumeSnapshot and VolumeSnapshotContent surface readiness, bound linkage, and restore-target context", func(t *testing.T) {
-		// Issue #669: VolumeSnapshot/VolumeSnapshotContent (snapshot.storage.k8s.io) had no
-		// standalone templates -- `kubectl status volumesnapshot/x` fell through to
-		// DefaultResource. minikube's hostpath storage-provisioner has no CSI snapshot support,
-		// so getting a real snapshot to reach ReadyToUse deterministically isn't possible here;
-		// instead (same trick as the VolumeAttachment subtest above) the objects and their
-		// status are created directly against the API -- the apiserver only validates their
-		// shape, not that a real external-snapshotter controller is behind them.
-		ensureVolumeSnapshotCRDs(t)
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		ns := "e2e-volumesnapshot"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		// Source PVC the snapshot is (nominally) taken from.
-		sourcePVCName := "e2e-vs-source-pvc"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: sourcePVCName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		vsGVR := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}
-		vscGVR := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotcontents"}
-		vsName := "e2e-vs"
-		vscName := "e2e-vsc"
-
-		vs := &unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": "snapshot.storage.k8s.io/v1",
-			"kind":       "VolumeSnapshot",
-			"metadata":   map[string]interface{}{"name": vsName, "namespace": ns},
-			"spec": map[string]interface{}{
-				"volumeSnapshotClassName": "e2e-snapclass",
-				"source": map[string]interface{}{
-					"persistentVolumeClaimName": sourcePVCName,
-				},
-			},
-		}}
-		createdVS, err := dynamicClient.Resource(vsGVR).Namespace(ns).Create(context.TODO(), vs, metav1.CreateOptions{})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			dynamicClient.Resource(vsGVR).Namespace(ns).Delete(context.TODO(), vsName, metav1.DeleteOptions{})
-		})
-
-		vsc := &unstructured.Unstructured{Object: map[string]interface{}{
-			"apiVersion": "snapshot.storage.k8s.io/v1",
-			"kind":       "VolumeSnapshotContent",
-			"metadata":   map[string]interface{}{"name": vscName},
-			"spec": map[string]interface{}{
-				"deletionPolicy":          "Delete",
-				"driver":                  "fake.csi.kubectl-status.io",
-				"volumeSnapshotClassName": "e2e-snapclass",
-				"volumeSnapshotRef": map[string]interface{}{
-					"name":      vsName,
-					"namespace": ns,
-					"uid":       string(createdVS.GetUID()),
-				},
-				"source": map[string]interface{}{
-					"volumeHandle": "vol-e2e-fake",
-				},
-			},
-		}}
-		createdVSC, err := dynamicClient.Resource(vscGVR).Create(context.TODO(), vsc, metav1.CreateOptions{})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			dynamicClient.Resource(vscGVR).Delete(context.TODO(), vscName, metav1.DeleteOptions{})
-		})
-
-		// Bind them to each other and mark both ready -- status is a subresource, set via
-		// UpdateStatus rather than at creation time.
-		require.NoError(t, unstructured.SetNestedField(createdVS.Object, true, "status", "readyToUse"))
-		require.NoError(t, unstructured.SetNestedField(createdVS.Object, vscName, "status", "boundVolumeSnapshotContentName"))
-		require.NoError(t, unstructured.SetNestedField(createdVS.Object, "2026-07-21T02:00:00Z", "status", "creationTime"))
-		require.NoError(t, unstructured.SetNestedField(createdVS.Object, "5Gi", "status", "restoreSize"))
-		_, err = dynamicClient.Resource(vsGVR).Namespace(ns).UpdateStatus(context.TODO(), createdVS, metav1.UpdateOptions{})
-		require.NoError(t, err)
-
-		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, true, "status", "readyToUse"))
-		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, "snap-e2e-fake-handle", "status", "snapshotHandle"))
-		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, int64(1784599200000000000), "status", "creationTime"))
-		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, int64(5368709120), "status", "restoreSize"))
-		_, err = dynamicClient.Resource(vscGVR).UpdateStatus(context.TODO(), createdVSC, metav1.UpdateOptions{})
-		require.NoError(t, err)
-
-		// A second PVC requesting to restore FROM the snapshot -- restore-target context.
-		restorePVCName := "e2e-vs-restore-pvc"
-		apiGroup := "snapshot.storage.k8s.io"
-		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: restorePVCName, Namespace: ns},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
-				},
-				DataSourceRef: &corev1.TypedObjectReference{
-					APIGroup: &apiGroup,
-					Kind:     "VolumeSnapshot",
-					Name:     vsName,
-				},
-			},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		cmdTest{
-			args:            []string{"volumesnapshot/" + vsName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/volumesnapshot-bound.regex",
-		}.assert(t, nil, opts...)
-		// --deep inlines the bound VolumeSnapshotContent in full -- offline artifact tests can't
-		// reach this branch either, since --shallow/--local (used by every offline test) makes
-		// the KubeGetFirst behind it a no-op.
-		cmdTest{
-			args:            []string{"volumesnapshot/" + vsName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/volumesnapshot-bound-deep.regex",
-		}.assert(t, nil, opts...)
-		cmdTest{
-			args:            []string{"volumesnapshotcontent/" + vscName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/volumesnapshotcontent-bound.regex",
-		}.assert(t, nil, opts...)
-		cmdTest{
-			args:            []string{"volumesnapshotcontent/" + vscName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/volumesnapshotcontent-bound-deep.regex",
 		}.assert(t, nil, opts...)
 	})
 	t.Run("Pod surfaces a bound PV's zone-restricting nodeAffinity when it can't be scheduled", func(t *testing.T) {
@@ -791,7 +362,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 			`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}=False`, ns)
 		// Fixture pins kstatus's own summary line, which only reports Unschedulable as Failed
 		// once the Pod is past its 15s ScheduleWindow -- same wait the Crossplane XR subtest
-		// above uses for the same reason.
+		// (runCrossplaneSubtests, cmd/e2e_crossplane_test.go) uses for the same reason.
 		waitForPodScheduleWindow(t, ns, "app="+podName)
 
 		cmdTest{
@@ -809,7 +380,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// allowedTopologies has no PV yet to cross-check, so pod_storage_locality must hedge
 		// ("isn't zone-pinned yet ... may still constrain") instead of asserting a zone. Reuses
 		// the same custom StorageClass pattern as the "PersistentVolumeClaim fetches its
-		// StorageClass" subtest above, adding allowedTopologies to it.
+		// StorageClass" subtest (runStorageSubtests, cmd/e2e_storage_test.go), adding
+		// allowedTopologies to it.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-pv-zone-wfc"
 		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
@@ -980,80 +552,6 @@ func TestE2EDynamicManifests(t *testing.T) {
 		cmdTest{
 			args:            []string{"pod/" + satisfiablePodName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
 			stdoutRegexPath: "e2e-artifacts/pod-karpenter-satisfiable.regex",
-		}.assert(t, nil, opts...)
-	})
-	t.Run("Helm release Secret flags a superseded revision and resolves its manifest's live objects", func(t *testing.T) {
-		// A Helm release Secret's data.release is opaque (base64(gzip(JSON))) until decoded, and
-		// there was previously no indication at all that a Secret was Helm's own release-storage
-		// object, let alone whether it was superseded by a later revision or what it actually
-		// deployed. Offline artifact tests (tests/artifacts/secret-helm-release-*) already cover
-		// the parse itself and the --shallow/--local fallback (resource_ref, no "Newer revision"
-		// line); this exercises the two live-query-only branches: the sibling-Secret revision scan
-		// ($.KubeGetByLabelsMap) and resolving a manifest entry to its live object ($.KubeGetFirst
-		// / $.IncludeRenderableObject in --deep).
-		opts := combineOpts(hackOpts, viperTestHackOpts())
-		ns := "e2e-helm-release"
-		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
-			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
-		require.NoError(t, err)
-
-		configMapName := "e2e-helm-release-config"
-		_, err = clientset.CoreV1().ConfigMaps(ns).Create(context.TODO(), &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: ns},
-			Data:       map[string]string{"foo": "bar"},
-		}, metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		manifest := "---\n# Source: e2e-chart/templates/configmap.yaml\n" +
-			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + configMapName + "\ndata:\n  foo: bar\n"
-
-		releaseName := "e2e-helm-release"
-		newRelease := func(revision int, status string) map[string]interface{} {
-			return map[string]interface{}{
-				"name":      releaseName,
-				"namespace": ns,
-				"version":   revision,
-				"manifest":  manifest,
-				"info":      map[string]interface{}{"status": status, "description": "Install complete"},
-				"chart": map[string]interface{}{"metadata": map[string]interface{}{
-					"name": "e2e-chart", "version": "1.2.3", "appVersion": "2.0.0",
-				}},
-			}
-		}
-		newReleaseSecret := func(revision int, status string) *corev1.Secret {
-			return &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("sh.helm.release.v1.%s.v%d", releaseName, revision),
-					Namespace: ns,
-					Labels: map[string]string{
-						"name":    releaseName,
-						"owner":   "helm",
-						"status":  status,
-						"version": fmt.Sprintf("%d", revision),
-					},
-				},
-				Type: "helm.sh/release.v1",
-				Data: map[string][]byte{"release": buildHelmReleaseSecretData(t, newRelease(revision, status))},
-			}
-		}
-
-		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(1, "superseded"), metav1.CreateOptions{})
-		require.NoError(t, err)
-		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(2, "deployed"), metav1.CreateOptions{})
-		require.NoError(t, err)
-
-		oldSecretName := fmt.Sprintf("sh.helm.release.v1.%s.v1", releaseName)
-		cmdTest{
-			args:            []string{"secret/" + oldSecretName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded.regex",
-		}.assert(t, nil, opts...)
-		// --deep inlines the manifest's resolved ConfigMap in full -- offline artifact tests can't
-		// reach this branch either, since --shallow/--local (used by every offline test) makes the
-		// KubeGetFirst behind it a no-op.
-		cmdTest{
-			args:            []string{"secret/" + oldSecretName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded-deep.regex",
 		}.assert(t, nil, opts...)
 	})
 }

--- a/cmd/e2e_helm_test.go
+++ b/cmd/e2e_helm_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/bergerx/kubectl-status/pkg/plugin"
+)
+
+// buildHelmReleaseSecretData encodes release the same way Helm's own storage driver does for its
+// Secret backend (base64(gzip(JSON)), see encodeRelease in
+// https://github.com/helm/helm/blob/main/pkg/storage/driver/util.go) -- this single explicit
+// encoding, plus the outer base64 the Kubernetes API/dynamic client applies automatically to every
+// []byte Secret data value on the wire, reproduces the double-base64 layering
+// parseHelmReleaseSecret (pkg/plugin/template_functions_static.go) decodes.
+func buildHelmReleaseSecretData(t *testing.T, release map[string]interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(release)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	require.NoError(t, err)
+	_, err = gw.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return []byte(base64.StdEncoding.EncodeToString(buf.Bytes()))
+}
+
+func runHelmReleaseSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
+	t.Run("Helm release Secret flags a superseded revision and resolves its manifest's live objects", func(t *testing.T) {
+		t.Parallel()
+		// A Helm release Secret's data.release is opaque (base64(gzip(JSON))) until decoded, and
+		// there was previously no indication at all that a Secret was Helm's own release-storage
+		// object, let alone whether it was superseded by a later revision or what it actually
+		// deployed. Offline artifact tests (tests/artifacts/secret-helm-release-*) already cover
+		// the parse itself and the --shallow/--local fallback (resource_ref, no "Newer revision"
+		// line); this exercises the two live-query-only branches: the sibling-Secret revision scan
+		// ($.KubeGetByLabelsMap) and resolving a manifest entry to its live object ($.KubeGetFirst
+		// / $.IncludeRenderableObject in --deep).
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-helm-release"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		configMapName := "e2e-helm-release-config"
+		_, err = clientset.CoreV1().ConfigMaps(ns).Create(context.TODO(), &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: ns},
+			Data:       map[string]string{"foo": "bar"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		manifest := "---\n# Source: e2e-chart/templates/configmap.yaml\n" +
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: " + configMapName + "\ndata:\n  foo: bar\n"
+
+		releaseName := "e2e-helm-release"
+		newRelease := func(revision int, status string) map[string]interface{} {
+			return map[string]interface{}{
+				"name":      releaseName,
+				"namespace": ns,
+				"version":   revision,
+				"manifest":  manifest,
+				"info":      map[string]interface{}{"status": status, "description": "Install complete"},
+				"chart": map[string]interface{}{"metadata": map[string]interface{}{
+					"name": "e2e-chart", "version": "1.2.3", "appVersion": "2.0.0",
+				}},
+			}
+		}
+		newReleaseSecret := func(revision int, status string) *corev1.Secret {
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("sh.helm.release.v1.%s.v%d", releaseName, revision),
+					Namespace: ns,
+					Labels: map[string]string{
+						"name":    releaseName,
+						"owner":   "helm",
+						"status":  status,
+						"version": fmt.Sprintf("%d", revision),
+					},
+				},
+				Type: "helm.sh/release.v1",
+				Data: map[string][]byte{"release": buildHelmReleaseSecretData(t, newRelease(revision, status))},
+			}
+		}
+
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(1, "superseded"), metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = clientset.CoreV1().Secrets(ns).Create(context.TODO(), newReleaseSecret(2, "deployed"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		oldSecretName := fmt.Sprintf("sh.helm.release.v1.%s.v1", releaseName)
+		cmdTest{
+			args:            []string{"secret/" + oldSecretName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the manifest's resolved ConfigMap in full -- offline artifact tests can't
+		// reach this branch either, since --shallow/--local (used by every offline test) makes the
+		// KubeGetFirst behind it a no-op.
+		cmdTest{
+			args:            []string{"secret/" + oldSecretName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/secret-helm-release-superseded-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+}

--- a/cmd/e2e_storage_test.go
+++ b/cmd/e2e_storage_test.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/bergerx/kubectl-status/pkg/plugin"
+)
+
+func runStorageSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset, dynamicClient dynamic.Interface) {
+	t.Run("PersistentVolumeClaim fetches its StorageClass and surfaces a non-default binding mode and volume expansion", func(t *testing.T) {
+		t.Parallel()
+		// Issue #669: PersistentVolumeClaim.tmpl previously only printed the storage class name
+		// as a string, never fetching the object -- so provisioning-relevant fields like
+		// volumeBindingMode (which explains a claim staying Pending until a Pod is scheduled)
+		// were invisible. This exercises the live KubeGetFirst fetch, which --shallow/--local
+		// (and thus every offline artifact test) makes a no-op.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-storageclass"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		storageClasses, err := clientset.StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, storageClasses.Items, "expected minikube's default storage-provisioner addon to have registered a StorageClass")
+		provisioner := storageClasses.Items[0].Provisioner
+
+		scName := "e2e-wait-for-first-consumer"
+		bindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		allowExpansion := true
+		_, err = clientset.StorageV1().StorageClasses().Create(context.TODO(), &storagev1.StorageClass{
+			ObjectMeta:           metav1.ObjectMeta{Name: scName},
+			Provisioner:          provisioner,
+			VolumeBindingMode:    &bindingMode,
+			AllowVolumeExpansion: &allowExpansion,
+			// Issue #738: this is the only e2e path that renders storageclass_summary (used by
+			// PersistentVolumeClaim.tmpl below) against a live class, so allowedTopologies is
+			// added here rather than to a separate StorageClass -- a dedicated fixture would only
+			// exercise the already-covered standalone StorageClass.tmpl render, not this compact
+			// partial's new branch.
+			AllowedTopologies: []corev1.TopologySelectorTerm{{
+				MatchLabelExpressions: []corev1.TopologySelectorLabelRequirement{{
+					Key:    "topology.kubernetes.io/zone",
+					Values: []string{"e2e-zone-a", "e2e-zone-b"},
+				}},
+			}},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.StorageV1().StorageClasses().Delete(context.TODO(), scName, metav1.DeleteOptions{})
+		})
+
+		// WaitForFirstConsumer keeps the claim Pending with no consuming Pod -- exactly the
+		// "unbound/late-bound claim" case the issue asks for, and it needs no wait: the claim
+		// is Pending as soon as it's created.
+		pvcName := "e2e-wfc-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &scName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the fetched StorageClass in full -- offline artifact tests can't reach
+		// this branch either, since --shallow/--local (which every offline test uses) makes the
+		// KubeGetFirst behind it a no-op, so this is the only tier that verifies it renders.
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-wait-for-first-consumer-deep.regex",
+		}.assert(t, nil, opts...)
+
+		// A claim referencing a StorageClass that doesn't exist can't be told apart from one that
+		// simply wasn't fetched (--shallow/--local) by any offline artifact -- only a live fetch
+		// that comes back empty proves the "not found" warning path.
+		missingSCPVCName := "e2e-missing-sc-pvc"
+		missingSCName := "e2e-no-such-storageclass"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: missingSCPVCName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				StorageClassName: &missingSCName,
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pvc/" + missingSCPVCName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-storageclass-missing.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("PersistentVolumeClaim renders an explicit conflict when two non-terminal Pods are scheduled against one ReadWriteOncePod claim", func(t *testing.T) {
+		t.Parallel()
+		// Issue #669: rwop_holder_diagnosis must never pick one Pod arbitrarily when more than
+		// one non-terminal Pod is scheduled against the same RWOP claim -- it has to render an
+		// explicit conflict instead. The kube-scheduler's VolumeRestrictions plugin normally
+		// prevents this from happening for real (see the ReadWriteOncePod holder/conflict
+		// subtest in cmd/e2e_dynamic_test.go), so to exercise the conflict branch
+		// deterministically we set spec.nodeName at Pod creation time, which
+		// skips the scheduler (and its RWOP check) entirely -- same "create it directly against
+		// the API" trick the VolumeAttachment subtest below uses to bypass needing a real CSI
+		// driver behind it. Pointed at a node name that doesn't exist rather than a real one: no
+		// kubelet ever claims the Pod, so phase stays Pending with no containerStatuses forever,
+		// instead of racing a real kubelet's admission/scheduling of the render against the
+		// test -- which flipped phase and readiness between runs when tried against a real node.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-rwop-conflict"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		const nodeName = "e2e-rwop-conflict-no-such-node"
+
+		pvcName := "e2e-rwop-conflict-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOncePod},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		for _, name := range []string{"e2e-rwop-conflict-a", "e2e-rwop-conflict-b"} {
+			_, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: corev1.PodSpec{
+					NodeName: nodeName,
+					Containers: []corev1.Container{{
+						Name: "main", Image: "busybox", Command: []string{"sleep", "infinity"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+						},
+					}},
+				},
+			}, metav1.CreateOptions{})
+			require.NoError(t, err)
+			podName := name
+			t.Cleanup(func() {
+				clientset.CoreV1().Pods(ns).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+			})
+		}
+
+		cmdTest{
+			args:            []string{"pvc/" + pvcName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pvc-rwop-conflict.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("PersistentVolume surfaces a VolumeAttachment attach error", func(t *testing.T) {
+		t.Parallel()
+		// Issue #669: VolumeAttachment has zero references anywhere in the templates today, so a
+		// PV/PVC pair can render fully Bound while the actual CSI attach/detach is stuck or
+		// erroring -- invisible from both the Pod and PVC/PV views. minikube's own
+		// storage-provisioner addon isn't a real CSI driver (hostpath needs no attacher), so it
+		// never creates VolumeAttachment objects itself -- there's nothing to wait on
+		// deterministically. Instead we create the VolumeAttachment object directly against the
+		// API (same trick as the StorageClass subtest above): the apiserver only validates the
+		// object's shape, not that a driver is actually behind it, so this is fully
+		// deterministic and not flaky.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		// Its own namespace, not the "e2e-storageclass" one the subtest above uses: reusing it
+		// raced against that subtest's own namespace deletion still being in flight ("unable to
+		// create new content ... because it is being terminated") when both ran in the same
+		// process.
+		ns := "e2e-volumeattachment"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, nodes.Items)
+		nodeName := nodes.Items[0].Name
+
+		// No storageClassName -- picks up the cluster's default class (Immediate binding), so
+		// this actually provisions and binds a real PV to attach the fake VolumeAttachment to.
+		pvcName := "e2e-attach-error-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		waitForInNamespace(t, "pvc/"+pvcName, "jsonpath={.status.phase}=Bound", ns)
+
+		pvc, err := clientset.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		require.NoError(t, err)
+		pvName := pvc.Spec.VolumeName
+		require.NotEmpty(t, pvName)
+
+		vaName := "e2e-fake-attach-error"
+		va := &storagev1.VolumeAttachment{
+			ObjectMeta: metav1.ObjectMeta{Name: vaName},
+			Spec: storagev1.VolumeAttachmentSpec{
+				Attacher: "fake.csi.kubectl-status.io",
+				NodeName: nodeName,
+				Source:   storagev1.VolumeAttachmentSource{PersistentVolumeName: &pvName},
+			},
+		}
+		created, err := clientset.StorageV1().VolumeAttachments().Create(context.TODO(), va, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			clientset.StorageV1().VolumeAttachments().Delete(context.TODO(), vaName, metav1.DeleteOptions{})
+		})
+		created.Status = storagev1.VolumeAttachmentStatus{
+			Attached: false,
+			AttachError: &storagev1.VolumeError{
+				Time:    metav1.Now(),
+				Message: "rpc error: code = Internal desc = fake attach failure for e2e test",
+			},
+		}
+		_, err = clientset.StorageV1().VolumeAttachments().UpdateStatus(context.TODO(), created, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"pv/" + pvName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the matching VolumeAttachment in full -- offline artifact tests can't
+		// reach this branch either, since --shallow/--local (used by every offline test) makes
+		// the KubeGet behind it a no-op.
+		cmdTest{
+			args:            []string{"pv/" + pvName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/pv-volumeattachment-error-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+	t.Run("VolumeSnapshot and VolumeSnapshotContent surface readiness, bound linkage, and restore-target context", func(t *testing.T) {
+		t.Parallel()
+		// Issue #669: VolumeSnapshot/VolumeSnapshotContent (snapshot.storage.k8s.io) had no
+		// standalone templates -- `kubectl status volumesnapshot/x` fell through to
+		// DefaultResource. minikube's hostpath storage-provisioner has no CSI snapshot support,
+		// so getting a real snapshot to reach ReadyToUse deterministically isn't possible here;
+		// instead (same trick as the VolumeAttachment subtest above) the objects and their
+		// status are created directly against the API -- the apiserver only validates their
+		// shape, not that a real external-snapshotter controller is behind them.
+		ensureVolumeSnapshotCRDs(t)
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-volumesnapshot"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		// Source PVC the snapshot is (nominally) taken from.
+		sourcePVCName := "e2e-vs-source-pvc"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: sourcePVCName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		vsGVR := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}
+		vscGVR := schema.GroupVersionResource{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotcontents"}
+		vsName := "e2e-vs"
+		vscName := "e2e-vsc"
+
+		vs := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "snapshot.storage.k8s.io/v1",
+			"kind":       "VolumeSnapshot",
+			"metadata":   map[string]interface{}{"name": vsName, "namespace": ns},
+			"spec": map[string]interface{}{
+				"volumeSnapshotClassName": "e2e-snapclass",
+				"source": map[string]interface{}{
+					"persistentVolumeClaimName": sourcePVCName,
+				},
+			},
+		}}
+		createdVS, err := dynamicClient.Resource(vsGVR).Namespace(ns).Create(context.TODO(), vs, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			dynamicClient.Resource(vsGVR).Namespace(ns).Delete(context.TODO(), vsName, metav1.DeleteOptions{})
+		})
+
+		vsc := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "snapshot.storage.k8s.io/v1",
+			"kind":       "VolumeSnapshotContent",
+			"metadata":   map[string]interface{}{"name": vscName},
+			"spec": map[string]interface{}{
+				"deletionPolicy":          "Delete",
+				"driver":                  "fake.csi.kubectl-status.io",
+				"volumeSnapshotClassName": "e2e-snapclass",
+				"volumeSnapshotRef": map[string]interface{}{
+					"name":      vsName,
+					"namespace": ns,
+					"uid":       string(createdVS.GetUID()),
+				},
+				"source": map[string]interface{}{
+					"volumeHandle": "vol-e2e-fake",
+				},
+			},
+		}}
+		createdVSC, err := dynamicClient.Resource(vscGVR).Create(context.TODO(), vsc, metav1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			dynamicClient.Resource(vscGVR).Delete(context.TODO(), vscName, metav1.DeleteOptions{})
+		})
+
+		// Bind them to each other and mark both ready -- status is a subresource, set via
+		// UpdateStatus rather than at creation time.
+		require.NoError(t, unstructured.SetNestedField(createdVS.Object, true, "status", "readyToUse"))
+		require.NoError(t, unstructured.SetNestedField(createdVS.Object, vscName, "status", "boundVolumeSnapshotContentName"))
+		require.NoError(t, unstructured.SetNestedField(createdVS.Object, "2026-07-21T02:00:00Z", "status", "creationTime"))
+		require.NoError(t, unstructured.SetNestedField(createdVS.Object, "5Gi", "status", "restoreSize"))
+		_, err = dynamicClient.Resource(vsGVR).Namespace(ns).UpdateStatus(context.TODO(), createdVS, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, true, "status", "readyToUse"))
+		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, "snap-e2e-fake-handle", "status", "snapshotHandle"))
+		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, int64(1784599200000000000), "status", "creationTime"))
+		require.NoError(t, unstructured.SetNestedField(createdVSC.Object, int64(5368709120), "status", "restoreSize"))
+		_, err = dynamicClient.Resource(vscGVR).UpdateStatus(context.TODO(), createdVSC, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		// A second PVC requesting to restore FROM the snapshot -- restore-target context.
+		restorePVCName := "e2e-vs-restore-pvc"
+		apiGroup := "snapshot.storage.k8s.io"
+		_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: restorePVCName, Namespace: ns},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("5Gi")},
+				},
+				DataSourceRef: &corev1.TypedObjectReference{
+					APIGroup: &apiGroup,
+					Kind:     "VolumeSnapshot",
+					Name:     vsName,
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		cmdTest{
+			args:            []string{"volumesnapshot/" + vsName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/volumesnapshot-bound.regex",
+		}.assert(t, nil, opts...)
+		// --deep inlines the bound VolumeSnapshotContent in full -- offline artifact tests can't
+		// reach this branch either, since --shallow/--local (used by every offline test) makes
+		// the KubeGetFirst behind it a no-op.
+		cmdTest{
+			args:            []string{"volumesnapshot/" + vsName, "-n", ns, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/volumesnapshot-bound-deep.regex",
+		}.assert(t, nil, opts...)
+		cmdTest{
+			args:            []string{"volumesnapshotcontent/" + vscName, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/volumesnapshotcontent-bound.regex",
+		}.assert(t, nil, opts...)
+		cmdTest{
+			args:            []string{"volumesnapshotcontent/" + vscName, "--deep", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/volumesnapshotcontent-bound-deep.regex",
+		}.assert(t, nil, opts...)
+	})
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -50,4 +50,7 @@ func TestE2EParallel(t *testing.T) {
 	runFluxSubtests(t, hackOpts, clientset)
 	runIstioSubtests(t, hackOpts, clientset)
 	runKyvernoSubtests(t, hackOpts, clientset)
+	runStorageSubtests(t, hackOpts, clientset, dynamicClient)
+	runCrossplaneSubtests(t, hackOpts, clientset)
+	runHelmReleaseSubtests(t, hackOpts, clientset)
 }


### PR DESCRIPTION
## Summary

- Moves the 6 subtests that already meet `TestE2EParallel`'s eligibility bar (own dedicated namespace, no cluster-wide/cluster-scoped state shared with other subtests) out of the serial `TestE2EDynamicManifests` and into the concurrent pool:
  - `PersistentVolumeClaim fetches its StorageClass and surfaces a non-default binding mode and volume expansion`
  - `PersistentVolumeClaim renders an explicit conflict when two non-terminal Pods are scheduled against one ReadWriteOncePod claim`
  - `PersistentVolume surfaces a VolumeAttachment attach error`
  - `VolumeSnapshot and VolumeSnapshotContent surface readiness, bound linkage, and restore-target context`
  - `Crossplane XR composes namespaced children and surfaces their health`
  - `Helm release Secret flags a superseded revision and resolves its manifest's live objects`
- Follows the established `runXSubtests` pattern: `runStorageSubtests` (`cmd/e2e_storage_test.go`), `runCrossplaneSubtests` (`cmd/e2e_crossplane_test.go`), `runHelmReleaseSubtests` (`cmd/e2e_helm_test.go`), each called from `TestE2EParallel` (`cmd/main_test.go`); every promoted subtest gets `t.Parallel()` as its first line.
- Checked each promoted subtest's namespace and cluster-scoped names (StorageClass, VolumeAttachment, VolumeSnapshotContent) against the full existing `TestE2EParallel` pool, not just its old `TestE2EDynamicManifests` siblings — no collisions.
- Updated `TestE2EDynamicManifests`'s doc comment to reflect the audit and point at the new homes; fixed a few in-subtest comments that cross-referenced now-relocated subtests ("the subtest above").
- `TestE2EDynamicManifests` now holds the 6 remaining subtests: metrics-server APIService (perturbs cluster-wide state), VPA (starves a shared dependency), PV-zone/Karpenter-nodeSelector (pin kube-scheduler's exact node-count-dependent message), plus the RWOP-holder and WaitForFirstConsumer-topologies subtests, which weren't part of #832's audited list and are called out as such rather than left with an invented reason.

Fixes #832.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `go test ./...` (full offline suite) passes
- [x] Ran the 6 promoted subtests live against a real cluster concurrently (`go test ./cmd/... -run 'TestE2EParallel/(PersistentVolumeClaim_fetches|PersistentVolumeClaim_renders_an_explicit_conflict|PersistentVolume_surfaces_a_VolumeAttachment|VolumeSnapshot_and_VolumeSnapshotContent|Crossplane_XR|Helm_release)' -parallel=2`) — all 6 pass with no namespace/name collisions
- [ ] A full `make test-e2e` run (all ~55 `TestE2EParallel` subtests together) — attempted in this sandbox but the shared minikube cluster here is capped well below the 4-CPU/6GB `e2e-minikube-up` sizes for (2 host vCPUs), and running the whole pool at `-parallel=4` exhausted it (apiserver/controller-manager/metrics-server crash-looping, ~40 unrelated subtests failing on TLS handshake timeouts/connection resets) independent of this change — recommend a maintainer confirm with a properly-sized cluster/CI before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)