### PR TITLE
Enable Codecov Test Analytics via gotestsum JUnit output

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,6 +43,20 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload unit test results to Codecov
+        # if: always() -- Test Analytics' main value (flaky-test detection, failure history)
+        # comes from seeing failing runs too, not just green ones.
+        # codecov/test-results-action is deprecated in favor of report_type: test_results on
+        # this same action (https://github.com/codecov/test-results-action), so this reuses the
+        # codecov-action already pinned above rather than pinning a second, sunsetting action.
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: unit-junit.xml
+          flags: unittests
+          report_type: test_results
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Start minikube
         uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
@@ -85,6 +99,17 @@ jobs:
         with:
           files: cover-e2e.out
           flags: e2e
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload e2e test results to Codecov
+        # if: always() -- same rationale as the unit test results step above: a retry attempt
+        # that ultimately failed should still surface in Test Analytics.
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: e2e-junit.xml
+          flags: e2e
+          report_type: test_results
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Render template coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ cover-e2e.out
 cover.html
 coverage.txt
 
+# gotestsum --junitfile output (see `test`/`test-e2e` in Makefile), fed to Codecov Test Analytics
+unit-junit.xml
+e2e-junit.xml
+
 # Output of `make template-cover-html` (see Makefile) -- .tmpl line coverage
 unit-template-cover.out
 e2e-template-cover.out

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,10 @@ test: vet staticcheck
 	# (not via pkg/plugin's own tests) would otherwise show as uncovered.
 	# -covermode=atomic: at least one test uses t.Parallel(), so counter writes need to be
 	# race-safe.
-	go test -coverprofile=cover.out -coverpkg=./... -covermode=atomic ./...
+	# gotestsum wraps go test the same way test-e2e below already does (see its comment for
+	# --format rationale); --junitfile is the only reason it's used here, feeding Codecov Test
+	# Analytics (per-test pass/fail/flake history, not coverage) in ci-test.yml.
+	go run $(GOTESTSUM_MODULE) --junitfile unit-junit.xml -- -coverprofile=cover.out -coverpkg=./... -covermode=atomic ./...
 
 # template-cover-html renders line-level coverage for pkg/plugin/templates/*.tmpl files -- Go's own
 # `go test -coverprofile` (above) only instruments compiled .go statements, it has no visibility
@@ -238,6 +241,9 @@ test-e2e: vet staticcheck install-e2e-deps
 	# per package (default --format=pkgname) -- the ~60 fixture/scenario subtests in
 	# cmd/e2e_*_test.go otherwise flood the terminal with "=== RUN"/"--- PASS" and t.Logf
 	# noise on every green run.
+	# --junitfile: per-test pass/fail/duration for Codecov Test Analytics, uploaded separately
+	# from coverage in ci-test.yml (unlike coverage, this has no templates-flag equivalent --
+	# see the `test` target's own --junitfile for why).
 	# -parallel=4: bounds how many TestE2EParallel subtests hit the cluster at once. Go's
 	# default (GOMAXPROCS, i.e. host core count) can far exceed what the e2e-minikube-up VM
 	# above is sized for, causing widespread `kubectl wait` timeouts instead of a speedup.
@@ -255,7 +261,7 @@ test-e2e: vet staticcheck install-e2e-deps
 	# subtests concurrently against the same instrumented code, so counter writes need to be
 	# race-safe.
 	@mkdir -p $(E2E_HOME)
-	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
+	RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 else
 test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# The cluster (profile: $(E2E_PROFILE)) is shared across every worktree/branch/session on
@@ -267,7 +273,7 @@ test-e2e: vet staticcheck e2e-minikube-up install-e2e-deps
 	# branch above.
 	# See the gotestsum note, the -parallel=4 note above the other branch's go test invocation,
 	# and the coverage flags note above the other branch's invocation.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_MINIKUBE_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 endif
 
 # Passed through to test-e2e-quick's own invocation below, not test-e2e's: UPDATE_FIXTURES=true


### PR DESCRIPTION
## Summary
- Unit tests now run via gotestsum (matching `test-e2e`) so both `make test` and `make test-e2e` emit `--junitfile` output (`unit-junit.xml`, `e2e-junit.xml`).
- ci-test.yml uploads each JUnit file to Codecov with `report_type: test_results`, reusing the already-pinned `codecov/codecov-action` rather than the now-deprecated `codecov/test-results-action`.
- Enables [Codecov Test Analytics](https://docs.codecov.com/docs/test-analytics) (per-test pass/fail/flake history) for the `unittests` and `e2e` flags. `templates` has no test-results equivalent since it isn't a separate test run — see Makefile:108-124.

## Test plan
- [x] `make test` locally confirmed gotestsum runs and produces a valid `unit-junit.xml` (1164 tests, well-formed JUnit XML)
- [ ] CI run on this PR uploads `unit-junit.xml`/`e2e-junit.xml` to Codecov without error
- [ ] Codecov's Test Analytics tab shows results once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)