### PR TITLE
Add line-level test coverage for .tmpl template files

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,7 +26,16 @@ jobs:
           # See pkg/plugin/template_coverage.go: adds line-level .tmpl coverage as a side effect of
           # this same `make test` run (confirmed output-transparent, see
           # pkg/plugin/template_coverage_test.go) rather than a separate, duplicate test run.
-          KUBECTL_STATUS_TEMPLATE_COVERAGE: unit-template-cover.out
+          #
+          # Must be absolute: `go test ./...` runs each package's test binary with its cwd set to
+          # that package's own source directory (not the repo root), and env: values here are
+          # literal strings -- GitHub Actions does not shell-expand them -- so a relative path
+          # would land at e.g. pkg/plugin/unit-template-cover.out and cmd/unit-template-cover.out
+          # instead of the repo root, where `make template-cover-html` below looks for it.
+          # ${{ github.workspace }} is the one GH Actions expression usable here (it's substituted
+          # before the shell ever runs); the e2e step below hits the same hazard but is a real
+          # shell command, so it uses $(pwd) instead.
+          KUBECTL_STATUS_TEMPLATE_COVERAGE: ${{ github.workspace }}/unit-template-cover.out
       - name: Upload unit test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -64,8 +73,10 @@ jobs:
           max_attempts: 2
           # KUBECTL_STATUS_TEMPLATE_COVERAGE inlined here (rather than a step-level `env:`) since
           # nick-fields/retry runs `command:` as its own shell invocation -- see the unit test step
-          # above for why this rides the existing test-e2e run instead of a separate one.
-          command: ASSUME_MINIKUBE_IS_CONFIGURED=true KUBECTL_STATUS_TEMPLATE_COVERAGE=e2e-template-cover.out make test-e2e
+          # above for why this rides the existing test-e2e run instead of a separate one, and for
+          # why the path must be absolute ($(pwd), since this line genuinely runs through a shell
+          # unlike the unit step's env: block, where the equivalent ${{ github.workspace }} lives).
+          command: ASSUME_MINIKUBE_IS_CONFIGURED=true KUBECTL_STATUS_TEMPLATE_COVERAGE=$(pwd)/e2e-template-cover.out make test-e2e
       - name: Upload e2e test coverage to Codecov
         # if: always() -- uploads whatever coverage was captured even if a retry attempt of
         # the e2e step above failed; codecov-action just no-ops if cover-e2e.out is missing.

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - run: make test
+        env:
+          # See pkg/plugin/template_coverage.go: adds line-level .tmpl coverage as a side effect of
+          # this same `make test` run (confirmed output-transparent, see
+          # pkg/plugin/template_coverage_test.go) rather than a separate, duplicate test run.
+          KUBECTL_STATUS_TEMPLATE_COVERAGE: unit-template-cover.out
       - name: Upload unit test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -57,7 +62,10 @@ jobs:
           # headroom plus setup slack.
           timeout_minutes: 30
           max_attempts: 2
-          command: ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
+          # KUBECTL_STATUS_TEMPLATE_COVERAGE inlined here (rather than a step-level `env:`) since
+          # nick-fields/retry runs `command:` as its own shell invocation -- see the unit test step
+          # above for why this rides the existing test-e2e run instead of a separate one.
+          command: ASSUME_MINIKUBE_IS_CONFIGURED=true KUBECTL_STATUS_TEMPLATE_COVERAGE=e2e-template-cover.out make test-e2e
       - name: Upload e2e test coverage to Codecov
         # if: always() -- uploads whatever coverage was captured even if a retry attempt of
         # the e2e step above failed; codecov-action just no-ops if cover-e2e.out is missing.
@@ -66,5 +74,16 @@ jobs:
         with:
           files: cover-e2e.out
           flags: e2e
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Render template coverage
+        if: always()
+        run: make template-cover-html
+      - name: Upload template coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: template-cover.out
+          flags: templates
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ cover-e2e.out
 cover.html
 coverage.txt
 
+# Output of `make template-cover-html` (see Makefile) -- .tmpl line coverage
+unit-template-cover.out
+e2e-template-cover.out
+template-cover.out
+template-cover.html
+
 bin/
 dist/
 .e2e/

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,27 @@ test: vet staticcheck
 	# race-safe.
 	go test -coverprofile=cover.out -coverpkg=./... -covermode=atomic ./...
 
+# template-cover-html renders line-level coverage for pkg/plugin/templates/*.tmpl files -- Go's own
+# `go test -coverprofile` (above) only instruments compiled .go statements, it has no visibility
+# into .tmpl content executed at runtime by text/template. Unlike `test` above, this target does
+# NOT run any tests itself: it only merges and renders whatever unit-template-cover.out/
+# e2e-template-cover.out profile(s) a prior KUBECTL_STATUS_TEMPLATE_COVERAGE-enabled test run
+# already produced (either or both may be absent, e.g. a dev who only ran the unit suite) --
+# running tests here too would silently double the cost of whichever of those runs already
+# happened, which is exactly what this instrumentation is designed to avoid (it's provably
+# output-transparent, see pkg/plugin/template_coverage_test.go, precisely so it can ride the
+# existing `make test`/`make test-e2e` runs instead of requiring a separate one). Typical use:
+#   KUBECTL_STATUS_TEMPLATE_COVERAGE=unit-template-cover.out make test
+#   KUBECTL_STATUS_TEMPLATE_COVERAGE=e2e-template-cover.out ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
+#   make template-cover-html
+.PHONY: template-cover-html
+template-cover-html:
+	{ echo "mode: count"; \
+	  tail -n +2 unit-template-cover.out 2>/dev/null; \
+	  tail -n +2 e2e-template-cover.out 2>/dev/null; } > template-cover.out
+	go tool cover -html=template-cover.out -o template-cover.html
+	@echo "wrote template-cover.html"
+
 #--------------------------
 # E2E cluster identity
 #--------------------------

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,13 @@ test: vet staticcheck
 # running tests here too would silently double the cost of whichever of those runs already
 # happened, which is exactly what this instrumentation is designed to avoid (it's provably
 # output-transparent, see pkg/plugin/template_coverage_test.go, precisely so it can ride the
-# existing `make test`/`make test-e2e` runs instead of requiring a separate one). Typical use:
-#   KUBECTL_STATUS_TEMPLATE_COVERAGE=unit-template-cover.out make test
-#   KUBECTL_STATUS_TEMPLATE_COVERAGE=e2e-template-cover.out ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
+# existing `make test`/`make test-e2e` runs instead of requiring a separate one). Typical use, run
+# from the repo root (KUBECTL_STATUS_TEMPLATE_COVERAGE must be an absolute path: `go test ./...`
+# runs each package's test binary from that package's own directory, not the repo root, so a bare
+# relative filename here would silently land inside pkg/plugin/ or cmd/ instead -- FlushTemplateCoverageProfile
+# in pkg/plugin/template_coverage.go rejects a relative one outright rather than doing that):
+#   KUBECTL_STATUS_TEMPLATE_COVERAGE=$(pwd)/unit-template-cover.out make test
+#   KUBECTL_STATUS_TEMPLATE_COVERAGE=$(pwd)/e2e-template-cover.out ASSUME_MINIKUBE_IS_CONFIGURED=true make test-e2e
 #   make template-cover-html
 .PHONY: template-cover-html
 template-cover-html:

--- a/cmd/template_coverage_test.go
+++ b/cmd/template_coverage_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bergerx/kubectl-status/pkg/plugin"
+)
+
+// TestMain flushes this process's accumulated template coverage after every test in the package
+// has run. cmd's e2e tests (TestE2E*) call into pkg/plugin's render path in-process via
+// RootCmd/plugin.Run, so any KUBECTL_STATUS_TEMPLATE_COVERAGE-gated instrumentation in
+// pkg/plugin.buildTemplateSet fires here too -- but cmd's test binary is a separate OS process from
+// pkg/plugin's own, with its own copy of pkg/plugin's package-level coverage recorder, so it needs
+// its own flush call. See pkg/plugin.FlushTemplateCoverageProfile's doc for why this is a no-op
+// (rather than clobbering a sibling process's profile) when this process never actually recorded a
+// hit, e.g. `make test-e2e`'s `go test ./... -run 'TestE2E*'` also runs pkg/plugin's suite with
+// zero matching tests.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if err := plugin.FlushTemplateCoverageProfile(); err != nil {
+		fmt.Fprintln(os.Stderr, "template coverage: failed to write profile:", err)
+	}
+	os.Exit(code)
+}

--- a/cmd/template_coverage_test.go
+++ b/cmd/template_coverage_test.go
@@ -20,7 +20,12 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	if err := plugin.FlushTemplateCoverageProfile(); err != nil {
+		// See pkg/plugin/template_coverage_test.go's TestMain for why this must fail the run
+		// rather than just log.
 		fmt.Fprintln(os.Stderr, "template coverage: failed to write profile:", err)
+		if code == 0 {
+			code = 1
+		}
 	}
 	os.Exit(code)
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# See https://github.com/bergerx/kubectl-status/issues/858: without this, Codecov posts the PR
+# comment/status check as soon as it receives the *first* upload for a commit, so the initial
+# comment only reflects whichever flag's job finished first and the rest show up later as silent
+# edits. .github/workflows/ci-test.yml uploads three separate flags per commit -- unittests
+# (`make test`), e2e (`make test-e2e`), templates (this repo's own .tmpl line coverage, see
+# pkg/plugin/template_coverage.go) -- so wait for all three before notifying.
+#
+# Tradeoff: since the e2e job can take up to ~30 min, this delays the PR comment/status until it
+# finishes, rather than getting quick feedback from the unittests upload alone. If any of these
+# three uploads is ever made conditional (e.g. skipped for docs-only changes), coverage
+# targets/thresholds added here later will need `carryforward: true` for that flag, or a commit
+# where it didn't run will be treated as 0% for that flag -- see #858.
+codecov:
+  notify:
+    after_n_builds: 3

--- a/pkg/plugin/render_engine.go
+++ b/pkg/plugin/render_engine.go
@@ -216,7 +216,15 @@ func buildTemplateSet(funcs template.FuncMap) (*templateSet, error) {
 	// per-ecosystem subdirectories (templates/<group>/<Kind>.tmpl, templates/<group>/<group>_common.tmpl
 	// -- see #807). ParseFS accepts multiple glob patterns; this does not touch the separate
 	// user-override glob in parseUserOverlay below, which stays a flat ~/.kubectl-status/templates/*.tmpl.
-	embedded, err := template.New("templates").Funcs(funcs).ParseFS(templatesFS, "templates/*.tmpl", "templates/*/*.tmpl")
+	var embedded *template.Template
+	var err error
+	if templateCoverageEnabled() {
+		// See template_coverage.go: only active under KUBECTL_STATUS_TEMPLATE_COVERAGE (the
+		// Makefile's coverage targets), never in normal CLI use or the default `make test`.
+		embedded, err = buildInstrumentedEmbedded(funcs)
+	} else {
+		embedded, err = template.New("templates").Funcs(funcs).ParseFS(templatesFS, "templates/*.tmpl", "templates/*/*.tmpl")
+	}
 	if err != nil {
 		klog.V(3).ErrorS(err, "Error parsing some templates")
 		return nil, err

--- a/pkg/plugin/template_coverage.go
+++ b/pkg/plugin/template_coverage.go
@@ -104,6 +104,14 @@ func FlushTemplateCoverageProfile() error {
 	if path == "" {
 		return nil
 	}
+	// `go test ./...` runs each package's test binary with its cwd set to that package's own
+	// source directory, not wherever `go test`/`make` was invoked from -- so a relative path here
+	// would silently land inside pkg/plugin/ or cmd/ instead of wherever the caller (e.g.
+	// `make template-cover-html`) actually looks for it, for a process-boundary reason that isn't
+	// obvious from the resulting "file not found". Fail loudly instead.
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("%s must be an absolute path (got %q): go test runs each package's test binary from that package's own directory, not the repo root", templateCoverageEnvVar, path)
+	}
 	return coverageRecorder.writeProfile(path)
 }
 

--- a/pkg/plugin/template_coverage.go
+++ b/pkg/plugin/template_coverage.go
@@ -1,0 +1,304 @@
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"text/template"
+	"text/template/parse"
+)
+
+// This file implements opt-in line-level test coverage for the embedded .tmpl files, mirroring
+// what `go test -coverprofile` gives .go files -- something Go's own coverage tooling can't do,
+// since it only instruments compiled .go statements and has no visibility into text/template
+// content executed at runtime. It is only ever active when templateCoverageEnvVar is set (unit
+// and e2e test runs via the Makefile's coverage targets); with it unset -- every normal CLI
+// invocation and the default `make test` -- buildTemplateSet takes its original, unmodified
+// ParseFS path with zero overhead.
+//
+// Approach: reparse each embedded file in isolation to get its real *parse.Tree (the same tree
+// text/template itself builds), walk it to find every leaf "statement" node (action/template/
+// break/continue calls, recursing into if/range/with bodies but not instrumenting the branch
+// construct itself), and splice a no-op marker call immediately before each one's own opening
+// delimiter -- mirroring that delimiter's `{{`/`{{-` style exactly, so the splice is provably a
+// no-op regardless of whether the surrounding template relies on `{{-`/`-}}` whitespace trimming
+// or on plain delimiters plus meaningful literal whitespace (both patterns exist in this
+// codebase; see core/Service.tmpl's ExternalName branch for the latter). Using the real AST
+// (rather than a hand-rolled lexer) means comments, multi-line actions, quoted/raw strings, etc.
+// never need special-casing -- the real parser has already resolved all of that before this code
+// ever sees a byte offset.
+//
+// Deriving splice points from the real parser this way still requires a second, actually-executed
+// parse of the instrumented source (there's no exported hook into text/template's unexported
+// executor), so each file is parsed twice when coverage is enabled: once (via
+// instrumentTemplateSource) purely to discover coverable nodes, and once for real via the
+// resulting instrumented text.
+
+const (
+	// templateCoverageEnvVar, when set to a non-empty output path, enables template instrumentation
+	// in buildTemplateSet and is where FlushTemplateCoverageProfile writes the accumulated profile.
+	templateCoverageEnvVar = "KUBECTL_STATUS_TEMPLATE_COVERAGE"
+	// templateCoverageFuncName is the marker function spliced into instrumented template source.
+	// It is only ever added to the FuncMap used for the embedded tree's instrumented parse -- never
+	// to the FuncMap parseUserOverlay uses -- so a user's ~/.kubectl-status/templates overlay can
+	// never invoke it.
+	templateCoverageFuncName = "__templateCoverageHit"
+)
+
+func templateCoverageEnabled() bool {
+	return os.Getenv(templateCoverageEnvVar) != ""
+}
+
+// templateCoverageRecorder accumulates per-line hit counts for instrumented template source
+// across every buildTemplateSet call in this process (each renderEngine/test case builds its own
+// templateSet, but they all share this one package-level recorder so counts accumulate across the
+// whole test run rather than resetting per call).
+type templateCoverageRecorder struct {
+	mu      sync.Mutex
+	hits    map[string]int64
+	lineLen map[string]int
+}
+
+var coverageRecorder = &templateCoverageRecorder{
+	hits:    make(map[string]int64),
+	lineLen: make(map[string]int),
+}
+
+// register records that key ("relpath:line") is instrumented, so it's reported even if never hit.
+func (r *templateCoverageRecorder) register(key string, lineLen int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.hits[key]; !ok {
+		r.hits[key] = 0
+	}
+	r.lineLen[key] = lineLen
+}
+
+// hitFunc returns the closure bound into the instrumented FuncMap as templateCoverageFuncName.
+func (r *templateCoverageRecorder) hitFunc() func(string) string {
+	return func(key string) string {
+		r.mu.Lock()
+		r.hits[key]++
+		r.mu.Unlock()
+		return ""
+	}
+}
+
+// FlushTemplateCoverageProfile writes this process's accumulated template line-hit counts, in `go
+// tool cover`'s "mode: count" profile format, to the path named by templateCoverageEnvVar. It is a
+// no-op if the env var is unset, or if this process never actually recorded any hits -- the latter
+// matters because pkg/plugin's and cmd's test binaries are separate processes each with their own
+// copy of coverageRecorder, and `make test-e2e` runs `go test ./... -run 'TestE2E*'`, under which
+// pkg/plugin's own TestMain would otherwise fire with zero hits and clobber a sibling process's
+// already-written profile at the same path.
+//
+// Exported for pkg/plugin's and cmd's TestMain to call after m.Run().
+func FlushTemplateCoverageProfile() error {
+	path := os.Getenv(templateCoverageEnvVar)
+	if path == "" {
+		return nil
+	}
+	return coverageRecorder.writeProfile(path)
+}
+
+func (r *templateCoverageRecorder) writeProfile(path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.hits) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(r.hits))
+	for k := range r.hits {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	buf.WriteString("mode: count\n")
+	for _, key := range keys {
+		idx := strings.LastIndexByte(key, ':')
+		file, line := key[:idx], key[idx+1:]
+		length := r.lineLen[key]
+		if length < 1 {
+			length = 1
+		}
+		fmt.Fprintf(&buf, "%s:%s.1,%s.%d 1 %d\n", file, line, line, length+1, r.hits[key])
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+// buildInstrumentedEmbedded is the coverage-enabled replacement for buildTemplateSet's normal
+// `template.New("templates").Funcs(funcs).ParseFS(templatesFS, ...)` call. It mirrors ParseFS's
+// own naming semantics (see stdlib text/template/helper.go's parseFiles) exactly, but parses each
+// file's instrumented source instead of its raw content.
+func buildInstrumentedEmbedded(funcs template.FuncMap) (*template.Template, error) {
+	instrumentedFuncs := make(template.FuncMap, len(funcs)+1)
+	for name, fn := range funcs {
+		instrumentedFuncs[name] = fn
+	}
+	instrumentedFuncs[templateCoverageFuncName] = coverageRecorder.hitFunc()
+
+	// Pre-named "templates", exactly like buildTemplateSet's own root -- since no embedded file is
+	// ever named "templates.tmpl", every file below becomes a t.New(name) child and this root stays
+	// an empty, never-executed template, matching today's behavior.
+	t := template.New("templates").Funcs(instrumentedFuncs)
+	for _, pattern := range []string{"templates/*.tmpl", "templates/*/*.tmpl"} {
+		filenames, err := fs.Glob(templatesFS, pattern)
+		if err != nil {
+			return nil, err
+		}
+		for _, filename := range filenames {
+			raw, err := fs.ReadFile(templatesFS, filename)
+			if err != nil {
+				return nil, err
+			}
+			instrumented, err := instrumentTemplateSource(filename, raw, funcs)
+			if err != nil {
+				return nil, err
+			}
+			if _, err := t.New(filepath.Base(filename)).Parse(string(instrumented)); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return t, nil
+}
+
+// coverPoint is one located, not-yet-spliced coverable node: a byte offset (into the node's own
+// content, just past its opening delimiter -- see parse.Node.Position's doc) and the node's line.
+type coverPoint struct {
+	pos  int
+	line int
+}
+
+// instrumentTemplateSource parses filename's raw content in isolation (using the real FuncMap so
+// every function call resolves, but not yet the coverage marker) purely to discover coverable
+// nodes via the real *parse.Tree, then splices a marker before each one's own opening delimiter in
+// the raw bytes and returns the result. filename is the templatesFS-relative path (e.g.
+// "templates/workloads/Pod.tmpl"); every discovered line is registered with coverageRecorder under
+// the repo-root-relative key "./pkg/plugin/<filename>:<line>" so `go tool cover -html` (which
+// reads report paths directly via os.ReadFile for any path starting with "." or "/", bypassing its
+// usual go-list package resolution) renders it correctly.
+func instrumentTemplateSource(filename string, raw []byte, funcs template.FuncMap) ([]byte, error) {
+	probe, err := template.New(filepath.Base(filename)).Funcs(funcs).Parse(string(raw))
+	if err != nil {
+		return nil, err
+	}
+
+	var points []coverPoint
+	for _, tmpl := range probe.Templates() {
+		if tmpl.Tree == nil {
+			continue
+		}
+		collectCoverPoints(tmpl.Tree.Root, &points)
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].pos < points[j].pos })
+
+	relPath := "./pkg/plugin/" + filename
+	lineLens := lineLengths(raw)
+
+	var out bytes.Buffer
+	last := 0
+	for _, p := range points {
+		delimStart, dashed, ok := findOpenDelim(raw, p.pos)
+		if !ok || delimStart < last {
+			// Can't safely locate (or would overlap an already-placed marker for) this point's own
+			// opening delimiter -- skip instrumenting it rather than risk corrupting output.
+			continue
+		}
+		out.Write(raw[last:delimStart])
+		key := fmt.Sprintf("%s:%d", relPath, p.line)
+		lineLen := 1
+		if p.line < len(lineLens) {
+			lineLen = lineLens[p.line]
+		}
+		coverageRecorder.register(key, lineLen)
+		if dashed {
+			fmt.Fprintf(&out, `{{- %s %s -}}`, templateCoverageFuncName, strconv.Quote(key))
+		} else {
+			fmt.Fprintf(&out, `{{%s %s}}`, templateCoverageFuncName, strconv.Quote(key))
+		}
+		last = delimStart
+	}
+	out.Write(raw[last:])
+	return out.Bytes(), nil
+}
+
+// collectCoverPoints recursively walks list, collecting one coverPoint per leaf "statement" node:
+// action calls, {{template}} calls, and {{break}}/{{continue}}. if/range/with nodes are not
+// themselves instrumented -- only their List/ElseList bodies are recursed into -- since the
+// coverage signal that matters is which branch/iteration ran, which the body nodes already give
+// (including, for free, empty-vs-nonempty range coverage via List vs. ElseList). Comments never
+// appear as nodes at all unless parse.ParseComments was set (it isn't, here), so this walk skips
+// every comment -- including multi-line block comments -- automatically.
+func collectCoverPoints(list *parse.ListNode, out *[]coverPoint) {
+	if list == nil {
+		return
+	}
+	for _, n := range list.Nodes {
+		switch node := n.(type) {
+		case *parse.ActionNode:
+			*out = append(*out, coverPoint{pos: int(node.Pos), line: node.Line})
+		case *parse.TemplateNode:
+			*out = append(*out, coverPoint{pos: int(node.Pos), line: node.Line})
+		case *parse.BreakNode:
+			*out = append(*out, coverPoint{pos: int(node.Pos), line: node.Line})
+		case *parse.ContinueNode:
+			*out = append(*out, coverPoint{pos: int(node.Pos), line: node.Line})
+		case *parse.IfNode:
+			collectCoverPoints(node.List, out)
+			collectCoverPoints(node.ElseList, out)
+		case *parse.RangeNode:
+			collectCoverPoints(node.List, out)
+			collectCoverPoints(node.ElseList, out)
+		case *parse.WithNode:
+			collectCoverPoints(node.List, out)
+			collectCoverPoints(node.ElseList, out)
+		}
+	}
+}
+
+// findOpenDelim locates the true `{{`/`{{-` opening delimiter of the node whose own content starts
+// at contentPos (parse.Node.Position() -- confirmed against the Go 1.26 lexer, this is the byte
+// just past the delimiter and its optional trim-marker-plus-space, not the delimiter itself). The
+// only bytes that can legally appear between a node's true delimiter and its own first content
+// token are whitespace, plus an optional "- " trim marker -- so a bounded backward scan for that
+// exact shape is sufficient; it doesn't need to (and must not try to) reason about anything a real
+// lexer would have to.
+func findOpenDelim(src []byte, contentPos int) (delimStart int, dashed bool, ok bool) {
+	if contentPos > len(src) {
+		return 0, false, false
+	}
+	i := contentPos
+	for i > 0 && isTemplateSpace(src[i-1]) {
+		i--
+	}
+	if i >= 3 && src[i-1] == '-' && string(src[i-3:i-1]) == "{{" {
+		return i - 3, true, true
+	}
+	if i >= 2 && string(src[i-2:i]) == "{{" {
+		return i - 2, false, true
+	}
+	return 0, false, false
+}
+
+func isTemplateSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
+}
+
+// lineLengths returns, 1-indexed (index 0 unused), the byte length of each line in raw excluding
+// its trailing newline.
+func lineLengths(raw []byte) []int {
+	lines := bytes.Split(raw, []byte("\n"))
+	lens := make([]int, len(lines)+1)
+	for i, l := range lines {
+		lens[i+1] = len(l)
+	}
+	return lens
+}

--- a/pkg/plugin/template_coverage_test.go
+++ b/pkg/plugin/template_coverage_test.go
@@ -21,7 +21,14 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	if err := FlushTemplateCoverageProfile(); err != nil {
+		// A flush failure (e.g. a relative KUBECTL_STATUS_TEMPLATE_COVERAGE path -- see that
+		// function's doc) must fail the run, not just log: a silent failure here was exactly how
+		// this surfaced originally, as a much harder to diagnose failure two steps later in
+		// `make template-cover-html`, well after `go test` itself had already reported success.
 		fmt.Fprintln(os.Stderr, "template coverage: failed to write profile:", err)
+		if code == 0 {
+			code = 1
+		}
 	}
 	os.Exit(code)
 }

--- a/pkg/plugin/template_coverage_test.go
+++ b/pkg/plugin/template_coverage_test.go
@@ -1,0 +1,133 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"text/template"
+
+	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	"github.com/bergerx/kubectl-status/pkg/input"
+)
+
+// TestMain flushes this process's accumulated template coverage (see template_coverage.go) once
+// after every test in the package has run. pkg/plugin's test binary is a separate OS process from
+// cmd's -- see FlushTemplateCoverageProfile's doc for why each needs its own TestMain rather than
+// sharing one flush call.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if err := FlushTemplateCoverageProfile(); err != nil {
+		fmt.Fprintln(os.Stderr, "template coverage: failed to write profile:", err)
+	}
+	os.Exit(code)
+}
+
+// renderKindWithTree renders kind against obj using an explicit embedded tree, bypassing
+// getTemplate/buildTemplateSet's own coverage-enabled gate -- letting
+// TestTemplateCoverageInstrumentationIsOutputTransparent compare a plain and an instrumented tree
+// built from identical source in the same test process, regardless of whether
+// KUBECTL_STATUS_TEMPLATE_COVERAGE happens to be set for this test run.
+func renderKindWithTree(t *testing.T, cfg *RenderConfig, embedded *template.Template, kind string, obj map[string]interface{}) string {
+	t.Helper()
+	user, err := embedded.Clone()
+	if err != nil {
+		t.Fatalf("cloning tree: %v", err)
+	}
+	kindNames, err := kindTemplateNames(embedded)
+	if err != nil {
+		t.Fatalf("kindTemplateNames: %v", err)
+	}
+	ts := &templateSet{embedded: embedded, user: user, kindNames: kindNames, userDefinedNames: map[string]bool{}}
+
+	f := cmdtesting.NewTestFactory().WithNamespace("test")
+	f.Client = &fake.RESTClient{}
+	f.UnstructuredClient = f.Client
+	t.Cleanup(func() { f.Cleanup() })
+	repo, _ := input.NewResourceRepo(f, cfg.Viper)
+	e, err := newRenderEngine(genericiooptions.NewTestIOStreamsDiscard(), cfg)
+	if err != nil {
+		t.Fatalf("newRenderEngine: %v", err)
+	}
+	e.templateSet = ts
+	r := newRenderableObject(obj, e, repo)
+	got, err := r.renderTemplate(kind, r)
+	if err != nil {
+		t.Fatalf("renderTemplate(%s): %v", kind, err)
+	}
+	return got
+}
+
+// TestTemplateCoverageInstrumentationIsOutputTransparent guards the riskiest part of
+// template_coverage.go: that splicing a coverage marker before every coverable node's own opening
+// delimiter never changes rendered output. It renders a representative set of Kinds through both a
+// plain and an instrumented tree parsed from the same embedded source and asserts byte-identical
+// output, specifically including the two patterns a design review surfaced as capable of breaking
+// a naive (fixed-delimiter) marker: a non-dashed-delimiter branch with meaningful literal
+// whitespace (Service.tmpl's ExternalName case) and a multi-line action (Pod.tmpl's
+// imagePullSecrets handling, structurally similar to Node.tmpl's multi-line dict(...) call).
+func TestTemplateCoverageInstrumentationIsOutputTransparent(t *testing.T) {
+	cfg := NewRenderConfig(viper.New())
+	funcs := templateFuncs(cfg)
+
+	plain, err := template.New("templates").Funcs(funcs).ParseFS(templatesFS, "templates/*.tmpl", "templates/*/*.tmpl")
+	if err != nil {
+		t.Fatalf("plain parse: %v", err)
+	}
+	instrumented, err := buildInstrumentedEmbedded(funcs)
+	if err != nil {
+		t.Fatalf("instrumented parse: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		kind string
+		obj  map[string]interface{}
+	}{
+		{
+			name: "ExternalName Service (non-dashed delimiter + literal whitespace)",
+			kind: "Service",
+			obj: map[string]interface{}{
+				"kind":     "Service",
+				"metadata": map[string]interface{}{"name": "svc", "namespace": "test"},
+				"spec":     map[string]interface{}{"type": "ExternalName", "externalName": "example.com"},
+			},
+		},
+		{
+			name: "ClusterIP Service",
+			kind: "Service",
+			obj: map[string]interface{}{
+				"kind":     "Service",
+				"metadata": map[string]interface{}{"name": "svc2", "namespace": "test"},
+				"spec":     map[string]interface{}{"type": "ClusterIP", "clusterIP": "10.0.0.1"},
+			},
+		},
+		{
+			name: "Pod with imagePullSecrets (multi-line action)",
+			kind: "Pod",
+			obj: map[string]interface{}{
+				"kind":     "Pod",
+				"metadata": map[string]interface{}{"name": "p", "namespace": "test"},
+				"spec": map[string]interface{}{
+					"containers":       []interface{}{map[string]interface{}{"name": "c", "image": "busybox"}},
+					"imagePullSecrets": []interface{}{map[string]interface{}{"name": "regcred"}},
+				},
+				"status": map[string]interface{}{"phase": "Running"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := renderKindWithTree(t, cfg, plain, tc.kind, tc.obj)
+			got := renderKindWithTree(t, cfg, instrumented, tc.kind, tc.obj)
+			if got != want {
+				t.Errorf("instrumentation changed rendered output for %s\n--- plain (%d bytes) ---\n%q\n--- instrumented (%d bytes) ---\n%q",
+					tc.kind, len(want), want, len(got), got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `go test -coverprofile` only instruments compiled `.go` statements, so it has zero visibility into `pkg/plugin/templates/*.tmpl` content executed at runtime by `text/template`. This adds opt-in line-level instrumentation, gated on `KUBECTL_STATUS_TEMPLATE_COVERAGE` (no-op when unset), that walks the real `text/template/parse` AST for each embedded template and splices a no-op marker before every coverable node — mirroring the marker's own opening delimiter to the target's (`{{-`/plain), so it's provably transparent to this codebase's `{{-`/`-}}` whitespace-trimming discipline.
- Writes a standard `go tool cover` `mode: count` profile, so `.tmpl` files render in `go tool cover -html` and in Codecov exactly like `.go` files (both confirmed against the Go 1.26 stdlib and against a real Codecov upload path).
- CI now sets the env var on the *existing* `make test`/`make test-e2e` steps (confirmed output-transparent: both the `pkg/plugin` and `cmd` suites pass byte-identical with instrumentation forced on) rather than adding a separate, duplicate test run, then uploads the merged `template-cover.out` to Codecov under its own `templates` flag.
- Rebased onto master to pick up #857 (which landed while this was in progress and added its own `unittests`/`e2e` Codecov flags for Go-code coverage) — both `ci-test.yml` and `Makefile` now carry both sets of changes; the two features are independent (Go-code coverage vs. `.tmpl` line coverage) and don't overlap in what they instrument.
- Adds `codecov.yml` (`notify.after_n_builds: 3`), addressing [#858's followup comment](https://github.com/bergerx/kubectl-status/issues/858#issuecomment-5322041666): without it, Codecov posts the PR comment/status after the *first* of the now-three per-commit uploads (`unittests`, `e2e`, `templates`) and the rest show up later as silent edits. The comment suggested `2` before this PR's `templates` flag existed; bumped to `3` so all three are waited on.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `make staticcheck` all clean
- [x] All 77 `.tmpl` files instrument and parse successfully
- [x] `pkg/plugin/template_coverage_test.go`'s `TestTemplateCoverageInstrumentationIsOutputTransparent` passes, including regression cases for a non-dashed-delimiter branch with meaningful literal whitespace (`Service.tmpl`'s `ExternalName` case) and a multi-line action (Pod's `imagePullSecrets` handling)
- [x] Full `pkg/plugin` and `cmd` (non-cluster) unit suites pass byte-identical with `KUBECTL_STATUS_TEMPLATE_COVERAGE` forced on for the entire run
- [x] `go tool cover -html` renders the resulting profile with real coverage gradients; the unit+e2e profile merge (concatenated `mode: count` blocks) parses and renders correctly
- [x] `codecov.yml` parses as valid YAML
- [x] Rebase onto master resolved with no leftover conflict markers; `go build`/`go vet`/`make staticcheck` re-verified on the merged state
- [ ] Real `TestE2E*` suite against a live cluster (not run in this environment — CI or `make e2e-minikube-up` will exercise it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)