### PR TITLE
Strip terminal escape sequences from cluster data (CVE-2021-25743-class fix)

### DIFF
--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -18,7 +18,7 @@ import (
 
 func newRenderableObject(obj map[string]interface{}, engine *renderEngine, repo *input.ResourceRepo) RenderableObject {
 	r := RenderableObject{
-		Unstructured: unstructured.Unstructured{Object: obj},
+		Unstructured: unstructured.Unstructured{Object: sanitizeObject(obj)},
 		engine:       engine,
 		repo:         repo,
 		Config:       engine.cfg.Viper,

--- a/pkg/plugin/sanitize.go
+++ b/pkg/plugin/sanitize.go
@@ -1,0 +1,63 @@
+package plugin
+
+import "regexp"
+
+// ansiControlSequence matches ANSI/VT100 terminal escape sequences: CSI sequences (ESC [ ... final
+// byte), OSC sequences (ESC ] ... terminated by BEL or ST), and other two-byte Fe escapes.
+var ansiControlSequence = regexp.MustCompile(
+	"\x1b(?:" +
+		"\\[[0-?]*[ -/]*[@-~]" + // CSI, e.g. "\x1b[31m"
+		"|\\][^\x07\x1b]*(?:\x07|\x1b\\\\)" + // OSC, e.g. "\x1b]0;title\x07"
+		"|[@-Z\\\\-_]" + // other Fe escapes, e.g. "\x1bc"
+		")")
+
+// otherControlChars matches remaining C0/C1 control characters -- including a bare ESC that
+// ansiControlSequence didn't recognize as a full sequence, and CR which can be used to overwrite
+// already-printed text -- while leaving tab and newline alone since templates rely on them for
+// layout. C0 (\x00-\x1f minus tab/newline) and DEL (\x7f) are ASCII byte escapes; the C1 half
+// (U+0080-U+009F) has to be built from a decimal code-point range instead, since raw bytes >=
+// 0x80 aren't valid standalone UTF-8 and regexp.MustCompile would reject them.
+var otherControlChars = regexp.MustCompile("[\x00-\x08\x0b-\x1f\x7f]|[\U00000080-\U0000009f]")
+
+// sanitizeString strips terminal escape/control sequences from a single string value.
+func sanitizeString(s string) string {
+	s = ansiControlSequence.ReplaceAllString(s, "")
+	s = otherControlChars.ReplaceAllString(s, "")
+	return s
+}
+
+// sanitizeValue recursively strips terminal escape/control sequences out of string values found
+// anywhere inside cluster-supplied data (maps/slices from unstructured content), leaving other
+// types untouched.
+func sanitizeValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		return sanitizeString(val)
+	case map[string]interface{}:
+		for k, vv := range val {
+			val[k] = sanitizeValue(vv)
+		}
+		return val
+	case []interface{}:
+		for i, vv := range val {
+			val[i] = sanitizeValue(vv)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// sanitizeObject strips terminal escape/control sequences from every string value in obj, in
+// place. Applied once at the point cluster data enters rendering (newRenderableObject) so that
+// nothing downstream -- any template, any helper -- has to remember to do it: a Condition or
+// Event message (or any other free-text field) set by anything with write access in the cluster
+// could otherwise embed ANSI sequences to spoof or hide terminal output, the same class of issue
+// fixed upstream in kubectl as CVE-2021-25743.
+func sanitizeObject(obj map[string]interface{}) map[string]interface{} {
+	if obj == nil {
+		return obj
+	}
+	sanitizeValue(obj)
+	return obj
+}

--- a/pkg/plugin/sanitize_test.go
+++ b/pkg/plugin/sanitize_test.go
@@ -1,0 +1,48 @@
+package plugin
+
+import "testing"
+
+func TestSanitizeString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text is untouched", "container failed to start", "container failed to start"},
+		{"newline and tab preserved", "line1\n\tindented", "line1\n\tindented"},
+		{"CSI color sequence stripped", "\x1b[31mCrashLoopBackOff\x1b[0m", "CrashLoopBackOff"},
+		{"OSC sequence stripped", "\x1b]0;fake title\x07visible", "visible"},
+		{"carriage return stripped", "real message\rFAKE OVERWRITE", "real messageFAKE OVERWRITE"},
+		{"bare ESC not forming a full sequence is stripped", "abc\x1bdef", "abcdef"},
+		{"C0 control chars stripped", "a\x00b\x07c", "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeString(tt.in); got != tt.want {
+				t.Errorf("sanitizeString(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeObject(t *testing.T) {
+	obj := map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"message": "\x1b[2K\rReady\x1b[0m",
+				},
+			},
+		},
+		"count": float64(3),
+	}
+	sanitizeObject(obj)
+	conditions := obj["status"].(map[string]interface{})["conditions"].([]interface{})
+	msg := conditions[0].(map[string]interface{})["message"]
+	if msg != "Ready" {
+		t.Errorf("nested message = %q, want %q", msg, "Ready")
+	}
+	if obj["count"] != float64(3) {
+		t.Errorf("non-string value was mutated: %v", obj["count"])
+	}
+}


### PR DESCRIPTION
## Summary
- kubectl-status renders object fields (Condition/Event messages, annotations, etc.) through its own Go templates instead of kubectl's printer package, so it never inherited kubectl's fix for [CVE-2021-25743](https://nvd.nist.gov/vuln/detail/cve-2021-25743) (ANSI/control-sequence injection via raw object data into terminal output).
- Anything with write access to an object in a cluster you have read access to (e.g. a malicious/compromised workload's status, or an Event) could embed ANSI escape or other control sequences in a free-text field to spoof or hide `kubectl status` terminal output.
- Adds `pkg/plugin/sanitize.go`: strips ANSI/VT100 escape sequences and C0/C1 control characters (preserving `\n`/`\t`) from every string value in a cluster object, applied once at `newRenderableObject` (`pkg/plugin/renderable.go`) — the single point where fetched cluster data enters rendering, so all templates/helpers get already-sanitized strings without each one needing to remember to sanitize.
- Other kubectl CVEs (`kubectl cp` path-traversal series, `--cache-dir` world-writable cache, client-go token logging) were checked and don't apply: this plugin doesn't implement `cp`/tar extraction or its own caching, and pins `k8s.io/client-go`/`k8s.io/kubectl` at v0.36.3, long past those fixes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, including golden-file template output tests in `cmd`)
- [x] Added `pkg/plugin/sanitize_test.go` covering CSI/OSC stripping, bare ESC, CR overwrite, C0 controls, and nested map/slice sanitization while leaving non-string values untouched