### PR TITLE
Bump Go to 1.26.6 to fix govulncheck findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bergerx/kubectl-status
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
## Summary
- CI run [31760787710](https://github.com/bergerx/kubectl-status/actions/runs/31760787710/job/94646484376) failed govulncheck with 4 findings, all in the Go standard library and all fixed in go1.26.6:
  - GO-2026-6218 — quadratic complexity in `net/url` resolvePath
  - GO-2026-6090 — post-handshake message limits in `crypto/tls`
  - GO-2026-5972 — recursion depth limit in `encoding/asn1`
  - GO-2026-5026 — Punycode label validation reachable via `net/http`
- Bumped the `go` directive in `go.mod` from `1.26.5` to `1.26.6` so CI's `setup-go` (which reads `go-version-file: go.mod`) installs the patched toolchain.

## Test plan
- [x] `go build ./...` with go1.26.6
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `govulncheck ./...` with go1.26.6 — 0 vulnerabilities in code (down from 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)