### PR TITLE
Include e2e coverage in the Codecov report

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: make test
-      - name: Upload coverage to Codecov
+      - name: Upload unit test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: cover.out
+          flags: unittests
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Start minikube
@@ -57,3 +58,13 @@ jobs:
           timeout_minutes: 30
           max_attempts: 2
           command: ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
+      - name: Upload e2e test coverage to Codecov
+        # if: always() -- uploads whatever coverage was captured even if a retry attempt of
+        # the e2e step above failed; codecov-action just no-ops if cover-e2e.out is missing.
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: cover-e2e.out
+          flags: e2e
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 cover.out
+cover-e2e.out
 cover.html
 coverage.txt
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,12 @@ govulncheck:
 #--------------------------
 .PHONY: test
 test: vet staticcheck
-	go test -coverprofile=cover.out ./...
+	# -coverpkg=./...: without it, coverage for a package is only attributed from tests
+	# living in that same package -- e.g. pkg/plugin code reached only via cmd/local_test.go
+	# (not via pkg/plugin's own tests) would otherwise show as uncovered.
+	# -covermode=atomic: at least one test uses t.Parallel(), so counter writes need to be
+	# race-safe.
+	go test -coverprofile=cover.out -coverpkg=./... -covermode=atomic ./...
 
 #--------------------------
 # E2E cluster identity
@@ -216,8 +221,16 @@ test-e2e: vet staticcheck install-e2e-deps
 	# e2e-minikube-up (the only other target that creates $(E2E_HOME)), so on a bare
 	# CI runner $(E2E_LOCKFILE)'s parent dir wouldn't otherwise exist and flock would
 	# fail outright.
+	# -coverprofile/-coverpkg/-covermode: executeCMD() (cmd/e2e_helpers_test.go) calls
+	# RootCmd()/Execute() in-process rather than shelling out to a built binary, so standard
+	# go coverage instrumentation faithfully captures what the e2e suite exercises, including
+	# pkg/ code that unit tests may not reach the same way. -coverpkg=./... is needed since
+	# these tests live in package main (cmd/e2e_*_test.go) -- without it only cmd's own
+	# statements would be tracked, missing pkg/. -covermode=atomic: -parallel=4 below runs
+	# subtests concurrently against the same instrumented code, so counter writes need to be
+	# race-safe.
 	@mkdir -p $(E2E_HOME)
-	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
+	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 else
 test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# The cluster (profile: $(E2E_PROFILE)) is shared across every worktree/branch/session on
@@ -227,8 +240,9 @@ test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# namespace names, so two concurrent runs would otherwise collide).
 	# using count to prevent caching; see the timeout note in the ASSUME_MINIKUBE_IS_CONFIGURED
 	# branch above.
-	# See the gotestsum note, and the -parallel=4 note above the other branch's go test invocation.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*'
+	# See the gotestsum note, the -parallel=4 note above the other branch's go test invocation,
+	# and the coverage flags note above the other branch's invocation.
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 endif
 
 # Passed through to test-e2e-quick's own invocation below, not test-e2e's: UPDATE_FIXTURES=true


### PR DESCRIPTION
## Summary
- `make test-e2e` now writes `cover-e2e.out` (previously no `-coverprofile` at all, so e2e-exercised code never showed up in the coverage report). `executeCMD()` calls `RootCmd()`/`Execute()` in-process (`cmd/e2e_helpers_test.go`), so standard go coverage instrumentation captures this faithfully.
- `make test` (and `test-e2e`) now pass `-coverpkg=./...`, fixing a pre-existing gap where a package's coverage was only attributed from tests living in that same package — e.g. `pkg/` code reached only via `cmd`'s unit tests (not `pkg/`'s own tests) showed as uncovered. Verified locally this moves total merged unit coverage from 69.1% to 78.0%.
- `-covermode=atomic` on both, since tests run concurrently (`t.Parallel()` / `-parallel=4`).
- CI now uploads both profiles to Codecov as separate flags (`unittests`, `e2e`).

## Test plan
- [x] `make test` passes locally with the new flags; spot-checked `go tool cover -func=cover.out` shows previously-0% `pkg/plugin/time.go` functions now correctly covered
- [ ] `make test-e2e` end-to-end against a real cluster (not run locally — no cluster available in this environment)
- [ ] CI run confirms both Codecov upload steps succeed and the Codecov UI shows both `unittests` and `e2e` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)