### PR TITLE
Fall back to partial name matching when exact name isn't found

### DIFF
--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -145,6 +145,7 @@ func (r *ResourceRepo) newBaseBuilder() *resource.Builder {
 }
 
 func (r *ResourceRepo) CLIQueryResults(args []string) *resource.Result {
+	args = r.resolvePartialNameArgs(args)
 	builder := r.newBaseBuilder().
 		LabelSelectorParam(r.viper.GetString("selector")).
 		FieldSelectorParam(r.viper.GetString("field-selector"))
@@ -160,6 +161,72 @@ func (r *ResourceRepo) CLIQueryResults(args []string) *resource.Result {
 		builder = builder.ResourceTypeOrNameArgs(true, args...)
 	}
 	return builder.Do()
+}
+
+// resolvePartialNameArgs implements `k status TYPE name` matching by substring when the exact
+// name doesn't exist, e.g. `k status deploy component` matching Deployment/myapp-mycomponent.
+// It only handles the common single-type "TYPE name..." shape (as opposed to "TYPE/NAME" or
+// multiple comma-separated types), and only kicks in once the exact name lookup has already
+// come back NotFound, so `k status deploy pod-full-name` and `k status deploy` keep behaving
+// exactly as before. Names that still don't match anything (even partially) are passed through
+// unchanged so the normal "not found" error is reported.
+func (r *ResourceRepo) resolvePartialNameArgs(args []string) []string {
+	if len(args) < 2 || r.viper.GetBool("local") {
+		return args
+	}
+	resourceTypeArg := args[0]
+	if strings.ContainsAny(resourceTypeArg, "/,") {
+		return args
+	}
+	mapping, err := r.mappingFor(resourceTypeArg)
+	if err != nil {
+		return args
+	}
+	namespace := r.viper.GetString("namespace")
+	if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+		namespace = ""
+	}
+	resolvedNames := make([]string, 0, len(args)-1)
+	changed := false
+	for _, name := range args[1:] {
+		_, getErr := r.dynamicClient.Resource(mapping.Resource).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if getErr == nil {
+			resolvedNames = append(resolvedNames, name)
+			continue
+		}
+		if !apierrors.IsNotFound(getErr) {
+			resolvedNames = append(resolvedNames, name)
+			continue
+		}
+		matches, listErr := r.namesContaining(mapping.Resource, namespace, name)
+		if listErr != nil || len(matches) == 0 {
+			resolvedNames = append(resolvedNames, name)
+			continue
+		}
+		klog.V(4).InfoS("partial name match", "resourceType", resourceTypeArg, "requested", name, "matched", matches)
+		resolvedNames = append(resolvedNames, matches...)
+		changed = true
+	}
+	if !changed {
+		return args
+	}
+	return append([]string{resourceTypeArg}, resolvedNames...)
+}
+
+// namesContaining lists every object of the given resource and returns the names that contain
+// substr, used as the fallback once an exact name lookup has failed.
+func (r *ResourceRepo) namesContaining(gvr schema.GroupVersionResource, namespace, substr string) ([]string, error) {
+	list, err := r.dynamicClient.Resource(gvr).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, item := range list.Items {
+		if strings.Contains(item.GetName(), substr) {
+			names = append(names, item.GetName())
+		}
+	}
+	return names, nil
 }
 
 func (r *ResourceRepo) Objects(namespace string, args []string, labelSelector string) (Objects, error) {

--- a/pkg/input/input_test.go
+++ b/pkg/input/input_test.go
@@ -150,6 +150,105 @@ func TestOwnersClusterScopedOwner(t *testing.T) {
 	}
 }
 
+// TestResolvePartialNameArgs covers `k status TYPE name` falling back to a substring match on
+// the resource's name once the exact name lookup fails, e.g. `k status deploy component`
+// matching Deployment/myapp-mycomponent -- but only after the exact match already failed, so
+// exact names and plain `TYPE` (list-all) calls are left untouched.
+func TestResolvePartialNameArgs(t *testing.T) {
+	newDeploymentFactory := func(t *testing.T, names ...string) *cmdtesting.TestFactory {
+		t.Helper()
+		f := newTestFactory()
+		var objs []runtime.Object
+		for _, name := range names {
+			objs = append(objs, &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": "test",
+				},
+			}})
+		}
+		f.FakeDynamicClient = fakedynamic.NewSimpleDynamicClient(scheme.Scheme, objs...)
+		return f
+	}
+
+	t.Run("exact name match is left untouched", func(t *testing.T) {
+		f := newDeploymentFactory(t, "myapp-mycomponent")
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f, viper.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.viper.Set("namespace", "test")
+		got := repo.resolvePartialNameArgs([]string{"deployments.apps", "myapp-mycomponent"})
+		want := []string{"deployments.apps", "myapp-mycomponent"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("type-only call (list all) is left untouched", func(t *testing.T) {
+		f := newDeploymentFactory(t, "myapp-mycomponent")
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f, viper.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.viper.Set("namespace", "test")
+		got := repo.resolvePartialNameArgs([]string{"deployments"})
+		want := []string{"deployments"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("partial name falls back to a substring match once the exact lookup fails", func(t *testing.T) {
+		f := newDeploymentFactory(t, "myapp-mycomponent")
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f, viper.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.viper.Set("namespace", "test")
+		got := repo.resolvePartialNameArgs([]string{"deployments.apps", "component"})
+		want := []string{"deployments.apps", "myapp-mycomponent"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("no match at all (even partial) is left untouched", func(t *testing.T) {
+		f := newDeploymentFactory(t, "myapp-mycomponent")
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f, viper.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.viper.Set("namespace", "test")
+		got := repo.resolvePartialNameArgs([]string{"deployments.apps", "does-not-exist"})
+		want := []string{"deployments.apps", "does-not-exist"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("multiple partial matches are all included", func(t *testing.T) {
+		f := newDeploymentFactory(t, "myapp-mycomponent", "otherapp-mycomponent")
+		t.Cleanup(func() { f.Cleanup() })
+		repo, err := NewResourceRepo(f, viper.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+		repo.viper.Set("namespace", "test")
+		got := repo.resolvePartialNameArgs([]string{"deployments.apps", "component"})
+		want := []string{"deployments.apps", "myapp-mycomponent", "otherapp-mycomponent"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
 // newAPIServiceFactory builds a test factory whose dynamic client can Get/Create
 // apiregistration.k8s.io APIService objects -- a group client-go's own scheme doesn't know about,
 // so the fake dynamic client needs an explicit List-kind mapping for it.


### PR DESCRIPTION
## Summary
- `k status TYPE name` now falls back to substring matching on resource name when the exact name isn't found, e.g. `k status deploy component` matches `Deployment/myapp-mycomponent`.
- The fallback only triggers after the exact lookup already came back NotFound, so `k status deploy pod-full-name` and `k status deploy` (list all) behave exactly as before.
- Multiple resources whose names contain the given substring are all included, mirroring how `kubectl get TYPE name1 name2` would render several exact matches.
- Scoped to the top-level CLI resource-type/name arguments (`pkg/input.ResourceRepo.CLIQueryResults`) only; internal template-side lookups (owner references, imagePullSecrets existence checks, etc.) remain exact-match to avoid false positives.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/...` (includes new `TestResolvePartialNameArgs` covering exact match, list-all, single partial match, no match, and multiple partial matches)