### PR TITLE
Use GitHub-native changelog for release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ release:
     owner: bergerx
     name: kubectl-status
   replace_existing_artifacts: true
+changelog:
+  use: github-native
 before:
   hooks:
     - go generate ./...


### PR DESCRIPTION
## Summary
- goreleaser's default changelog is every commit since the last tag, including merge-commit noise (e.g. "Merge pull request #835 from ..."). That's raw VCS log output, which the OpenSSF Best Practices `release_notes` criterion explicitly disallows as a substitute for human-readable notes.
- Switch to `changelog: use: github-native`, GitHub's own "Generate release notes" API. It produces a "What's Changed" list of merged PR titles (already descriptive) plus a Full Changelog compare link and New Contributors callout — no raw commits, no merge noise.
- Zero added manual step: still just `git push --tags`, same as today.

Verified by calling the same API goreleaser uses under the hood (`gh api repos/bergerx/kubectl-status/releases/generate-notes -f tag_name=v0.7.24 -f previous_tag_name=v0.7.23`) — output is a clean 43-PR summary vs. the raw commit list currently published for v0.7.24.

Fixes #837

## Test plan
- [x] `goreleaser check` validates the updated `.goreleaser.yml`
- [x] Confirmed via GitHub's generate-notes API that the new changelog source produces readable, deduped output for the v0.7.23...v0.7.24 range
- [ ] Next tagged release goes through the real `goreleaser release` workflow and its GitHub Release body is reviewed