### PR TITLE
Two clusters, and dissolve the serial e2e bucket

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -12,6 +12,17 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # #867 split the e2e suite across two kind clusters (see CONTRIBUTING.md's "Running e2e
+      # Tests Locally"); with two clusters there's no single "current context" for `make
+      # test-e2e` to fall back to under ASSUME_CLUSTER_IS_CONFIGURED=true, so these two are
+      # required in that mode. Named kstat-e2e*, not kstat-e2e-shared* like the local dev
+      # clusters (Makefile's E2E_POOL_CLUSTER/E2E_CLUSTERWIDE_CLUSTER default), since a CI run's
+      # clusters live only for that run and aren't shared across workers the way the local ones
+      # are shared across worktrees/sessions. Set at job level so both the "Create kind cluster"
+      # steps below and the `make test-e2e` step read the identical names.
+      E2E_POOL_CONTEXT: kind-kstat-e2e
+      E2E_CLUSTERWIDE_CONTEXT: kind-kstat-e2e-clusterwide
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,9 +80,10 @@ jobs:
           source hack/versions.env
           echo "version=${KIND_VERSION}" >> "$GITHUB_OUTPUT"
           echo "node_image=${KIND_NODE_IMAGE}" >> "$GITHUB_OUTPUT"
-      - name: Create kind cluster
+      - name: Create kind cluster (pool)
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          # Must match E2E_POOL_CONTEXT above (kind names the context "kind-"+cluster_name).
           cluster_name: kstat-e2e
           # version/node_image set explicitly rather than taking the action's defaults: those
           # currently give kind v0.31.0 and a k8s 1.35.x node image -- older than what
@@ -92,6 +104,22 @@ jobs:
           # are not installed here: kind has no addons, so `make install-e2e-deps` (run as a
           # dependency of `make test-e2e` below) owns both, which also keeps CI and local runs
           # installing them the same way.
+      - name: Create kind cluster (cluster-wide)
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          # #867's second cluster -- see the job-level env: comment above and
+          # CONTRIBUTING.md's "Running e2e Tests Locally" for why TestE2EClusterWide/
+          # TestE2EAgainstVanillaCluster need a cluster of their own. Must match
+          # E2E_CLUSTERWIDE_CONTEXT above. Same version/node_image/config/wait as the pool
+          # cluster -- see that step's comments; kind merges this cluster's context into the
+          # same runner-default kubeconfig alongside the pool's rather than overwriting it, the
+          # same way local shared.kubeconfig holds both (see the Makefile's "E2E cluster
+          # identity" section).
+          cluster_name: kstat-e2e-clusterwide
+          version: ${{ steps.kind-pins.outputs.version }}
+          node_image: ${{ steps.kind-pins.outputs.node_image }}
+          config: hack/kind-cluster.yaml
+          wait: 300s
       - name: Run e2e tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,84 +282,108 @@ Test artifacts in `tests/artifacts/` verify template output changes. When modify
 
 ### Running e2e Tests Locally
 
-`make test-e2e` runs the `TestE2E*` suite against a real cluster. That suite has three top-level
-entry points — `TestE2EParallel` (`cmd/main_test.go`), which calls one topical `runXSubtests`
-function per `cmd/e2e_*_test.go` file, plus `TestE2EDynamicManifests` (`cmd/e2e_dynamic_test.go`)
-and `TestE2EAgainstVanillaCluster` (`cmd/e2e_vanilla_test.go`) — sharing the harness in
-`cmd/e2e_helpers_test.go` (`cmdTest`, `applyManifest`/`waitFor`, the `ensureX` dependency
-installers). `cmd/local_test.go` holds the
-tests that need no cluster and so run under plain `make test` instead. `make test-e2e` manages one
-**shared** [kind](https://kind.sigs.k8s.io/) cluster (`kstat-e2e-shared`), reused across every
-worktree, branch, and session on your machine — not one per branch/session. Run
-`make print-e2e-cluster` to see the cluster name and kubeconfig path
-(`~/.kstat-e2e/shared.kubeconfig`) it uses. Its shape is `hack/kind-cluster.yaml` (single node) and
-its Kubernetes version is the digest-pinned `KIND_NODE_IMAGE` in `hack/versions.env` — the same two
+`make test-e2e` runs the `TestE2E*` suite against real clusters. That suite has three top-level
+entry points, split across **two** [kind](https://kind.sigs.k8s.io/) clusters (#867) because two of
+them interfere with each other through cluster-scoped state (node count, the metrics-server
+`APIService`) that no namespace can isolate:
+
+- `TestE2EParallel` (`cmd/main_test.go`) — the pool. Calls one topical `runXSubtests` function per
+  `cmd/e2e_*_test.go` file; this is where a new subtest goes by default. Owns the
+  `kstat-e2e-shared` cluster and every heavy dependency (cert-manager, Flux, Crossplane, Kyverno,
+  Gatekeeper, Gateway API, Istio, Cilium/Calico).
+- `TestE2EClusterWide` (`cmd/e2e_clusterwide_test.go`) and `TestE2EAgainstVanillaCluster`
+  (`cmd/e2e_vanilla_test.go`) — share the `kstat-e2e-shared-clusterwide` cluster, kept otherwise
+  idle (just `ensureVPA`/`ensureKarpenterCRDs`) so the two clusters cost little more than one. See
+  `cmd/e2e_clusterwide_test.go`'s doc comment for exactly which subtests belong here instead of the
+  pool.
+
+All three share the harness in `cmd/e2e_helpers_test.go` (`cmdTest`, `applyManifest`/`waitFor`, the
+`ensureX` dependency installers, and the `e2eTarget`/`e2eClusterRole` plumbing that tells every
+`kubectl`/`helm`/rendered-command shell-out which of the two clusters to hit via `--context`).
+`cmd/local_test.go` holds the tests that need no cluster and so run under plain `make test` instead.
+
+Both clusters are **shared**, reused across every worktree, branch, and session on your machine —
+not one pair per branch/session. Run `make print-e2e-cluster` to see both cluster names, their kube
+contexts, and the kubeconfig path (`~/.kstat-e2e/shared.kubeconfig`) they live in (kind merges both
+into one file). Their shape is `hack/kind-cluster.yaml` (single node, same file for both) and their
+Kubernetes version is the digest-pinned `KIND_NODE_IMAGE` in `hack/versions.env` — the same two
 values CI passes to `helm/kind-action`, so a local run and CI render against the identical
-Kubernetes build. `install-e2e-deps`
-runs against that same cluster right after it's created, so deps always land on the cluster the
-tests actually use (see [Cluster Dependencies](#cluster-dependencies) below for what it does and
-doesn't install). The cluster is left running after the tests finish, for fast reruns from any
-worktree/session; delete it explicitly with `make e2e-cluster-down` when you're sure no other
-worktree/session still needs it — this tears it down for everyone sharing it, not just you.
+Kubernetes build. `install-e2e-deps` runs against both clusters right after they're created (see
+[Cluster Dependencies](#cluster-dependencies) below for what it does and doesn't install). Both are
+left running after the tests finish, for fast reruns from any worktree/session; delete them
+explicitly with `make e2e-cluster-down` when you're sure no other worktree/session still needs
+them — this tears them down for everyone sharing them, not just you.
 
 `kind` (and Docker) must be on your PATH for the local targets; CI installs it via
-`helm/kind-action`. `make e2e-cluster-up` reuses a running shared cluster rather than recreating
+`helm/kind-action`. `make e2e-cluster-up` reuses each running shared cluster rather than recreating
 it — but since a kind node is a container, a cluster can survive a host reboot as *stopped*
 containers and still be listed by `kind get clusters` while answering nothing. The target checks
-both, and recreates a listed-but-unresponsive cluster rather than handing it to the suite.
+both clusters for both conditions, and recreates a listed-but-unresponsive one rather than handing
+it to the suite.
 
-Because the cluster is shared and the e2e suite uses fixed (not generated) scratch namespace
-names, two `test-e2e`/`test-e2e-quick` runs against it at the same time would collide with
-"already exists" errors. Both targets guard against that with `flock` on a host-global lockfile:
-a second invocation (from another worktree, another terminal, a background Claude Code task)
-simply waits for the first to finish rather than racing it or getting its own cluster. This trades
-some concurrency for a much smaller footprint — one cluster total instead of one per
+Because the clusters are shared and the e2e suite uses fixed (not generated) scratch namespace
+names, two `test-e2e`/`test-e2e-quick` runs against them at the same time would collide with
+"already exists" errors. Both targets guard against that with `flock` on a host-global lockfile —
+one lock for the pair of clusters, not one per cluster, since a run needs both for its whole
+duration: a second invocation (from another worktree, another terminal, a background Claude Code
+task) simply waits for the first to finish rather than racing it or getting its own clusters. This
+trades some concurrency for a much smaller footprint — two clusters total instead of two per
 worktree/branch/session, which is what actually hogs the host if left unchecked. `flock` (from
 `util-linux`) is required; it's standard on Linux but not present on macOS by default.
 
 If a run is killed ungracefully (Ctrl+C, OOM) mid-subtest, its cleanup won't run and it can leave
 a stale namespace behind that collides with the next run's fixed name. Recover with
-`kubectl --kubeconfig ~/.kstat-e2e/shared.kubeconfig delete ns <name>`, or nuke and recreate the
-whole cluster with `make e2e-cluster-down e2e-cluster-up`.
+`kubectl --kubeconfig ~/.kstat-e2e/shared.kubeconfig --context <context> delete ns <name>` (see
+`make print-e2e-cluster` for the context names), or nuke and recreate both clusters with
+`make e2e-cluster-down e2e-cluster-up`.
 
-CI instead sets `ASSUME_CLUSTER_IS_CONFIGURED=true`, which makes `make test-e2e` skip all of the
-above and use whatever cluster your current kubeconfig context already points at (that's what
-`helm/kind-action` in `ci-test.yml` provisions) — set the same var locally if you'd rather
-manage the cluster yourself.
+CI instead sets `ASSUME_CLUSTER_IS_CONFIGURED=true` plus `E2E_POOL_CONTEXT`/
+`E2E_CLUSTERWIDE_CONTEXT`, which makes `make test-e2e` skip all of the above and use whichever kube
+contexts those two vars name (that's what `helm/kind-action` in `ci-test.yml` provisions, into the
+runner's default kubeconfig) — set the same vars locally if you'd rather manage the clusters
+yourself. Both vars are required in this mode: with two clusters there's no single "current
+context" to fall back to, so the suite fails loudly instead of silently running both entry points
+against the same cluster.
 
-Note: `TestE2E*` functions invoked directly via `go test -run TestE2E...` (bypassing the
-Makefile) fall back to using the bare test function name as the cluster name if `E2E_CLUSTER`
-isn't set in the environment, which starts (and leaks) a one-off cluster instead of using the
-shared one — export `E2E_CLUSTER` yourself (e.g. from `make print-e2e-cluster`) to land on the
-shared cluster too.
+Note: `TestE2E*` functions invoked directly via `go test -run TestE2E...` (bypassing the Makefile)
+fall back to using the bare test function name as the cluster name for whichever role they own if
+`E2E_POOL_CLUSTER`/`E2E_CLUSTERWIDE_CLUSTER` isn't set in the environment, which starts (and leaks)
+a one-off cluster instead of using the shared one — export both yourself (`make print-e2e-cluster`
+prints the shared names) to land on the shared clusters too.
 
 #### Cluster Dependencies
 
-metrics-server is the only dependency installed upfront, by the `install-e2e-deps` target — see
-the comment there for why it has to be an invariant of the whole run rather than one group's
-concern. That target also recreates kind's default `standard` StorageClass with
-`volumeBindingMode: Immediate`: kind's binds `WaitForFirstConsumer`, and several subtests create a
-PVC with no consuming Pod and then wait for it to Bind. `volumeBindingMode` is immutable, so it's a
-delete-and-recreate (`kubectl replace --force`) of the live object with only that field rewritten,
-not a hand-written class. Everything else (cert-manager, Gateway API CRDs, Cilium/Calico CRDs, VolumeSnapshot CRDs,
-Karpenter CRDs, Istio CRDs, VPA, Crossplane, Flux) is installed on demand by the test that needs it,
-so a cluster only ever grows the dependencies the suite actually exercises. No manual setup either
-way.
+metrics-server is the only dependency installed upfront, on **both** clusters, by the
+`install-e2e-deps` target — see the comment there for why it has to be an invariant of the whole
+run rather than one group's concern (the cluster-wide cluster needs it just as much: its VPA
+subtest needs a recommender fed by real samples, and its metrics-server-`APIService` subtest needs
+an `APIService` there to delete in the first place). That target also recreates each cluster's
+default `standard` StorageClass with `volumeBindingMode: Immediate`: kind's binds
+`WaitForFirstConsumer`, and several subtests create a PVC with no consuming Pod and then wait for it
+to Bind. `volumeBindingMode` is immutable, so it's a delete-and-recreate (`kubectl replace --force`)
+of the live object with only that field rewritten, not a hand-written class. Everything else
+(cert-manager, Gateway API CRDs, Cilium/Calico CRDs, VolumeSnapshot CRDs, Karpenter CRDs, Istio
+CRDs, VPA, Crossplane, Flux) is installed on demand by the test that needs it, via the `ensureX(t)`
+functions below, which target their own subtest's cluster — so all of those land on the pool's
+cluster, and only the cluster-wide bucket's own two (`ensureVPA`, `ensureKarpenterCRDs`) go to the
+other one. That asymmetry is what makes the second cluster nearly free instead of a 2x install tax;
+keep it that way when adding a new dependency. A cluster only ever grows the dependencies the suite
+actually exercises on it. No manual setup either way.
 
 Note that "on demand" tracks the *entry point*, not your `-run` pattern. The `runXSubtests`
 functions are plain calls, and `-run` filters at `t.Run` below them, so any
 `RUN='TestE2EParallel/...'` still runs every group's install regardless of which subtests survive
 the filter — cert-manager, Gateway API CRDs and Cilium/Calico CRDs go in even for a pattern that
 matches nothing. On a warm cluster that's a few seconds and not worth restructuring for; on a fresh
-one it's the bulk of a narrow run's wall clock. `TestE2EDynamicManifests` doesn't have this
-property: its `ensureX` calls sit inside the subtest bodies, so filtering does skip them.
-`runFluxSubtests` is the one pool group that does the same, for the same reason — `ensureFlux` is
-the suite's heaviest install, so it sits inside the `t.Run` rather than at the top of the group,
-where it would go in on any `TestE2EParallel` run whose pattern doesn't even reach that subtest.
+one it's the bulk of a narrow run's wall clock. `TestE2EClusterWide` doesn't have this property: its
+`ensureX` calls sit inside the subtest bodies, so filtering does skip them. `runFluxSubtests` is the
+one pool group that does the same, for the same reason — `ensureFlux` is the suite's heaviest
+install, so it sits inside the `t.Run` rather than at the top of the group, where it would go in on
+any `TestE2EParallel` run whose pattern doesn't even reach that subtest.
 
 The installers are the `ensureX(t)` functions in `cmd/e2e_helpers_test.go`; keep new ones there
 rather than inline in a test file. A topical group in `TestE2EParallel` calls the ones it needs at
-the top of its `runXSubtests` function; under `TestE2EDynamicManifests`, where a dependency usually
+the top of its `runXSubtests` function; under `TestE2EClusterWide`, where a dependency usually
 serves a single scenario, the call goes at the top of that subtest instead — including when the
 scenario lives in its own file behind a `runXSubtests` function. Most install CRDs only —
 kubectl-status reads and matches these objects client-side, so no real controller is needed;
@@ -415,28 +439,32 @@ to query either way), which makes `KubeGetFirst` a no-op — they can't exercise
 related object" or `--deep` include branches, so the live e2e suite is the only place that covers
 them.
 
-**Put new subtests in `TestE2EParallel`'s pool by default, running with `t.Parallel()`.** Don't
-opt a new subtest out of the pool just because it feels risky or touches cluster state — write it
-parallel and dedicated (own namespace/generated names, see [Parallel-Safe e2e
-Subtests](#parallel-safe-e2e-subtests) below) unless it actually trips one of the exceptions below.
-`TestE2EDynamicManifests` (or a serial subtest) is the exception, and a subtest only earns a place
-there by tripping one of the two criteria in `TestE2EParallel`'s doc comment (`cmd/main_test.go`) —
-with the reason written on the subtest, so the next person inherits a rule rather than a precedent.
-The qualifying reasons are all about what a subtest does *to* its neighbours: it perturbs
-cluster-wide state they read (deleting the metrics-server `APIService`), it starves a shared
-dependency (the VPA subtest pegs a full CPU and takes metrics-server's readiness probe down with it
-on a single-node cluster), or it can't be given a namespace/generated name of its own.
+**Put new subtests in `TestE2EParallel`'s pool by default, running with `t.Parallel()`.** Every
+subtest in the suite runs with `t.Parallel()` now (#867) — there's no serial bucket left to opt
+into, so the question is never "can I justify skipping the pool," it's "does anything else on *my*
+cluster see what I do, or do I see what it does?" (see `cmd/e2e_clusterwide_test.go`'s doc comment).
+Don't opt a new subtest out of the pool just because it feels risky or touches cluster state — write
+it parallel and dedicated (own namespace/generated names, see [Parallel-Safe e2e
+Subtests](#parallel-safe-e2e-subtests) below) unless it actually trips one of the interference
+reasons below, in which case it belongs in `TestE2EClusterWide` instead, with the reason written on
+the subtest so the next person inherits a rule rather than a precedent. The qualifying reasons are
+all about what a subtest does *to*, or has done *to it by*, its neighbours on the same cluster: it
+perturbs cluster-wide state they read (deleting the metrics-server `APIService`), it starves a
+shared dependency (the VPA subtest pegs a full CPU and takes metrics-server's readiness probe down
+with it on a single-node cluster), or it pins a fact about the cluster (kube-scheduler's exact
+`0/N nodes are available` message) that another subtest's fixture could move.
 
-Because the shared cluster is reused by every subtest in the pool at once, be especially careful
-with anything cluster-scoped: mutating or deleting a cluster-level resource (a Node, a CRD, a
+Because each cluster is reused by every subtest that runs on it at once, be especially careful with
+anything cluster-scoped: mutating or deleting a cluster-level resource (a Node, a CRD, a
 ClusterRole, the metrics-server `APIService`, a webhook config, ...), or relying on a *fixed*
 cluster-scoped name another subtest could also use, can silently change another subtest's rendered
 output rather than fail loudly with a name collision. Prefer generated names
 (`GenerateName`/`metav1.GenerateName`, see `createBadNode`) for any cluster-scoped object a subtest
-creates, and never mutate a cluster-scoped resource another subtest might read unless that subtest
-is one of the documented non-parallel exceptions above.
+creates, and never mutate a cluster-scoped resource another subtest on the same cluster might read
+unless that subtest is one of the documented interference cases in `TestE2EClusterWide`.
 
-Several things look disqualifying but aren't, and shouldn't be used to justify a serial subtest:
+Several things look disqualifying but aren't, and shouldn't be used to justify moving a subtest to
+`TestE2EClusterWide`:
 
 - **Needing a live-cluster query.** Most of the pool needs one; that's the normal case, not an
   exception.
@@ -448,13 +476,13 @@ Several things look disqualifying but aren't, and shouldn't be used to justify a
   load. Relative timestamps aren't a hazard either: `ApplyTestHack` freezes `DurationRound`, so
   `created 1m ago` is a constant, not elapsed time.
 - **How the objects come into being** (built in Go, applied from static YAML, or patched in place).
-  This distinguishes nothing, whatever the `DynamicManifests` name suggests.
+  This distinguishes nothing.
 
 See #784: the Flux scenario was a standalone top-level test, then a serial subtest, before anyone
 checked it against the criteria — which it met, so it's a pool group now. Don't add a fourth
 top-level `TestE2E*` function either; a scenario long enough to crowd its host file can live in its
 own `cmd/e2e_*_test.go` behind a `runXSubtests` function, the way `runFluxSubtests` does. The file a
-subtest sits in and the entry point it runs under are separate choices.
+subtest sits in and the entry point (and therefore cluster) it runs under are separate choices.
 
 Assert on stdout with a whole-output `.regex` fixture (`stdoutRegexPath`, or
 `assertStdoutMatchesRegexFixture` when the subtest also needs to assert something the fixture can't

--- a/Makefile
+++ b/Makefile
@@ -136,31 +136,55 @@ template-cover-html:
 #--------------------------
 # E2E cluster identity
 #--------------------------
-# All local test-e2e/test-e2e-quick runs share one kind cluster, across every
-# worktree/branch/session on this machine -- a cluster per branch/session (the
-# previous scheme) meant every worktree you'd touched left its own cluster
-# running, which piles up fast and starves the host. Trade-off: since the cluster
-# is shared, concurrent runs (two worktrees, two Claude Code sessions, a background
-# task) must be serialized -- see the `flock $(E2E_LOCKFILE)` in test-e2e/
-# test-e2e-quick below, which makes a second invocation wait for the first instead
-# of racing it (the e2e suite uses fixed, not generated, scratch namespace names,
-# so two concurrent runs would otherwise collide with "already exists" errors).
+# All local test-e2e/test-e2e-quick runs share the same *two* kind clusters, across every
+# worktree/branch/session on this machine -- a cluster per branch/session (the previous scheme)
+# meant every worktree you'd touched left its own cluster running, which piles up fast and starves
+# the host. Trade-off: since the clusters are shared, concurrent runs (two worktrees, two Claude
+# Code sessions, a background task) must be serialized -- see the `flock $(E2E_LOCKFILE)` in
+# test-e2e/test-e2e-quick below, which makes a second invocation wait for the first instead of
+# racing it (the e2e suite uses fixed, not generated, scratch namespace names, so two concurrent
+# runs would otherwise collide with "already exists" errors).
+# One lock for the pair, not one per cluster: a run needs *both* clusters for its whole duration,
+# so per-cluster locks would buy no extra concurrency (nothing can proceed holding just one) while
+# adding a way for two runs to deadlock by taking them in different orders. The lock covers a run,
+# not a cluster.
 # E2E_HOME/E2E_KUBECONFIG/E2E_LOCKFILE are deliberately host-global ($(HOME)-based),
 # not $(CURDIR)-relative -- each worktree has a different CURDIR, and sharing
 # requires them to all agree on the same paths regardless of which one invokes make.
-# E2E_CLUSTER is the cluster's name (kind --name) and is the only per-cluster
-# identity that lives here rather than in hack/kind-cluster.yaml, so #867 can add a
-# second cluster off the same config file by varying this alone.
-E2E_CLUSTER := kstat-e2e-shared
+# Both clusters live in the one shared kubeconfig (kind merges into whatever --kubeconfig it's
+# given), so what selects between them is the context, not the file -- which is also true in CI,
+# where helm/kind-action writes both into the runner's default kubeconfig.
+#
+# Why two clusters (#867): the pool (TestE2EParallel) and the cluster-wide bucket
+# (TestE2EClusterWide + TestE2EAgainstVanillaCluster) interfere through cluster-scoped state --
+# node count, the metrics-server APIService -- not through anything a namespace can isolate. One
+# cluster each removes the interference instead of scheduling around it, and costs little because
+# every heavy dependency (cert-manager, Flux, Crossplane, Kyverno, Gatekeeper, Gateway API, Istio,
+# Cilium/Calico) is installed on demand by the pool's own subtests and never lands on the
+# cluster-wide one. See cmd/e2e_clusterwide_test.go.
+#
+# ?= throughout: ci-test.yml sets these as job-level environment variables (its clusters are named
+# kstat-e2e*, not kstat-e2e-shared*) and passes them to both helm/kind-action and `make test-e2e`
+# from one place, so the names aren't duplicated between this file and the workflow.
+E2E_POOL_CLUSTER ?= kstat-e2e-shared
+E2E_CLUSTERWIDE_CLUSTER ?= kstat-e2e-shared-clusterwide
+E2E_CLUSTERS := $(E2E_POOL_CLUSTER) $(E2E_CLUSTERWIDE_CLUSTER)
+# kind names the context it writes after the cluster, prefixed with "kind-". The suite is handed
+# context names rather than cluster names because a context is all it can act on: --context is what
+# every kubectl/helm shell-out and every rendered kubectl-status command below takes.
+E2E_POOL_CONTEXT ?= kind-$(E2E_POOL_CLUSTER)
+E2E_CLUSTERWIDE_CONTEXT ?= kind-$(E2E_CLUSTERWIDE_CLUSTER)
+E2E_CONTEXT_ENV := E2E_POOL_CONTEXT=$(E2E_POOL_CONTEXT) E2E_CLUSTERWIDE_CONTEXT=$(E2E_CLUSTERWIDE_CONTEXT)
 E2E_HOME := $(HOME)/.kstat-e2e
 E2E_KUBECONFIG := $(E2E_HOME)/shared.kubeconfig
 E2E_LOCKFILE := $(E2E_HOME)/shared.lock
 GOTESTSUM_MODULE := gotest.tools/gotestsum@v1.13.0
 
-# CI (and anyone else who already has a suitable cluster configured) sets
+# CI (and anyone else who already has suitable clusters configured) sets
 # ASSUME_CLUSTER_IS_CONFIGURED=true, in which case we deliberately fall back to the
-# ambient kubeconfig/context instead of the isolated one above -- that's what
-# helm/kind-action in ci-test.yml provisions.
+# ambient kubeconfig instead of the isolated one above -- that's where helm/kind-action in
+# ci-test.yml puts the clusters it provisions. The contexts above still apply either way: with two
+# clusters there is no such thing as "the current one".
 ifeq ($(ASSUME_CLUSTER_IS_CONFIGURED),true)
 E2E_KUBECONFIG_ENV :=
 else
@@ -169,8 +193,9 @@ endif
 
 .PHONY: print-e2e-cluster
 print-e2e-cluster:
-	@echo "cluster:   $(E2E_CLUSTER)"
-	@echo "kubeconfig: $(E2E_KUBECONFIG)"
+	@echo "pool cluster:         $(E2E_POOL_CLUSTER) (context $(E2E_POOL_CONTEXT))"
+	@echo "cluster-wide cluster: $(E2E_CLUSTERWIDE_CLUSTER) (context $(E2E_CLUSTERWIDE_CONTEXT))"
+	@echo "kubeconfig:           $(E2E_KUBECONFIG)"
 
 .PHONY: reap
 reap:
@@ -183,28 +208,21 @@ reap-apply:
 .PHONY: e2e-cluster-up
 e2e-cluster-up:
 	@mkdir -p $(E2E_HOME)
-	# Reuse the shared cluster if it's already up instead of wiping it first (the old
-	# per-branch profile could safely delete-first since nothing else depended on it;
-	# this one is shared across worktrees/sessions, so deleting it here could yank it
-	# out from under another session's run).
+	# Brings up both e2e clusters (see "E2E cluster identity" above for why there are two). The
+	# loop is over names only: they differ in nothing else -- same hack/kind-cluster.yaml, same
+	# node image, same everything -- and hack/kind-cluster.yaml deliberately carries no `name:` so
+	# that stays true.
+	# Reuse a shared cluster if it's already up instead of wiping it first (the old per-branch
+	# profile could safely delete-first since nothing else depended on it; these are shared across
+	# worktrees/sessions, so deleting one here could yank it out from under another session's run).
 	# Two checks, not one: `kind get clusters` only proves the cluster's *node containers*
 	# exist, and a kind node is a container -- after a host reboot or a `docker stop` the
 	# cluster is still listed while its API server answers nothing. So a positive listing is
-	# followed by a `kubectl get ns` liveness probe against the shared kubeconfig, and a
+	# followed by a `kubectl get ns` liveness probe against that cluster's context, and a
 	# listed-but-dead cluster is deleted and recreated rather than handed to the suite to
 	# time out against (this is the documented recovery for a stale shared cluster, see
 	# CONTRIBUTING.md). Deleting here is safe in a way the "reuse if up" case above is not:
 	# a cluster that doesn't answer isn't one another session is usefully running against.
-	@if kind get clusters 2>/dev/null | grep -qx '$(E2E_CLUSTER)'; then \
-		if $(E2E_KUBECONFIG_ENV) kubectl get ns >/dev/null 2>&1; then \
-			echo "Shared e2e cluster '$(E2E_CLUSTER)' already running, reusing it."; \
-			exit 0; \
-		fi; \
-		echo "Shared e2e cluster '$(E2E_CLUSTER)' exists but its API server is not answering; recreating it."; \
-		$(E2E_KUBECONFIG_ENV) kind delete cluster --name $(E2E_CLUSTER); \
-	fi; \
-	echo "kind create cluster --name $(E2E_CLUSTER) --image $(KIND_NODE_IMAGE) --config hack/kind-cluster.yaml"; \
-	$(E2E_KUBECONFIG_ENV) kind create cluster --name $(E2E_CLUSTER) --image $(KIND_NODE_IMAGE) --config hack/kind-cluster.yaml --wait 300s
 	# --image $(KIND_NODE_IMAGE): the digest-pinned node image from hack/versions.env, which is
 	# where every other dependency version already lives and what ci-test.yml passes as
 	# helm/kind-action's node_image -- so local and CI render against the exact same Kubernetes
@@ -216,25 +234,47 @@ e2e-cluster-up:
 	# node is a container with no CPU or memory limit, so it sees the whole host. That also
 	# retires the reason ensureKyverno/ensureGatekeeper carry CPU-request overrides
 	# (cmd/e2e_helpers_test.go) -- left in place for now, they're harmless, and removing them is
-	# a coverage-affecting change (#868), not part of the provider swap.
+	# a coverage-affecting change (#868), not part of the two-cluster split.
+	@set -e; for cluster in $(E2E_CLUSTERS); do \
+		if kind get clusters 2>/dev/null | grep -qx "$$cluster"; then \
+			if $(E2E_KUBECONFIG_ENV) kubectl --context "kind-$$cluster" get ns >/dev/null 2>&1; then \
+				echo "Shared e2e cluster '$$cluster' already running, reusing it."; \
+				continue; \
+			fi; \
+			echo "Shared e2e cluster '$$cluster' exists but its API server is not answering; recreating it."; \
+			kind delete cluster --name "$$cluster"; \
+		fi; \
+		echo "kind create cluster --name $$cluster --image $(KIND_NODE_IMAGE) --config hack/kind-cluster.yaml"; \
+		$(E2E_KUBECONFIG_ENV) kind create cluster --name "$$cluster" --image $(KIND_NODE_IMAGE) --config hack/kind-cluster.yaml --wait 300s; \
+	done
 
 .PHONY: e2e-cluster-down
 e2e-cluster-down:
-	# Tears down the cluster every worktree/session on this machine shares -- only run
+	# Tears down both clusters every worktree/session on this machine shares -- only run
 	# this when you're sure nobody else (another worktree, another Claude Code session)
-	# still needs it. `flock`ed like test-e2e/test-e2e-quick so it can't race a live run.
-	$(E2E_KUBECONFIG_ENV) flock $(E2E_LOCKFILE) kind delete cluster --name $(E2E_CLUSTER)
+	# still needs them. `flock`ed like test-e2e/test-e2e-quick so it can't race a live run,
+	# and one flock around the whole loop so a run can't start against the cluster that's
+	# still up while the other is being deleted.
+	$(E2E_KUBECONFIG_ENV) flock $(E2E_LOCKFILE) sh -c 'for cluster in $(E2E_CLUSTERS); do kind delete cluster --name "$$cluster"; done'
 	@rm -f $(E2E_KUBECONFIG)
 
 .PHONY: install-e2e-deps
 install-e2e-deps:
+	# Installed on both clusters, hence the loop -- but note that this target is *all* the
+	# cluster-wide cluster ever gets from here. Everything else (cert-manager, Gateway API CRDs,
+	# Cilium/Calico CRDs, VolumeSnapshot CRDs, Istio CRDs, Crossplane, Flux, Kyverno, Gatekeeper)
+	# is installed on demand by the subtest that needs it, via the ensure*(t) functions in
+	# cmd/e2e_helpers_test.go, which target their own subtest's cluster -- so those all land on the
+	# pool's cluster and only the cluster-wide bucket's own two (ensureVPA, ensureKarpenterCRDs) go
+	# to the other one. That asymmetry is what makes a second cluster nearly free instead of a 2x
+	# install tax; keep it that way.
 	# metrics-server is the one cluster dependency that stays here as a global, upfront install
-	# rather than moving into its topical e2e test group (see cmd/e2e_helpers_test.go's
-	# ensure*(t) functions for cert-manager, Gateway API CRDs, Cilium/Calico CRDs, VPA, Crossplane
-	# and Flux -- #720): pdb-empty-selector-conflict, not itself a metrics test, can render a
-	# spurious "metrics-server is not available" line if the metrics API isn't queryable yet
-	# when TestE2EParallel's parallel pool starts, so metrics availability is an invariant for
-	# the whole pool, not a per-group concern.
+	# rather than moving into its topical e2e test group (#720): pdb-empty-selector-conflict, not
+	# itself a metrics test, can render a spurious "metrics-server is not available" line if the
+	# metrics API isn't queryable yet when TestE2EParallel's parallel pool starts, so metrics
+	# availability is an invariant for the whole pool, not a per-group concern. The cluster-wide
+	# cluster needs it just as much: its VPA subtest needs a recommender fed by real samples, and
+	# its metrics-server-APIService subtest needs an APIService there to delete in the first place.
 	# Installed via Helm (version pinned in hack/versions.env like every other dependency)
 	# rather than the addon this used to enable: kind has no addons.
 	# --kubelet-insecure-tls is load-bearing, not a convenience. kind's kubelet serving certs
@@ -244,15 +284,39 @@ install-e2e-deps:
 	# just returns no data. Every fixture with a usage line depends on this flag.
 	$(E2E_KUBECONFIG_ENV) helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 	$(E2E_KUBECONFIG_ENV) helm repo update metrics-server
-	$(E2E_KUBECONFIG_ENV) helm upgrade --install metrics-server metrics-server/metrics-server \
-		--version $(METRICS_SERVER_VERSION) -n kube-system \
-		--set 'args={--kubelet-insecure-tls}' --wait --timeout 5m
+	@set -e; for context in $(E2E_POOL_CONTEXT) $(E2E_CLUSTERWIDE_CONTEXT); do \
+		echo "--- installing e2e dependencies into $$context"; \
+		$(E2E_KUBECONFIG_ENV) helm --kube-context "$$context" upgrade --install metrics-server metrics-server/metrics-server \
+			--version $(METRICS_SERVER_VERSION) -n kube-system \
+			--set 'args={--kubelet-insecure-tls}' --wait --timeout 5m; \
+		$(E2E_KUBECONFIG_ENV) bash -c 'for ((i=1; i<=60; i++)); do kubectl --context "'"$$context"'" get --raw /apis/metrics.k8s.io/v1beta1/nodes >/dev/null 2>&1 && exit 0; sleep 2; done; echo "metrics.k8s.io never became queryable on '"$$context"'" >&2; exit 1'; \
+		$(E2E_KUBECONFIG_ENV) bash -c 'if [ "$$(kubectl --context "'"$$context"'" get storageclass standard -o jsonpath={.volumeBindingMode})" != "Immediate" ]; then \
+			kubectl --context "'"$$context"'" get storageclass standard -o yaml --show-managed-fields=false \
+				| sed "s/^volumeBindingMode: .*/volumeBindingMode: Immediate/" \
+				| kubectl --context "'"$$context"'" replace --force -f -; \
+		else \
+			echo "StorageClass/standard already binds Immediate on '"$$context"', leaving it as-is."; \
+		fi'; \
+	done
 	# The Deployment/Pod going Ready above (which is all `helm --wait` proves) can still briefly
 	# precede the Service's EndpointSlice getting its addresses -- a subtest that happens to run
 	# first in TestE2EParallel's pool (e.g. pdb-empty-selector-conflict) can otherwise race that
-	# gap and render a spurious "metrics-server is not available" line. Poll the actual data path
-	# instead of the rollout.
-	$(E2E_KUBECONFIG_ENV) bash -c 'for ((i=1; i<=60; i++)); do kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes >/dev/null 2>&1 && exit 0; sleep 2; done; echo "metrics.k8s.io never became queryable" >&2; exit 1'
+	# gap and render a spurious "metrics-server is not available" line. Hence the poll of the
+	# actual data path (/apis/metrics.k8s.io/...) rather than of the rollout, above.
+	#
+	# kind's default `standard` StorageClass (rancher.io/local-path) binds WaitForFirstConsumer,
+	# where minikube's bound Immediately. Four subtests create a PVC with no consuming Pod and
+	# then block on phase=Bound (RWOP holder/blocked on the cluster-wide cluster, RWOP conflict and
+	# VolumeAttachment attach error on the pool's) -- under WaitForFirstConsumer those claims stay
+	# Pending until waitForInNamespace's 8m timeout, which is why both clusters get the rewrite
+	# above. volumeBindingMode is immutable, so the class has to be deleted and recreated rather
+	# than patched; `kubectl replace --force` is exactly that delete+create.
+	# Recreated from the live object with only that one field rewritten, rather than from a
+	# hand-written manifest, so the provisioner/reclaimPolicy/parameters stay whatever the node
+	# image actually ships (two subtests clone the cluster's own provisioner into a custom class
+	# and would drift from a hardcoded copy).
+	# Guarded on the current value so a warm cluster isn't churned on every run: deleting a
+	# StorageClass another run is mid-provision against is worth avoiding when it's a no-op.
 
 .PHONY: test-e2e
 ifeq ($(ASSUME_CLUSTER_IS_CONFIGURED),true)
@@ -268,10 +332,21 @@ test-e2e: vet staticcheck install-e2e-deps
 	# --junitfile: per-test pass/fail/duration for Codecov Test Analytics, uploaded separately
 	# from coverage in ci-test.yml (unlike coverage, this has no templates-flag equivalent --
 	# see the `test` target's own --junitfile for why).
-	# -parallel=4: bounds how many TestE2EParallel subtests hit the cluster at once. Go's
-	# default (GOMAXPROCS, i.e. host core count) can far exceed what the host running the
-	# e2e-cluster-up cluster can absorb, causing widespread `kubectl wait` timeouts instead
-	# of a speedup.
+	# -parallel=4: bounds how many subtests are in flight at once. Go's default (GOMAXPROCS,
+	# i.e. host core count) can far exceed what the host running the e2e-cluster-up clusters can
+	# absorb, causing widespread `kubectl wait` timeouts instead of a speedup.
+	# Left at 4 across the two-cluster split (#867) rather than retuned, deliberately and with the
+	# caveat that 4 now means something different: it is a single process-wide budget (Go's
+	# parallel semaphore is per test binary, not per parent test), so the pool's subtests and
+	# TestE2EClusterWide's now draw from it together instead of the pool having all four. A
+	# parallel *parent* releases its own slot while its subtests run, so the two entry points
+	# themselves don't consume two of the four. Whether 4 is still right can only be settled by
+	# measuring on a runner shaped like CI's (4 vCPU / 16 GB): compare total wall clock and the
+	# `kubectl wait` timeout rate at -parallel=4, 6 and 8, and watch whether the cluster-wide
+	# bucket (6 subtests, one of them a CPU burner) finishes well inside the pool's run -- if it
+	# does, its slots are idle most of the time and raising the number mostly helps the pool.
+	# Guessing a bigger number without that measurement is how you turn a scheduling problem into
+	# a flaky-timeout problem.
 	# flock: harmless here (CI runs one job at a time anyway) but keeps this branch
 	# consistent with the shared-cluster branch below. mkdir: this branch skips
 	# e2e-cluster-up (the only other target that creates $(E2E_HOME)), so on a bare
@@ -286,19 +361,19 @@ test-e2e: vet staticcheck install-e2e-deps
 	# subtests concurrently against the same instrumented code, so counter writes need to be
 	# race-safe.
 	@mkdir -p $(E2E_HOME)
-	RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
+	RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true $(E2E_CONTEXT_ENV) flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 else
 test-e2e: vet staticcheck e2e-cluster-up install-e2e-deps
-	# The cluster (name: $(E2E_CLUSTER)) is shared across every worktree/branch/session on
-	# this machine and is left running afterwards -- run `make e2e-cluster-down` yourself when
-	# you're sure nothing else still needs it. `flock $(E2E_LOCKFILE)` serializes this against
+	# The clusters ($(E2E_CLUSTERS)) are shared across every worktree/branch/session on
+	# this machine and are left running afterwards -- run `make e2e-cluster-down` yourself when
+	# you're sure nothing else still needs them. `flock $(E2E_LOCKFILE)` serializes this against
 	# any other test-e2e/test-e2e-quick run on the machine (the suite uses fixed scratch
 	# namespace names, so two concurrent runs would otherwise collide).
 	# using count to prevent caching; see the timeout note in the ASSUME_CLUSTER_IS_CONFIGURED
 	# branch above.
 	# See the gotestsum note, the -parallel=4 note above the other branch's go test invocation,
 	# and the coverage flags note above the other branch's invocation.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true $(E2E_CONTEXT_ENV) flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) --junitfile e2e-junit.xml -- ./... -count=1 -timeout=25m -parallel=4 -run 'TestE2E*' -coverprofile=cover-e2e.out -coverpkg=./... -covermode=atomic
 endif
 
 # Passed through to test-e2e-quick's own invocation below, not test-e2e's: UPDATE_FIXTURES=true
@@ -320,7 +395,7 @@ test-e2e-quick:
 		exit 1; \
 	fi
 	@if [ "$(ASSUME_CLUSTER_IS_CONFIGURED)" != "true" ] && [ ! -f "$(E2E_KUBECONFIG)" ]; then \
-		echo "No shared e2e cluster found ($(E2E_KUBECONFIG))."; \
+		echo "No shared e2e clusters found ($(E2E_KUBECONFIG))."; \
 		echo "Run 'make e2e-cluster-up install-e2e-deps' once first, then reuse it with test-e2e-quick."; \
 		exit 1; \
 	fi
@@ -329,13 +404,13 @@ test-e2e-quick:
 	# creates $(E2E_HOME), so $(E2E_LOCKFILE)'s parent dir could otherwise be missing.
 	@mkdir -p $(E2E_HOME)
 	# Skips vet/staticcheck/install-e2e-deps and the cluster up/down that test-e2e does --
-	# for iterating on a single scenario against the shared cluster you already brought up
+	# for iterating on a single scenario against the shared clusters you already brought up
 	# (and are leaving up) with e2e-cluster-up/install-e2e-deps. Same -parallel=4 as test-e2e:
-	# sized for the host the e2e-cluster-up cluster runs on (see that target's comment), not
-	# worth changing for a narrower -run since it's still the same cluster taking the load.
+	# sized for the host the e2e-cluster-up clusters run on (see that target's comment), not
+	# worth changing for a narrower -run since it's still the same host taking the load.
 	# flock $(E2E_LOCKFILE):
 	# see the comment on the shared-cluster branch of test-e2e above.
-	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true $(UPDATE_FIXTURES_ENV) flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=10m -parallel=4 -run '$(RUN)'
+	$(E2E_KUBECONFIG_ENV) RUN_E2E_TESTS=true ASSUME_CLUSTER_IS_CONFIGURED=true $(E2E_CONTEXT_ENV) $(UPDATE_FIXTURES_ENV) flock $(E2E_LOCKFILE) go run $(GOTESTSUM_MODULE) -- ./... -count=1 -timeout=10m -parallel=4 -run '$(RUN)'
 
 #--------------------------
 # Test Artifacts

--- a/cmd/e2e_clusterwide_test.go
+++ b/cmd/e2e_clusterwide_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,61 +15,55 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TestE2EDynamicManifests holds the scenarios that have a specific, stated reason not to be in
-// TestE2EParallel's pool. It is the exception, not the default: a new subtest belongs in the pool
-// (cmd/main_test.go) unless it trips one of that function's two criteria, and the reason goes in a
-// comment on the subtest.
+// TestE2EClusterWide runs on the second of the suite's two kind clusters (#867): the one for
+// subtests that can't share a cluster with TestE2EParallel's pool -- in either direction. Either
+// they mutate cluster-wide state the pool's renders read, or their own fixtures pin cluster-wide
+// state the pool moves:
 //
-// The reasons that actually qualify are narrow, and all of them are about what the subtest does
-// *to* its neighbours:
-//   - it perturbs cluster-wide state they read (the metrics-server APIService subtest deletes the
-//     APIService other renders depend on),
-//   - it starves a shared dependency (the VPA subtest pegs a full CPU to give the recommender
-//     something to act on, which on a single-node cluster takes metrics-server's readiness probe
-//     down with it),
-//   - it pins kube-scheduler's exact "0/N nodes are available" message (the PV-zone and
-//     Karpenter-nodeSelector subtests below), which would drift if run alongside
-//     TestE2EParallel's createBadNode-based subtests changing the node count.
+//   - deleting the v1beta1.metrics.k8s.io APIService, which every render with a usage line needs
+//     (the first subtest below),
+//   - starving metrics-server: the VPA subtest pegs a CPU to give the recommender something to act
+//     on, which on a single-node cluster takes metrics-server's readiness probe down with it,
+//   - pinning kube-scheduler's exact "0/N nodes are available" message, which is a function of the
+//     cluster's node count -- and the pool's createBadNode subtests transiently add a node.
 //
-// Several things that look disqualifying aren't. Needing a live cluster interaction the offline
-// artifacts can't reach ($.KubeGetFirst, $.IncludeRenderableObject/$.Include) doesn't -- most of the
-// pool needs one. Installing a real controller and waiting for it to reconcile doesn't either: the
-// installers are shared onceInstallers serialized by installMu, so ensureX is safe from inside a
-// t.Parallel() subtest, and the Flux scenario (runFluxSubtests, cmd/e2e_flux_test.go) is in the pool
-// on exactly that basis. Nor does depending on metrics, as long as the subtest is a consumer of them
-// rather than a threat to them. And how the objects come into being certainly doesn't, whatever the
-// "DynamicManifests" name suggests: the subtests below build objects in Go, apply static YAML from
-// tests/e2e-artifacts, and mutate objects the cluster already has, in no particular pattern.
+// This is not a serial bucket and there is no exemption to earn: the subtests here run with
+// t.Parallel() exactly like the pool's, they just run on a cluster that is otherwise idle. The
+// choice a new subtest faces is "does anything else on my cluster see what I do (or do I see what
+// it does)?", not "can I justify skipping the pool" -- see CONTRIBUTING.md. That question used to
+// be litigated per subtest (#784, #832) against three criteria that only existed because both
+// buckets shared one cluster.
 //
-// See #784, where the Flux scenario went from a standalone top-level test to a subtest here before
-// anyone checked it against the pool's criteria -- which it met.
+// Keeping this cluster's dependency set small is what makes it nearly free: metrics-server (from
+// `make install-e2e-deps`) plus ensureVPA and ensureKarpenterCRDs. Everything heavy -- cert-manager,
+// Flux, Crossplane, Kyverno, Gatekeeper, Gateway API, Istio, Cilium/Calico -- stays on the pool's
+// cluster. Don't reach for a pool dependency from here without checking that; installing it twice
+// is most of the cost the second cluster was supposed to avoid.
 //
-// See #832, where auditing this function's subtests against the criteria above found six with no
-// actual reason to be here -- promoted to runStorageSubtests (cmd/e2e_storage_test.go),
-// runCrossplaneSubtests (cmd/e2e_crossplane_test.go), and runHelmReleaseSubtests
-// (cmd/e2e_helm_test.go). The PersistentVolumeClaim RWOP-holder subtest and the
-// WaitForFirstConsumer-topologies subtest below weren't part of that audit's named list and haven't
-// been individually confirmed against the pool's criteria -- don't assume they're exceptions for a
-// stated reason the way the ones above are.
-//
-// The other two entry points exist for reasons this one can't absorb: TestE2EParallel owns the
-// concurrent pool and the single e2eClients() setup its subtests share (see #719), and
-// TestE2EAgainstVanillaCluster (cmd/e2e_vanilla_test.go) covers CLI error/usage paths that need no
-// cluster dependency at all. Don't add a fourth.
-func TestE2EDynamicManifests(t *testing.T) {
-	e2eClusterTest(t)
+// The other two entry points: TestE2EParallel (cmd/main_test.go) owns the pool and the single
+// e2eClients() setup its subtests share (see #719), and TestE2EAgainstVanillaCluster
+// (cmd/e2e_vanilla_test.go) covers CLI error/usage paths -- it shares this cluster, and see its doc
+// comment for why it alone stays non-parallel. Don't add a fourth.
+func TestE2EClusterWide(t *testing.T) {
+	t.Parallel()
+	e2eClusterTest(t, clusterWideCluster)
 	hackOpts, clientset, dynamicClient := e2eClients(t)
+	// The one subtest in the suite without t.Parallel(), and the only reason this cluster can't be
+	// a straight second pool: for the few seconds it holds, no render anywhere on this cluster can
+	// see metrics. Go parks parallel subtests until the parent function returns, so a plain
+	// non-parallel t.Run here runs to completion -- APIService restored and re-Available -- before
+	// any sibling below starts. That is a property of this subtest, not a bucket to justify a
+	// place in; siblings are unaffected and stay parallel.
 	t.Run("pod containers section warns when metrics-server's APIService is missing", func(t *testing.T) {
 		// Issue #165 case 1: metrics-server was never installed. We simulate that by removing
 		// just the APIService object that fronts it (not the Deployment/Service), which is
-		// exactly what KubeMetricsUnavailableReason checks -- so the round trip is near-instant
-		// and doesn't disturb metrics-server's actual health for other subtests.
+		// exactly what KubeMetricsUnavailableReason checks -- so the round trip is near-instant.
 		opts := combineOpts(hackOpts, viperTestHackOpts())
-		apiServiceYAML, err := exec.Command("kubectl", "get", "apiservice", "v1beta1.metrics.k8s.io", "-o", "yaml").Output()
+		apiServiceYAML, err := kubectlCmd(t, "get", "apiservice", "v1beta1.metrics.k8s.io", "-o", "yaml").Output()
 		require.NoError(t, err)
-		require.NoError(t, exec.Command("kubectl", "delete", "apiservice", "v1beta1.metrics.k8s.io").Run())
+		require.NoError(t, kubectlCmd(t, "delete", "apiservice", "v1beta1.metrics.k8s.io").Run())
 		t.Cleanup(func() {
-			applyCmd := exec.Command("kubectl", "apply", "-f", "-")
+			applyCmd := kubectlCmd(t, "apply", "-f", "-")
 			applyCmd.Stdin = bytes.NewReader(apiServiceYAML)
 			require.NoError(t, applyCmd.Run())
 			waitForMetricsAPIServiceAvailable(t)
@@ -86,7 +79,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		t.Cleanup(func() {
 			clientset.CoreV1().Pods("default").Delete(context.TODO(), "e2e-pod-metrics-server-missing", metav1.DeleteOptions{})
 		})
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Ready",
 			"pod/e2e-pod-metrics-server-missing", "--timeout=2m").Run())
 
 		cmdTest{
@@ -95,12 +88,12 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("VerticalPodAutoscaler reverse-matches its target workload and shows an applied recommendation", func(t *testing.T) {
-		// Deliberately kept out of TestE2EParallel's pool: the burner container below
-		// intentionally pegs a full CPU to give the VPA recommender a reason to act, and on a
-		// single-node cluster that starves metrics-server's own readiness probe when it runs
-		// alongside the other concurrent subtests -- causing unrelated renders elsewhere to
-		// intermittently report "metrics-server is not available". Running it serially, alongside
-		// the other genuinely cluster-wide-affecting subtest above, avoids that.
+		t.Parallel()
+		// On this cluster and not the pool's: the burner container below intentionally loads a
+		// CPU to give the VPA recommender a reason to act, and on a single-node cluster that
+		// starves metrics-server's own readiness probe -- which made unrelated renders elsewhere
+		// intermittently report "metrics-server is not available". Nothing else here consumes
+		// metrics while it runs.
 		ensureVPA(t)
 		opts := combineOpts(hackOpts, viperTestHackOpts())
 		ns := "e2e-vpa"
@@ -141,7 +134,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}
 		_, err = clientset.AppsV1().Deployments(ns).Create(context.TODO(), dep, metav1.CreateOptions{})
 		require.NoError(t, err)
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Available",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Available",
 			"deployment/"+name, "-n", ns, "--timeout=4m").Run())
 		originalPod := waitForPodByLabel(t, ns, "app="+name)
 
@@ -180,7 +173,7 @@ func TestE2EDynamicManifests(t *testing.T) {
 		// its readiness -- under concurrent cluster load its Running/Ready transition can lag
 		// well behind that, and the fixture below pins the Deployment as fully Available, so wait
 		// for that explicitly rather than racing the kubelet.
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Available",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Available",
 			"deployment/"+name, "-n", ns, "--timeout=5m").Run())
 		waitForVPAPodsMatched(t, ns, name)
 
@@ -194,6 +187,12 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("PersistentVolumeClaim surfaces its ReadWriteOncePod holder and a scheduling conflict", func(t *testing.T) {
+		t.Parallel()
+		// On this cluster and not the pool's: the blocked-Pod fixture pins kube-scheduler's exact
+		// "0/1 nodes are available" message, which is a function of the cluster's node count --
+		// the pool's createBadNode subtests transiently make that 0/2. (#832 noted this subtest
+		// had never been checked against the old pool criteria; the node count is the reason, and
+		// it's the same one the three subtests below have.)
 		// Issue #669: a ReadWriteOncePod claim allows only one non-terminal Pod to use it at a
 		// time -- enforced by the kube-scheduler's built-in VolumeRestrictions plugin, no CSI
 		// driver involved, so this is fully deterministic on the cluster's default scheduler.
@@ -280,12 +279,15 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("Pod surfaces a bound PV's zone-restricting nodeAffinity when it can't be scheduled", func(t *testing.T) {
+		t.Parallel()
+		// On this cluster and not the pool's: the fixture pins kube-scheduler's "0/1 nodes are
+		// available" message, which the pool's createBadNode subtests would move.
 		// Issue #738: pod_storage_locality resolves a Pod's PVC-backed volume to its bound PV and
 		// surfaces the PV's spec.nodeAffinity when the Pod itself can't be scheduled -- a fact
 		// PersistentVolume.tmpl, StorageClass.tmpl, and Pod.tmpl never connected before. There's
 		// no live cluster mechanism that reliably produces a real zone-restricted CSI PV on
 		// the e2e cluster (kind's local-path provisioner isn't zone-aware), so -- same "create
-		// directly against the API" trick the VolumeAttachment/RWOP-conflict subtests above use
+		// directly against the API" trick the VolumeAttachment/RWOP-conflict subtests use
 		// -- we hand-craft a PV with a nodeAffinity requirement no real Node label
 		// satisfies, and a PVC statically bound to it via spec.volumeName (bypassing dynamic
 		// provisioning). The kube-scheduler's VolumeBinding plugin still evaluates a bound PVC's
@@ -381,6 +383,9 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("Pod hedges on an unbound WaitForFirstConsumer PVC's allowedTopologies", func(t *testing.T) {
+		t.Parallel()
+		// On this cluster and not the pool's, same as the subtest above: the fixture pins
+		// kube-scheduler's "0/1 nodes are available" message.
 		// Issue #738: an unbound claim against a WaitForFirstConsumer class with
 		// allowedTopologies has no PV yet to cross-check, so pod_storage_locality must hedge
 		// ("isn't zone-pinned yet ... may still constrain") instead of asserting a zone. Reuses
@@ -465,7 +470,8 @@ func TestE2EDynamicManifests(t *testing.T) {
 		}.assert(t, nil, opts...)
 	})
 	t.Run("pod nodeSelector key no NodePool declares surfaces a Karpenter incompatibility, a satisfiable one stays silent", func(t *testing.T) {
-		// Kept out of TestE2EParallel's pool, same reasoning as the PV-zone/WFC-topologies
+		t.Parallel()
+		// On this cluster and not the pool's, same reasoning as the PV-zone/WFC-topologies
 		// subtests above: the fixtures below pin kube-scheduler's exact "0/N nodes are
 		// available" message, which only holds for this cluster's real node count --
 		// running alongside TestE2EParallel's createBadNode-based subtests would transiently add

--- a/cmd/e2e_crossplane_test.go
+++ b/cmd/e2e_crossplane_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,7 +29,7 @@ func runCrossplaneSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), 
 		require.NoError(t, err)
 
 		applyManifest(t, "e2e-artifacts/crossplane-xstatusprobe.yaml")
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Established",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Established",
 			"xrd/xstatusprobes.tests.kubectl-status.io", "--timeout=60s").Run())
 		applyManifestInNamespace(t, "e2e-artifacts/crossplane-xr.yaml", ns)
 		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Synced", ns)
@@ -44,7 +43,7 @@ func runCrossplaneSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), 
 		// pin a stable message instead of racing a transient "Replicas: 0/1" kstatus summary.
 		waitForInNamespace(t, "xstatusprobe/probe-a", "condition=Responsive", ns)
 		waitForInNamespace(t, "deployment/probe-a-blocked", "condition=Progressing", ns)
-		require.NoError(t, exec.Command("kubectl", "wait", "-n", ns,
+		require.NoError(t, kubectlCmd(t, "wait", "-n", ns,
 			"--for=condition=PodScheduled=false", "pod", "-l", "app=probe-a-blocked", "--timeout=2m").Run())
 		// kstatus (sigs.k8s.io/cli-utils/pkg/kstatus/status.ScheduleWindow) gives a Pod 15s from
 		// its creationTimestamp before reporting Unschedulable as Failed rather than InProgress --

--- a/cmd/e2e_flux_test.go
+++ b/cmd/e2e_flux_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -20,14 +19,14 @@ import (
 // thing in play is the Flux install itself, which is a shared onceInstaller like the CRD bundles
 // the other groups pull in, not a fixed object name this test could collide on.
 //
-// Installing a real controller doesn't by itself make a scenario serial, and neither does depending
-// on metrics: the fixtures pin podinfo's HPA at its resting 2/2 against a 99%-of-request CPU target,
-// which is a function of podinfo being idle rather than of what else is on the cluster, and the
-// render's relative timestamps are frozen by ApplyTestHack's DurationRound rather than measured. The
-// one subtest that genuinely can't run here (VPA, in TestE2EDynamicManifests) is excluded because it
-// *pegs a CPU* and starves metrics-server for everyone else -- a cause, not a sensitivity. See #784:
-// this scenario was a standalone top-level test, then briefly serial, before either was checked
-// against the criteria above.
+// Installing a real controller doesn't by itself keep a scenario off the pool's cluster, and neither
+// does depending on metrics: the fixtures pin podinfo's HPA at its resting 2/2 against a
+// 99%-of-request CPU target, which is a function of podinfo being idle rather than of what else is
+// on the cluster, and the render's relative timestamps are frozen by ApplyTestHack's DurationRound
+// rather than measured. The one metrics scenario that genuinely can't run here (VPA, in
+// TestE2EClusterWide) is on the other cluster because it *pegs a CPU* and starves metrics-server for
+// everyone else -- a cause, not a sensitivity. See #784: this scenario was a standalone top-level
+// test, then briefly serial, before either was checked against the criteria above.
 func runFluxSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), clientset *kubernetes.Clientset) {
 	// This covers Kustomization.tmpl's live-query branches, which every offline artifact under
 	// tests/artifacts/kustomization-* leaves untouched because --shallow/--local make KubeGetFirst
@@ -88,7 +87,7 @@ func runFluxSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), client
 		// goes on reporting Ready because nothing re-checks it until spec.interval (60m) elapses.
 		// kubectl, not the clientset, so the deletion is ordered against the waits above the same way
 		// every other manifest change in this suite is.
-		out, err := exec.Command("kubectl", "delete", "service", "podinfo", "-n", ns, "--wait").CombinedOutput()
+		out, err := kubectlCmd(t, "delete", "service", "podinfo", "-n", ns, "--wait").CombinedOutput()
 		require.NoErrorf(t, err, "failed to delete the managed Service out-of-band: %s", out)
 		t.Logf("deleted managed Service podinfo in %s out-of-band: %s", ns, out)
 
@@ -136,7 +135,7 @@ func waitForFluxHPASettled(t *testing.T, namespace, name string) {
 	waitForInNamespace(t, "hpa/"+name, "condition=ScalingActive", namespace)
 	waitForInNamespace(t, "hpa/"+name, "condition=ScalingLimited", namespace)
 	require.Eventuallyf(t, func() bool {
-		out, err := exec.Command("kubectl", "get", "hpa", name, "-n", namespace,
+		out, err := kubectlCmd(t, "get", "hpa", name, "-n", namespace,
 			"-o", "jsonpath={.status.desiredReplicas}/{.status.currentReplicas}").Output()
 		if err != nil {
 			return false

--- a/cmd/e2e_helpers_test.go
+++ b/cmd/e2e_helpers_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -677,29 +676,181 @@ func executeCMD(t *testing.T, args []string, opts ...func(*plugin.RenderConfig))
 	cmd.SetOut(stdout)
 	stderr := &bytes.Buffer{}
 	cmd.SetErr(stderr)
+	// The rendered command gets the same explicit --kubeconfig/--context every kubectl shell-out
+	// below gets, so a render lands on the cluster its entry point owns rather than on the
+	// ambient current-context. A no-op for cmd/local_test.go's offline tests, which share cmdTest
+	// but register no target (see e2eTargetFor).
+	args = e2eTargetFor(t).renderArgs(args)
 	cmd.SetArgs(args)
 	t.Logf("running command with: %s", strings.Join(args, " "))
 	err := cmd.Execute()
 	return stdout.String(), stderr.String(), err
 }
 
-func startCluster(t *testing.T) {
+// ---------------------------------------------------------------------------
+// Which cluster a subtest talks to (#867).
+//
+// The suite runs against two kind clusters, so nothing below may fall back to "whatever the
+// ambient kubeconfig's current-context happens to be": every cluster interaction -- the `kubectl`
+// and `helm` shell-outs, the client-go clients, and the rendered kubectl-status command itself --
+// is targeted explicitly. An entry point declares which cluster its subtests own by passing a
+// role to e2eClusterTest, that resolves to an e2eTarget once, and every helper picks the target
+// back up from the *testing.T it is handed.
+//
+// Test code knows roles, not cluster names: the names differ between a local run
+// (kstat-e2e-shared*) and CI (kstat-e2e*), and both are chosen outside Go -- see E2E_POOL_CLUSTER /
+// E2E_CLUSTERWIDE_CLUSTER in the Makefile and in ci-test.yml's job-level env.
+//
+// Targeting kubectl-status itself needs no production change: --kubeconfig and --context are real
+// flags on RootCmd already (genericclioptions.ConfigFlags, cmd/main.go), merely hidden from the
+// default help by hideNoisyFlags.
+// ---------------------------------------------------------------------------
+
+// e2eClusterRole is one of the two clusters, named by what it is for rather than by what it is
+// called. contextEnv/clusterEnv are the environment variables the Makefile (and CI) use to say
+// which real cluster plays this role: contextEnv for an already-provisioned one
+// (ASSUME_CLUSTER_IS_CONFIGURED=true), clusterEnv for the ad hoc `go test -run TestE2E...`
+// fallback that provisions its own.
+type e2eClusterRole struct {
+	name       string
+	contextEnv string
+	clusterEnv string
+}
+
+var (
+	// poolCluster carries TestE2EParallel's pool, i.e. nearly everything, including every heavy
+	// dependency (cert-manager, Flux, Crossplane, Kyverno, Gatekeeper, Gateway API, Istio,
+	// Cilium/Calico).
+	poolCluster = e2eClusterRole{
+		name:       "pool",
+		contextEnv: "E2E_POOL_CONTEXT",
+		clusterEnv: "E2E_POOL_CLUSTER",
+	}
+	// clusterWideCluster carries the subtests that cannot share a cluster with the pool in either
+	// direction -- they mutate cluster-wide state the pool's renders read, or their own fixtures
+	// pin cluster-wide state the pool mutates. See TestE2EClusterWide (cmd/e2e_clusterwide_test.go)
+	// for the whole list; its dependency set is metrics-server plus ensureVPA and
+	// ensureKarpenterCRDs, which is what makes a second cluster nearly free rather than a 2x
+	// install tax.
+	clusterWideCluster = e2eClusterRole{
+		name:       "cluster-wide",
+		contextEnv: "E2E_CLUSTERWIDE_CONTEXT",
+		clusterEnv: "E2E_CLUSTERWIDE_CLUSTER",
+	}
+)
+
+// e2eTarget is one cluster, addressed the way every client here needs it: a kubeconfig path
+// ("" meaning the ambient $KUBECONFIG / ~/.kube/config resolution, which is what CI wants since
+// helm/kind-action writes both clusters into the default kubeconfig) plus the context to select
+// inside it. Comparable on purpose -- onceInstaller keys its per-cluster install results on it.
+type e2eTarget struct {
+	kubeconfig string
+	context    string
+}
+
+// flags renders the target as command-line flags. contextFlag differs per tool: kubectl and
+// kubectl-status spell it --context, helm spells it --kube-context. Both accept these before the
+// subcommand, which is where they go so a caller's args stay verbatim.
+func (tg e2eTarget) flags(contextFlag string) []string {
+	var flags []string
+	if tg.kubeconfig != "" {
+		flags = append(flags, "--kubeconfig", tg.kubeconfig)
+	}
+	if tg.context != "" {
+		flags = append(flags, contextFlag, tg.context)
+	}
+	return flags
+}
+
+func (tg e2eTarget) kubectl(args ...string) *exec.Cmd {
+	return exec.Command("kubectl", append(tg.flags("--context"), args...)...)
+}
+
+func (tg e2eTarget) helm(args ...string) *exec.Cmd {
+	return exec.Command("helm", append(tg.flags("--kube-context"), args...)...)
+}
+
+// renderArgs appends the target to a kubectl-status invocation's own args. Appended rather than
+// prepended so an arg list that starts with a resource still parses the same way, and so the flags
+// show up at the end of executeCMD's log line where they read as the harness's addition.
+func (tg e2eTarget) renderArgs(args []string) []string {
+	return append(append([]string{}, args...), tg.flags("--context")...)
+}
+
+// kubectlCmd is the shorthand for the helpers and subtests that have a *testing.T in hand, which
+// is every `kubectl` shell-out in the suite. There's deliberately no helmCmd twin: every `helm`
+// call sits inside an ensureX install closure, and those are t-free by contract (see
+// onceInstaller), so they resolve the target once in their wrapper and call target.helm directly.
+func kubectlCmd(t *testing.T, args ...string) *exec.Cmd {
 	t.Helper()
-	// `make test-e2e`/`test-e2e-quick` use one fixed shared cluster name (see Makefile)
-	// and pass ASSUME_CLUSTER_IS_CONFIGURED=true, so they never reach this function.
-	// This fallback only matters for ad hoc `go test -run TestE2E...` invocations that
-	// bypass the Makefile entirely: set E2E_CLUSTER yourself (`make print-e2e-cluster`
-	// prints the same shared name the Makefile would use) to land on that same cluster
-	// instead of starting (and leaking) a one-off one named after t.Name().
-	clusterName := os.Getenv("E2E_CLUSTER")
+	return e2eTargetFor(t).kubectl(args...)
+}
+
+// e2eTargets maps a top-level test's name to the cluster its subtests run against. Keyed by the
+// top-level name (t.Name()'s first path segment) rather than being passed down through every
+// helper signature: subtests nest several levels deep and the ~40 helpers below would each have
+// grown a parameter that is constant for a whole entry point.
+var (
+	e2eTargetsMu sync.Mutex
+	e2eTargets   = map[string]e2eTarget{}
+)
+
+func e2eRootTestName(t *testing.T) string {
+	root, _, _ := strings.Cut(t.Name(), "/")
+	return root
+}
+
+func setE2ETarget(t *testing.T, target e2eTarget) {
+	t.Helper()
+	e2eTargetsMu.Lock()
+	defer e2eTargetsMu.Unlock()
+	e2eTargets[e2eRootTestName(t)] = target
+}
+
+// e2eTargetFor returns the cluster t's entry point owns. The zero value (no flags, i.e. ambient
+// kubeconfig and current-context) is correct for the offline tests in cmd/local_test.go, which
+// share cmdTest but never touch a cluster -- but for a TestE2E* test it would mean silently
+// running against whichever cluster happened to be current, which is exactly the failure this
+// whole mechanism exists to prevent (it would look green while both buckets shared one cluster).
+// So that case fails loudly instead.
+func e2eTargetFor(t *testing.T) e2eTarget {
+	t.Helper()
+	root := e2eRootTestName(t)
+	e2eTargetsMu.Lock()
+	defer e2eTargetsMu.Unlock()
+	target, ok := e2eTargets[root]
+	if !ok && strings.HasPrefix(root, "TestE2E") {
+		t.Fatalf("%s did not register a cluster to run against: every TestE2E* entry point must "+
+			"call e2eClusterTest(t, <role>) before doing anything with a cluster", root)
+	}
+	return target
+}
+
+// startCluster provisions a cluster for role and returns how to reach it.
+//
+// `make test-e2e`/`test-e2e-quick` bring both clusters up themselves (see the Makefile) and pass
+// ASSUME_CLUSTER_IS_CONFIGURED=true, so they never reach this function. This fallback only matters
+// for ad hoc `go test -run TestE2E...` invocations that bypass the Makefile entirely: set the
+// role's cluster env var yourself (`make print-e2e-cluster` prints both shared names) to land on
+// the shared clusters instead of starting (and leaking) one-off ones named after t.Name().
+//
+// The kubeconfig is a per-test temp file whose path is handed back in the returned target, rather
+// than t.Setenv("KUBECONFIG", ...) as this used to do. That is what lets the entry points call
+// t.Parallel(): t.Setenv panics on an already-parallel test, and with two clusters a single
+// process-global KUBECONFIG could not have described both anyway.
+func startCluster(t *testing.T, role e2eClusterRole) e2eTarget {
+	t.Helper()
+	clusterName := os.Getenv(role.clusterEnv)
 	if clusterName == "" {
 		clusterName = t.Name()
 	}
-	t.Logf("Creating temp folder for kind.kubeconfig for cluster %s ...", clusterName)
+	t.Logf("Creating temp folder for kind.kubeconfig for the %s cluster %s ...", role.name, clusterName)
 	dir, err := os.MkdirTemp("", clusterName)
 	require.NoError(t, err)
 	kubeconfig := path.Join(dir, "kind.kubeconfig")
-	t.Setenv("KUBECONFIG", kubeconfig)
+	// kind names the context it writes after the cluster, prefixed -- the same name ci-test.yml
+	// and the Makefile derive their E2E_*_CONTEXT values from.
+	target := e2eTarget{kubeconfig: kubeconfig, context: "kind-" + clusterName}
 	t.Logf("Starting kind cluster %s with %s ...", clusterName, kubeconfig)
 	// --image/--config: the same digest-pinned node image and cluster shape the Makefile's
 	// e2e-cluster-up uses, so an ad hoc run renders against the same Kubernetes build as
@@ -707,15 +858,19 @@ func startCluster(t *testing.T) {
 	nodeImage, err := versionsEnvValue("KIND_NODE_IMAGE")
 	require.NoError(t, err)
 	startCluster := exec.Command("kind", "create", "cluster", "--name", clusterName,
+		"--kubeconfig", kubeconfig,
 		"--image", nodeImage, "--config", path.Join("..", "hack", "kind-cluster.yaml"), "--wait", "300s")
 	require.NoError(t, startCluster.Run())
 	// kind has no addons, so metrics-server is an explicit install here the way it is in the
 	// Makefile's install-e2e-deps -- see that target for why --kubelet-insecure-tls is
-	// load-bearing on kind rather than a convenience.
+	// load-bearing on kind rather than a convenience. Both roles need it: the pool because
+	// metrics availability is an invariant of the whole pool, the cluster-wide one because its
+	// VPA subtest needs a recommender with real samples and its metrics-server-APIService subtest
+	// needs an APIService to delete in the first place.
 	metricsServerVersion, err := versionsEnvValue("METRICS_SERVER_VERSION")
 	require.NoError(t, err)
 	require.NoError(t, helmRepoAddUpdate("metrics-server", "https://kubernetes-sigs.github.io/metrics-server/"))
-	output, err := exec.Command("helm", "upgrade", "--install", "metrics-server", "metrics-server/metrics-server",
+	output, err := target.helm("upgrade", "--install", "metrics-server", "metrics-server/metrics-server",
 		"--version", metricsServerVersion, "-n", "kube-system",
 		"--set", "args={--kubelet-insecure-tls}", "--wait", "--timeout", "5m").CombinedOutput()
 	require.NoErrorf(t, err, "helm upgrade metrics-server: %s", output)
@@ -730,32 +885,51 @@ func startCluster(t *testing.T) {
 			t.Log("Error deleting temp folder of kind.kubeconfig:", err)
 		}
 	})
+	return target
 }
 
-func e2eClusterTest(t *testing.T) {
+// e2eClusterTest is the first thing every TestE2E* entry point calls: it skips the test unless the
+// e2e suite was asked for, works out which real cluster plays the role the caller asked for, and
+// records it for every helper the entry point's subtests will reach.
+func e2eClusterTest(t *testing.T, role e2eClusterRole) {
 	t.Helper()
 	if os.Getenv("RUN_E2E_TESTS") != "true" {
 		t.Skip("Skipping e2e test as RUN_E2E_TESTS is not set to true")
 	}
 	if os.Getenv("ASSUME_CLUSTER_IS_CONFIGURED") == "true" {
-		t.Logf("assuming current kubeconfig context is pointing at a cluster to run e2e tests against")
-	} else {
-		startCluster(t)
+		kubeContext := os.Getenv(role.contextEnv)
+		if kubeContext == "" {
+			// Deliberately fatal rather than falling back to the current context. With two
+			// clusters, "no context" means both entry points would quietly run against the same
+			// one -- which mostly still passes, and only shows up as the occasional inexplicable
+			// fixture mismatch when the pool's node count or metrics availability moves under a
+			// cluster-wide subtest. `make test-e2e`/`test-e2e-quick` always set both vars.
+			t.Fatalf("ASSUME_CLUSTER_IS_CONFIGURED=true but %s is unset: the e2e suite needs a "+
+				"kube context for each of its two clusters (see the Makefile's E2E_POOL_CONTEXT/"+
+				"E2E_CLUSTERWIDE_CONTEXT, and CONTRIBUTING.md)", role.contextEnv)
+		}
+		t.Logf("using the %s cluster via kube context %s", role.name, kubeContext)
+		setE2ETarget(t, e2eTarget{context: kubeContext})
+		return
 	}
+	setE2ETarget(t, startCluster(t, role))
 }
 
 func e2eClients(t *testing.T) ([]func(*plugin.RenderConfig), *kubernetes.Clientset, dynamic.Interface) {
 	t.Helper()
 	hackOpts := testHackOpts(t)
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			t.Fatalf("failed to get user home directory: %v", err)
-		}
-		kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
+	// Built from the entry point's explicit target rather than from $KUBECONFIG: with two
+	// clusters the process environment can't say which one this test wants. The deferred loading
+	// rules keep the ambient resolution ($KUBECONFIG, else ~/.kube/config) for the kubeconfig
+	// *file* -- which is what CI needs, since helm/kind-action writes both clusters into the
+	// default one -- while ConfigOverrides.CurrentContext picks this test's cluster inside it.
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	target := e2eTargetFor(t)
+	if target.kubeconfig != "" {
+		loadingRules.ExplicitPath = target.kubeconfig
 	}
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, &clientcmd.ConfigOverrides{CurrentContext: target.context}).ClientConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +949,7 @@ func e2eClients(t *testing.T) ([]func(*plugin.RenderConfig), *kubernetes.Clients
 // creationTimestamp.
 func waitForPodScheduleWindow(t *testing.T, namespace, labelSelector string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+	cmd := kubectlCmd(t, "get", "pods", "-n", namespace, "-l", labelSelector,
 		"-o", "jsonpath={.items[0].metadata.creationTimestamp}")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -793,7 +967,7 @@ func waitForCrossplaneComposedRefs(t *testing.T, namespace, name string, wantCou
 	t.Helper()
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", "xstatusprobe", name, "-n", namespace,
+		cmd := kubectlCmd(t, "get", "xstatusprobe", name, "-n", namespace,
 			"-o", "jsonpath={.spec.crossplane.resourceRefs}")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
@@ -835,11 +1009,11 @@ func deleteNamespaceAndWait(t *testing.T, clientset *kubernetes.Clientset, names
 func applyManifest(t *testing.T, filepath string) {
 	t.Helper()
 	filepath = path.Join("..", "tests", filepath)
-	cmd := exec.Command("kubectl", "apply", "-f", filepath)
+	cmd := kubectlCmd(t, "apply", "-f", filepath)
 	output, err := cmd.CombinedOutput()
 	t.Cleanup(func() {
 		t.Logf("deleting manifest %s", filepath)
-		cmd := exec.Command("kubectl", "delete", "-f", filepath)
+		cmd := kubectlCmd(t, "delete", "-f", filepath)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Logf("warning: failed to delete manifest %s: %v (output: %s)", filepath, err, string(output))
@@ -859,11 +1033,11 @@ func applyManifest(t *testing.T, filepath string) {
 func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
 	t.Helper()
 	filepath = path.Join("..", "tests", filepath)
-	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", filepath)
+	cmd := kubectlCmd(t, "apply", "-n", namespace, "-f", filepath)
 	output, err := cmd.CombinedOutput()
 	t.Cleanup(func() {
 		t.Logf("deleting manifest %s from namespace %s", filepath, namespace)
-		cmd := exec.Command("kubectl", "delete", "-n", namespace, "-f", filepath)
+		cmd := kubectlCmd(t, "delete", "-n", namespace, "-f", filepath)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Logf("warning: failed to delete manifest %s from namespace %s: %v (output: %s)", filepath, namespace, err, string(output))
@@ -885,11 +1059,11 @@ func applyManifestInNamespace(t *testing.T, filepath, namespace string) {
 func createFromManifestCapturingName(t *testing.T, filepath, kind string) string {
 	t.Helper()
 	filepath = path.Join("..", "tests", filepath)
-	output, err := exec.Command("kubectl", "create", "-f", filepath, "-o", "jsonpath={.metadata.name}").CombinedOutput()
+	output, err := kubectlCmd(t, "create", "-f", filepath, "-o", "jsonpath={.metadata.name}").CombinedOutput()
 	require.NoErrorf(t, err, "kubectl create -f %s: %s", filepath, output)
 	name := string(output)
 	t.Cleanup(func() {
-		delOutput, err := exec.Command("kubectl", "delete", kind, name).CombinedOutput()
+		delOutput, err := kubectlCmd(t, "delete", kind, name).CombinedOutput()
 		if err != nil {
 			t.Logf("warning: failed to delete %s/%s: %v (output: %s)", kind, name, err, delOutput)
 			return
@@ -912,7 +1086,7 @@ func createFromManifestCapturingName(t *testing.T, filepath, kind string) string
 // job's -timeout=25m without the wait racing pool contention it doesn't control.
 func waitForInNamespace(t *testing.T, resource, forParam, namespace string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "wait", "-n", namespace, "--for", forParam, resource, "--timeout=8m")
+	cmd := kubectlCmd(t, "wait", "-n", namespace, "--for", forParam, resource, "--timeout=8m")
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s in namespace %s: %s", resource, namespace, string(output))
 	require.NoError(t, err)
@@ -929,7 +1103,7 @@ func waitForSinglePod(t *testing.T, namespace, labelSelector string) {
 	t.Helper()
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+		cmd := kubectlCmd(t, "get", "pods", "-n", namespace, "-l", labelSelector,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
@@ -951,7 +1125,7 @@ func waitForPodByLabel(t *testing.T, namespace, labelSelector string) string {
 	t.Helper()
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+		cmd := kubectlCmd(t, "get", "pods", "-n", namespace, "-l", labelSelector,
 			"-o", "jsonpath={.items[*].metadata.name}")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
@@ -975,7 +1149,7 @@ func waitForStatefulSetUpdateRevisionChange(t *testing.T, namespace, name, stale
 	t.Helper()
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", "statefulset", name, "-n", namespace,
+		cmd := kubectlCmd(t, "get", "statefulset", name, "-n", namespace,
 			"-o", "jsonpath={.status.updateRevision}")
 		output, err := cmd.CombinedOutput()
 		if err == nil {
@@ -997,7 +1171,7 @@ func waitForPodReadyInNamespace(t *testing.T, namespace, podName string) {
 	t.Helper()
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", "get", "pod", podName, "-n", namespace,
+		cmd := kubectlCmd(t, "get", "pod", podName, "-n", namespace,
 			"-o", `jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
 		output, err := cmd.CombinedOutput()
 		if err == nil && strings.TrimSpace(string(output)) == "True" {
@@ -1024,7 +1198,7 @@ func waitForContainerWaitingReasonInNamespace(t *testing.T, resource, containerN
 	}
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		cmd := exec.Command("kubectl", args...)
+		cmd := kubectlCmd(t, args...)
 		output, err := cmd.CombinedOutput()
 		if err == nil && strings.TrimSpace(string(output)) == reason {
 			t.Logf("%s container %s reached waiting reason %s", resource, containerName, reason)
@@ -1043,7 +1217,7 @@ func waitForPodMetrics(t *testing.T, namespace, name string) {
 	rawPath := fmt.Sprintf("/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods/%s", namespace, name)
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		if err := exec.Command("kubectl", "get", "--raw", rawPath).Run(); err == nil {
+		if err := kubectlCmd(t, "get", "--raw", rawPath).Run(); err == nil {
 			t.Logf("metrics available for pod %s/%s", namespace, name)
 			return
 		}
@@ -1072,7 +1246,7 @@ func waitForContainerMetrics(t *testing.T, namespace, name string, containerName
 	}
 	deadline := time.Now().Add(4 * time.Minute)
 	for time.Now().Before(deadline) {
-		output, err := exec.Command("kubectl", "get", "--raw", rawPath).Output()
+		output, err := kubectlCmd(t, "get", "--raw", rawPath).Output()
 		if err == nil {
 			var m podMetrics
 			if json.Unmarshal(output, &m) == nil {
@@ -1108,7 +1282,7 @@ func waitForMetricsAPIServiceAvailable(t *testing.T) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
-		output, err := exec.Command("kubectl", "get", "apiservice", "v1beta1.metrics.k8s.io",
+		output, err := kubectlCmd(t, "get", "apiservice", "v1beta1.metrics.k8s.io",
 			"-o", `jsonpath={.status.conditions[?(@.type=="Available")].status}`).Output()
 		if err == nil && strings.TrimSpace(string(output)) == "True" {
 			t.Log("metrics-server APIService is Available again")
@@ -1126,7 +1300,7 @@ func waitForVPARecommendation(t *testing.T, namespace, name string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Minute)
 	for time.Now().Before(deadline) {
-		output, err := exec.Command("kubectl", "get", "vpa", name, "-n", namespace,
+		output, err := kubectlCmd(t, "get", "vpa", name, "-n", namespace,
 			"-o", "jsonpath={.status.recommendation.containerRecommendations[0].target.cpu}").CombinedOutput()
 		if err == nil && strings.TrimSpace(string(output)) != "" {
 			t.Logf("VPA %s/%s has a recommendation: %s", namespace, name, strings.TrimSpace(string(output)))
@@ -1146,7 +1320,7 @@ func waitForVPAPodsMatched(t *testing.T, namespace, name string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
-		output, err := exec.Command("kubectl", "get", "vpa", name, "-n", namespace,
+		output, err := kubectlCmd(t, "get", "vpa", name, "-n", namespace,
 			"-o", `jsonpath={.status.conditions[?(@.type=="NoPodsMatched")].status}`).CombinedOutput()
 		if err == nil && strings.TrimSpace(string(output)) != "True" {
 			t.Logf("VPA %s/%s no longer reports NoPodsMatched", namespace, name)
@@ -1164,7 +1338,7 @@ func waitForPodRecreated(t *testing.T, namespace, labelSelector, originalPodName
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Minute)
 	for time.Now().Before(deadline) {
-		output, err := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", labelSelector,
+		output, err := kubectlCmd(t, "get", "pods", "-n", namespace, "-l", labelSelector,
 			"-o", "jsonpath={.items[*].metadata.name}").CombinedOutput()
 		if err == nil {
 			for _, name := range strings.Fields(string(output)) {
@@ -1187,35 +1361,39 @@ func waitForPodRecreated(t *testing.T, namespace, labelSelector, originalPodName
 // API CRDs, Cilium/Calico CRDs, VPA, Crossplane, Flux) instead of everything being installed
 // unconditionally by `make install-e2e-deps` before any test runs. metrics-server is the one
 // exception left as a Makefile step: it must be available before TestE2EParallel's pool starts
-// (see that function's doc comment), not merely before whichever group happens to use it.
+// (see that function's doc comment), not merely before whichever group happens to use it, and it
+// is installed on both clusters (see the Makefile) since TestE2EClusterWide needs it too.
 //
 // A dependency used by more than one topical group (Gateway API CRDs: service-routing and
 // tls-validation) needs to install exactly once across the whole run, not once per group -- each
-// onceInstaller below is a package-level singleton shared by every caller, guarded by
-// sync.Once. The error from that single install attempt is cached and replayed to every caller
-// (including ones after the first) rather than only failing the subtest that happened to trigger
-// the install: sync.Once.Do still marks itself done even if its function calls t.FailNow
-// (testify's require does, via runtime.Goexit), so the install closures below stay t-free and
-// return a plain error instead.
+// onceInstaller below is a package-level singleton shared by every caller. The error from that
+// single install attempt is cached and replayed to every caller (including ones after the first)
+// rather than only failing the subtest that happened to trigger the install, so the install
+// closures below stay t-free and return a plain error instead: a `require` inside one exits via
+// runtime.Goexit, and a caller that skipped the install because it was already "done" would have
+// no idea it had failed.
+//
+// "Once" is per cluster, not per process (#867): the suite runs against two clusters, and an
+// installer called from both must install on both. Keyed on the e2eTarget rather than on the role
+// so the key is the thing that actually determines where an install lands.
 // ---------------------------------------------------------------------------
 
 type onceInstaller struct {
-	once sync.Once
-	err  error
+	// results holds one entry per cluster this installer has been asked for; the zero
+	// onceInstaller is ready to use (the map is created on first insert). Guarded by installMu
+	// below, which every install already holds anyway.
+	results map[e2eTarget]error
 }
 
 // installMu serializes every install against every other one, across all onceInstallers. The
-// sync.Once above only keeps a single dependency from being installed twice; it says nothing about
-// two *different* ones overlapping. Most call sites can't overlap on their own: a group-level
-// ensureX in TestE2EParallel runs in that function's own goroutine, which a parallel subtest can't
-// resume ahead of (t.Run parks such a subtest and only releases it once the parent function
-// returns), and TestE2EDynamicManifests has no parallel subtests at all. But that's a property of
-// where those call sites happen to sit, not something the type enforces, and ensureFlux is already
-// the exception: it's called from inside a t.Parallel() subtest (runFluxSubtests,
-// cmd/e2e_flux_test.go), where without this mutex it would race installs of unrelated dependencies
-// running concurrently in sibling subtests. Serializing here costs nothing to be sure of -- a warm
+// per-target result map above only keeps a single dependency from being installed twice on the same
+// cluster; it says nothing about two *different* ones overlapping. Several call sites genuinely
+// can overlap: ensureFlux is called from inside a t.Parallel() subtest (runFluxSubtests,
+// cmd/e2e_flux_test.go), TestE2EClusterWide's ensureVPA/ensureKarpenterCRDs now are too, and since
+// the entry points themselves run in parallel a group-level ensureX on the pool's cluster can now
+// overlap an install on the other one. Serializing here costs nothing to be sure of -- a warm
 // re-run of every installer totals ~15s, and a cold one is exactly the case you want taking the
-// cluster one dependency at a time rather than several controller rollouts at once.
+// host one dependency at a time rather than several controller rollouts at once.
 //
 // Held only around the install itself, never around require.NoError: install closures are t-free by
 // contract (see above), but keeping the assertion outside means even a stray require inside one
@@ -1224,14 +1402,21 @@ var installMu sync.Mutex
 
 func (o *onceInstaller) ensure(t *testing.T, install func() error) {
 	t.Helper()
-	func() {
+	target := e2eTargetFor(t)
+	err := func() error {
 		installMu.Lock()
 		defer installMu.Unlock()
-		o.once.Do(func() {
-			o.err = install()
-		})
+		if err, done := o.results[target]; done {
+			return err
+		}
+		err := install()
+		if o.results == nil {
+			o.results = map[e2eTarget]error{}
+		}
+		o.results[target] = err
+		return err
 	}()
-	require.NoError(t, o.err)
+	require.NoError(t, err)
 }
 
 var (
@@ -1287,6 +1472,7 @@ var gatewayAPICRDsInstaller onceInstaller
 // kubectl.kubernetes.io/last-applied-configuration annotation trips the 262144-byte annotation
 // limit; server-side apply doesn't need that annotation.
 func ensureGatewayAPICRDs(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	gatewayAPICRDsInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("GATEWAY_API_VERSION")
@@ -1294,7 +1480,7 @@ func ensureGatewayAPICRDs(t *testing.T) {
 			return err
 		}
 		url := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/experimental-install.yaml", version)
-		output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+		output, err := target.kubectl("apply", "--server-side", "-f", url).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("kubectl apply gateway-api CRDs: %w: %s", err, output)
 		}
@@ -1308,6 +1494,7 @@ var certManagerInstaller onceInstaller
 // pinned in hack/versions.env (shared with hack/generate-screenshots.sh); bump them there
 // periodically.
 func ensureCertManager(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	certManagerInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("CERT_MANAGER_VERSION")
@@ -1315,10 +1502,10 @@ func ensureCertManager(t *testing.T) {
 			return err
 		}
 		url := fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", version)
-		if output, err := exec.Command("kubectl", "apply", "-f", url).CombinedOutput(); err != nil {
+		if output, err := target.kubectl("apply", "-f", url).CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply cert-manager.yaml: %w: %s", err, output)
 		}
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=300s",
+		output, err := target.kubectl("wait", "--for=condition=Available", "--timeout=300s",
 			"deployment", "--all", "-n", "cert-manager").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("kubectl wait cert-manager deployments: %w: %s", err, output)
@@ -1341,6 +1528,7 @@ var ciliumCalicoCRDsInstaller onceInstaller
 // OpenAPI schemas are large enough to trip the same client-side last-applied-configuration
 // annotation limit as HTTPRoute above.
 func ensureCiliumCalicoCRDs(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	ciliumCalicoCRDsInstaller.ensure(t, func() error {
 		urls := []string{
@@ -1349,7 +1537,7 @@ func ensureCiliumCalicoCRDs(t *testing.T) {
 			"https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/crds.yaml",
 		}
 		for _, url := range urls {
-			output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+			output, err := target.kubectl("apply", "--server-side", "-f", url).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("kubectl apply %s: %w: %s", url, err, output)
 			}
@@ -1361,7 +1549,7 @@ func ensureCiliumCalicoCRDs(t *testing.T) {
 var volumeSnapshotCRDsInstaller onceInstaller
 
 // ensureVolumeSnapshotCRDs installs the VolumeSnapshot/VolumeSnapshotContent CRDs (snapshot.
-// storage.k8s.io), needed by TestE2EDynamicManifests' VolumeSnapshot(Content) subtests. Same
+// storage.k8s.io), needed by the VolumeSnapshot(Content) subtests (runStorageSubtests). Same
 // "CRDs only" reasoning as Gateway API/Cilium/Calico above: kind's local-path
 // provisioner has no CSI snapshot support, and getting a real snapshot to reach
 // ReadyToUse deterministically would need a real CSI driver + external-snapshotter controller
@@ -1371,6 +1559,7 @@ var volumeSnapshotCRDsInstaller onceInstaller
 // apiserver, not a controller actually reconciling them. VolumeSnapshotClass isn't installed:
 // nothing here creates one, spec.volumeSnapshotClassName is just a free-form string reference.
 func ensureVolumeSnapshotCRDs(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	volumeSnapshotCRDsInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("EXTERNAL_SNAPSHOTTER_VERSION")
@@ -1382,7 +1571,7 @@ func ensureVolumeSnapshotCRDs(t *testing.T) {
 			fmt.Sprintf("https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/%s/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml", version),
 		}
 		for _, url := range urls {
-			output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+			output, err := target.kubectl("apply", "--server-side", "-f", url).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("kubectl apply %s: %w: %s", url, err, output)
 			}
@@ -1399,6 +1588,7 @@ var karpenterCRDsInstaller onceInstaller
 // controller installed) are enough -- same "CRDs only" reasoning as ensureCiliumCalicoCRDs/
 // ensureVolumeSnapshotCRDs above.
 func ensureKarpenterCRDs(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	karpenterCRDsInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("KARPENTER_VERSION")
@@ -1410,7 +1600,7 @@ func ensureKarpenterCRDs(t *testing.T) {
 			fmt.Sprintf("https://raw.githubusercontent.com/kubernetes-sigs/karpenter/%s/pkg/apis/crds/karpenter.sh_nodeclaims.yaml", version),
 		}
 		for _, url := range urls {
-			output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput()
+			output, err := target.kubectl("apply", "--server-side", "-f", url).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("kubectl apply %s: %w: %s", url, err, output)
 			}
@@ -1440,23 +1630,24 @@ func helmRepoAddUpdate(name, url string) error {
 
 var vpaInstaller onceInstaller
 
-// ensureVPA installs VerticalPodAutoscaler, needed by TestE2EDynamicManifests' VPA subtest.
+// ensureVPA installs VerticalPodAutoscaler, needed by TestE2EClusterWide's VPA subtest.
 // Unlike the CRD-only installers above, that scenario exercises it actually acting (the updater
 // evicting/recreating a Pod to apply a recommendation), so its controllers (recommender/updater/
 // admission-controller) need to run for real, not just the CRDs. The upstream project has no
 // plain `kubectl apply` release bundle (its install script generates webhook certs locally), so
 // this uses the cowboysysop community Helm chart instead.
 func ensureVPA(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	vpaInstaller.ensure(t, func() error {
 		if err := helmRepoAddUpdate("cowboysysop", "https://cowboysysop.github.io/charts/"); err != nil {
 			return err
 		}
-		if output, err := exec.Command("helm", "upgrade", "--install", "vpa", "cowboysysop/vertical-pod-autoscaler",
+		if output, err := target.helm("upgrade", "--install", "vpa", "cowboysysop/vertical-pod-autoscaler",
 			"--version", "11.1.1", "-n", "kube-system", "--wait", "--timeout", "5m").CombinedOutput(); err != nil {
 			return fmt.Errorf("helm upgrade vpa: %w: %s", err, output)
 		}
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=120s",
+		output, err := target.kubectl("wait", "--for=condition=Available", "--timeout=120s",
 			"deployment", "-l", "app.kubernetes.io/instance=vpa", "-n", "kube-system").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("kubectl wait vpa deployments: %w: %s", err, output)
@@ -1468,7 +1659,7 @@ func ensureVPA(t *testing.T) {
 var crossplaneInstaller onceInstaller
 
 // ensureCrossplane installs Crossplane core plus the two Composition Functions the e2e test
-// Composition needs, required by TestE2EDynamicManifests' Crossplane subtest. That scenario
+// Composition needs, required by the Crossplane subtest (runCrossplaneSubtests). That scenario
 // exercises a real XR composing real children (a Composition Function renders them and derives
 // readiness), not just kubectl-status reading static CRDs, so Crossplane needs to actually
 // reconcile -- same "controller must actually run" reasoning as VPA above. No cloud provider is
@@ -1478,6 +1669,7 @@ var crossplaneInstaller onceInstaller
 // Their versions are pinned in the manifest itself (not hack/versions.env) since they're only
 // used here.
 func ensureCrossplane(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	crossplaneInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("CROSSPLANE_VERSION")
@@ -1487,21 +1679,21 @@ func ensureCrossplane(t *testing.T) {
 		if err := helmRepoAddUpdate("crossplane-stable", "https://charts.crossplane.io/stable"); err != nil {
 			return err
 		}
-		if output, err := exec.Command("helm", "upgrade", "--install", "crossplane", "crossplane-stable/crossplane",
+		if output, err := target.helm("upgrade", "--install", "crossplane", "crossplane-stable/crossplane",
 			"--version", version, "-n", "crossplane-system", "--create-namespace", "--wait", "--timeout", "5m").CombinedOutput(); err != nil {
 			return fmt.Errorf("helm upgrade crossplane: %w: %s", err, output)
 		}
 		functionsManifest := path.Join("..", "tests", "e2e-artifacts", "crossplane-functions.yaml")
-		if output, err := exec.Command("kubectl", "apply", "-f", functionsManifest).CombinedOutput(); err != nil {
+		if output, err := target.kubectl("apply", "-f", functionsManifest).CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply %s: %w: %s", functionsManifest, err, output)
 		}
 		// 5m, matching the helm installs above rather than being the one short wait in the
 		// function: both Functions are OCI packages pulled on demand, so this is a cold pull of
 		// two images plus a Deployment rollout, racing whatever else the suite has running.
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Healthy", "--timeout=300s",
+		output, err := target.kubectl("wait", "--for=condition=Healthy", "--timeout=300s",
 			"function.pkg.crossplane.io", "--all").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("kubectl wait crossplane functions: %w: %s%s", err, output, crossplaneDiagnostics())
+			return fmt.Errorf("kubectl wait crossplane functions: %w: %s%s", err, output, crossplaneDiagnostics(target))
 		}
 		return nil
 	})
@@ -1523,6 +1715,7 @@ var fluxInstaller onceInstaller
 // the bundle's CRDs are large enough to trip the same client-side last-applied-configuration
 // annotation limit as the Gateway API bundle above.
 func ensureFlux(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	fluxInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("FLUX_VERSION")
@@ -1530,15 +1723,15 @@ func ensureFlux(t *testing.T) {
 			return err
 		}
 		url := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/%s/install.yaml", version)
-		if output, err := exec.Command("kubectl", "apply", "--server-side", "-f", url).CombinedOutput(); err != nil {
+		if output, err := target.kubectl("apply", "--server-side", "-f", url).CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply flux install.yaml: %w: %s", err, output)
 		}
 		// 300s matches the cert-manager/Crossplane installs: four controller Deployments, each a
 		// cold image pull, racing whatever else the suite has running on the shared cluster.
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=300s",
+		output, err := target.kubectl("wait", "--for=condition=Available", "--timeout=300s",
 			"deployment", "--all", "-n", "flux-system").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("kubectl wait flux deployments: %w: %s%s", err, output, fluxDiagnostics())
+			return fmt.Errorf("kubectl wait flux deployments: %w: %s%s", err, output, fluxDiagnostics(target))
 		}
 		return nil
 	})
@@ -1548,13 +1741,13 @@ func ensureFlux(t *testing.T) {
 // crossplaneDiagnostics exists: `kubectl wait`'s timeout message names no cause, and this install
 // runs unattended on a cluster the rest of the suite is loading, so this is the only evidence
 // anyone gets after the fact.
-func fluxDiagnostics() string {
+func fluxDiagnostics(target e2eTarget) string {
 	var b strings.Builder
 	for _, args := range [][]string{
 		{"get", "pods", "-n", "flux-system", "-o", "wide"},
 		{"get", "events", "-n", "flux-system", "--sort-by=.lastTimestamp"},
 	} {
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		out, err := target.kubectl(args...).CombinedOutput()
 		fmt.Fprintf(&b, "\n--- kubectl %s ---\n%s", strings.Join(args, " "), out)
 		if err != nil {
 			fmt.Fprintf(&b, "(%v)\n", err)
@@ -1569,7 +1762,7 @@ func fluxDiagnostics() string {
 // never got scheduled are indistinguishable in CI logs after the fact. The install runs
 // unattended on a cluster the rest of the suite is loading, so whatever is collected here is the
 // only evidence anyone gets -- the failure is not reproducible by re-reading the log later.
-func crossplaneDiagnostics() string {
+func crossplaneDiagnostics(target e2eTarget) string {
 	var b strings.Builder
 	for _, args := range [][]string{
 		{"get", "function.pkg.crossplane.io", "-o", "wide"},
@@ -1577,7 +1770,7 @@ func crossplaneDiagnostics() string {
 		{"get", "pods", "-n", "crossplane-system", "-o", "wide"},
 		{"get", "events", "-n", "crossplane-system", "--sort-by=.lastTimestamp"},
 	} {
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		out, err := target.kubectl(args...).CombinedOutput()
 		fmt.Fprintf(&b, "\n--- kubectl %s ---\n%s", strings.Join(args, " "), out)
 		if err != nil {
 			fmt.Fprintf(&b, "(%v)\n", err)
@@ -1616,6 +1809,7 @@ var istioCRDsWanted = []string{
 // --server-side: these CRDs' embedded schemas are large enough to trip client-side apply's
 // last-applied-configuration annotation limit, as the Gateway API's do.
 func ensureIstioCRDs(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	istioCRDsInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("ISTIO_VERSION")
@@ -1646,7 +1840,7 @@ func ensureIstioCRDs(t *testing.T) {
 		if len(wanted) != len(istioCRDsWanted) {
 			return fmt.Errorf("istio CRD bundle %s: found %d of %v", url, len(wanted), istioCRDsWanted)
 		}
-		cmd := exec.Command("kubectl", "apply", "--server-side", "-f", "-")
+		cmd := target.kubectl("apply", "--server-side", "-f", "-")
 		cmd.Stdin = strings.NewReader(strings.Join(wanted, "\n---\n"))
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply istio CRDs: %w: %s", err, output)
@@ -1668,6 +1862,7 @@ var kyvernoInstaller onceInstaller
 // Chart version is pinned in hack/versions.env as KYVERNO_VERSION (the chart version, e.g.
 // "3.8.2" -- Kyverno's Helm chart and app versions diverge, chart 3.8.2 ships app v1.18.2).
 func ensureKyverno(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	kyvernoInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("KYVERNO_VERSION")
@@ -1693,22 +1888,22 @@ func ensureKyverno(t *testing.T) {
 		// reports-controller Pending on "Insufficient cpu" (confirmed against this exact cluster).
 		// 10m each is still generous for a controller that's idle between the handful of events
 		// this one test namespace produces.
-		if output, err := exec.Command("helm", "upgrade", "--install", "kyverno", "kyverno/kyverno",
+		if output, err := target.helm("upgrade", "--install", "kyverno", "kyverno/kyverno",
 			"--version", version, "-n", "kyverno", "--create-namespace", "--wait", "--timeout", "5m",
 			"--set", "features.backgroundScan.backgroundScanInterval=30s",
 			"--set", "cleanupController.enabled=false",
 			"--set", "admissionController.resources.requests.cpu=10m",
 			"--set", "backgroundController.resources.requests.cpu=10m",
 			"--set", "reportsController.resources.requests.cpu=10m").CombinedOutput(); err != nil {
-			return fmt.Errorf("helm upgrade kyverno: %w: %s%s", err, output, kyvernoDiagnostics())
+			return fmt.Errorf("helm upgrade kyverno: %w: %s%s", err, output, kyvernoDiagnostics(target))
 		}
 		// Belt-and-suspenders alongside helm --wait above, matching ensureVPA: confirms the
 		// specific signal (Deployments Available) the rest of the suite depends on, with its own
 		// diagnostics if it's ever the one that times out instead of helm's own wait.
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=300s",
+		output, err := target.kubectl("wait", "--for=condition=Available", "--timeout=300s",
 			"deployment", "--all", "-n", "kyverno").CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("kubectl wait kyverno deployments: %w: %s%s", err, output, kyvernoDiagnostics())
+			return fmt.Errorf("kubectl wait kyverno deployments: %w: %s%s", err, output, kyvernoDiagnostics(target))
 		}
 		return nil
 	})
@@ -1717,13 +1912,13 @@ func ensureKyverno(t *testing.T) {
 // kyvernoDiagnostics dumps why the controllers never came up, for the same reason
 // fluxDiagnostics/crossplaneDiagnostics exist: a bare timeout names no cause, and this install
 // runs unattended on a cluster the rest of the suite is loading.
-func kyvernoDiagnostics() string {
+func kyvernoDiagnostics(target e2eTarget) string {
 	var b strings.Builder
 	for _, args := range [][]string{
 		{"get", "pods", "-n", "kyverno", "-o", "wide"},
 		{"get", "events", "-n", "kyverno", "--sort-by=.lastTimestamp"},
 	} {
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		out, err := target.kubectl(args...).CombinedOutput()
 		fmt.Fprintf(&b, "\n--- kubectl %s ---\n%s", strings.Join(args, " "), out)
 		if err != nil {
 			fmt.Fprintf(&b, "(%v)\n", err)
@@ -1769,6 +1964,7 @@ var gatekeeperInstaller onceInstaller
 // global replace, so they can't accidentally touch an unrelated document that happens to share
 // that text.
 func ensureGatekeeper(t *testing.T) {
+	target := e2eTargetFor(t)
 	t.Helper()
 	gatekeeperInstaller.ensure(t, func() error {
 		version, err := versionsEnvValue("GATEKEEPER_VERSION")
@@ -1803,12 +1999,12 @@ func ensureGatekeeper(t *testing.T) {
 			}
 			docs = append(docs, d)
 		}
-		cmd := exec.Command("kubectl", "apply", "--server-side", "-f", "-")
+		cmd := target.kubectl("apply", "--server-side", "-f", "-")
 		cmd.Stdin = strings.NewReader(strings.Join(docs, "\n---\n"))
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("kubectl apply gatekeeper bundle: %w: %s", err, output)
 		}
-		output, err := exec.Command("kubectl", "wait", "--for=condition=Available", "--timeout=300s",
+		output, err := target.kubectl("wait", "--for=condition=Available", "--timeout=300s",
 			"deployment", "--all", "-n", "gatekeeper-system").CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("kubectl wait gatekeeper deployments: %w: %s", err, output)

--- a/cmd/e2e_kyverno_test.go
+++ b/cmd/e2e_kyverno_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -83,7 +82,7 @@ func runKyvernoSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 // takes no `-n` for.
 func waitForClusterScoped(t *testing.T, resource, forParam string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "wait", "--for", forParam, resource, "--timeout=2m")
+	cmd := kubectlCmd(t, "wait", "--for", forParam, resource, "--timeout=2m")
 	output, err := cmd.CombinedOutput()
 	t.Logf("wait result for %s: %s", resource, string(output))
 	require.NoError(t, err)
@@ -133,7 +132,7 @@ func waitForPolicyReportSummary(t *testing.T, kind, namespace string, want func(
 		} else {
 			args = append(args, "-A")
 		}
-		out, err := exec.Command("kubectl", args...).CombinedOutput()
+		out, err := kubectlCmd(t, args...).CombinedOutput()
 		if err != nil {
 			t.Logf("kubectl get %s: %v: %s", kind, err, out)
 			return false

--- a/cmd/e2e_logs_metrics_test.go
+++ b/cmd/e2e_logs_metrics_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -100,7 +99,7 @@ func runPodLogsAndMetricsSubtests(t *testing.T, hackOpts []func(*plugin.RenderCo
 				},
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
-			require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+			require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Ready",
 				"pod/e2e-metrics-pod", "-n", ns, "--timeout=4m").Run())
 			waitForPodMetrics(t, ns, "e2e-metrics-pod")
 		}

--- a/cmd/e2e_misc_fixture_test.go
+++ b/cmd/e2e_misc_fixture_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -133,7 +132,7 @@ func runMiscFixtureSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig),
 		// ConstraintTemplate is cluster-scoped, so this can't go through waitForInNamespace.
 		// status.created is set once gatekeeper-controller-manager has generated and established
 		// the K8sRequiredLabels CRD from this template.
-		output, err := exec.Command("kubectl", "wait", "--for=jsonpath={.status.created}=true",
+		output, err := kubectlCmd(t, "wait", "--for=jsonpath={.status.created}=true",
 			"constrainttemplate/k8srequiredlabels", "--timeout=120s").CombinedOutput()
 		t.Logf("wait result for constrainttemplate/k8srequiredlabels: %s", output)
 		require.NoError(t, err)

--- a/cmd/e2e_networkpolicy_test.go
+++ b/cmd/e2e_networkpolicy_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,7 +58,7 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 
 		// The full-output regex fixture below pins the Pod to a Running/Ready state, so this
 		// must wait rather than race the kubelet -- otherwise the render can catch it Pending.
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Ready",
 			"pod/netpol-selected-pod", "-n", ns, "--timeout=4m").Run())
 
 		cmdTest{
@@ -137,7 +136,7 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 
 		// The full-output regex fixture below pins the Pod to a Running/Ready state, so this
 		// must wait rather than race the kubelet -- otherwise the render can catch it Pending.
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Ready",
 			"pod/netpol-multi-selected-pod", "-n", ns, "--timeout=4m").Run())
 
 		cmdTest{
@@ -232,7 +231,7 @@ func runNetworkPolicySubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig
 
 		// The full-output regex fixture below pins the Pod to a Running/Ready state, so this
 		// must wait rather than race the kubelet -- otherwise the render can catch it Pending.
-		require.NoError(t, exec.Command("kubectl", "wait", "--for=condition=Ready",
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Ready",
 			"pod/cni-policy-selected-pod", "-n", ns, "--timeout=4m").Run())
 
 		cmdTest{

--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -54,7 +53,7 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 		dep.Spec.Template.Spec.Containers[0].Image = "nginx:1.26"
 		_, err = clientset.AppsV1().Deployments(ns).Update(context.TODO(), dep, metav1.UpdateOptions{})
 		require.NoError(t, err)
-		rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
+		rolloutCmd := kubectlCmd(t, "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
 		output, err := rolloutCmd.CombinedOutput()
 		t.Logf("rollout status for %s: %s", name, output)
 		require.NoError(t, err)
@@ -274,17 +273,17 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 			applyManifestInNamespace(t, "e2e-artifacts/rollouts-three-revisions.yaml", ns)
 			waitForInNamespace(t, "deployment/"+name, "condition=Available", ns)
 
-			out, err := exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", ns).CombinedOutput()
+			out, err := kubectlCmd(t, "set", "image", "deployment/"+name, "nginx=nginx:1.26", "-n", ns).CombinedOutput()
 			require.NoError(t, err, string(out))
-			rolloutCmd := exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
+			rolloutCmd := kubectlCmd(t, "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
 			output, err := rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.26): %s", name, output)
 			require.NoError(t, err)
 			waitForSinglePod(t, ns, "app="+name)
 
-			out, err = exec.Command("kubectl", "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", ns).CombinedOutput()
+			out, err = kubectlCmd(t, "set", "image", "deployment/"+name, "nginx=nginx:1.27", "-n", ns).CombinedOutput()
 			require.NoError(t, err, string(out))
-			rolloutCmd = exec.Command("kubectl", "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
+			rolloutCmd = kubectlCmd(t, "rollout", "status", "deployment/"+name, "-n", ns, "--timeout=4m")
 			output, err = rolloutCmd.CombinedOutput()
 			t.Logf("rollout status for %s (nginx:1.27): %s", name, output)
 			require.NoError(t, err)

--- a/cmd/e2e_storage_test.go
+++ b/cmd/e2e_storage_test.go
@@ -118,7 +118,7 @@ func runStorageSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 		// one non-terminal Pod is scheduled against the same RWOP claim -- it has to render an
 		// explicit conflict instead. The kube-scheduler's VolumeRestrictions plugin normally
 		// prevents this from happening for real (see the ReadWriteOncePod holder/conflict
-		// subtest in cmd/e2e_dynamic_test.go), so to exercise the conflict branch
+		// subtest in cmd/e2e_clusterwide_test.go), so to exercise the conflict branch
 		// deterministically we set spec.nodeName at Pod creation time, which
 		// skips the scheduler (and its RWOP check) entirely -- same "create it directly against
 		// the API" trick the VolumeAttachment subtest below uses to bypass needing a real CSI

--- a/cmd/e2e_vanilla_test.go
+++ b/cmd/e2e_vanilla_test.go
@@ -6,8 +6,21 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// TestE2EAgainstVanillaCluster covers the CLI's own error/usage paths plus two whole-cluster
+// renders. It runs on the cluster-wide cluster (see e2e_clusterwide_test.go) rather than the pool's:
+// its "node query" fixture is a whole-output match against a single Node, and the pool transiently
+// grows a second one whenever a createBadNode-based subtest is in flight.
+//
+// It is the one entry point that does NOT call t.Parallel(), and that is load-bearing rather than
+// an oversight. Go runs the non-parallel top-level tests one at a time and only then releases the
+// parallel ones, so this function gets the cluster to itself -- which it needs, because its node
+// render also pins live metrics, and TestE2EClusterWide's first subtest deletes the metrics-server
+// APIService for a few seconds. Two top-level tests have no way to order themselves against each
+// other short of a package-level lock; one of them simply not being parallel is that ordering.
+// It is also the cheapest of the three (no installs, no controllers), so serializing it costs a
+// minute, not a fraction of the suite.
 func TestE2EAgainstVanillaCluster(t *testing.T) {
-	e2eClusterTest(t)
+	e2eClusterTest(t, clusterWideCluster)
 	hackOpts := testHackOpts(t)
 	klog.InitFlags(nil)
 	t.Log("starting tests...")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,7 +182,18 @@ func initFlags(cmd *cobra.Command) *genericclioptions.ConfigFlags {
 	return configFlags
 }
 
+// colorCobraMu serializes cc.Init: it calls cobra.AddTemplateFunc, which writes into cobra's
+// package-level (and unsynchronized) template function map. RootCmd() -- and so this -- runs once
+// per process for the production binary, but the e2e suite calls RootCmd() fresh per subtest
+// invocation, and #867 (two clusters, parallel entry points) made enough of those concurrent to
+// turn this into an actually-hit "fatal error: concurrent map writes" rather than a latent race.
+// The lock only wraps this registration step, not command execution, so it doesn't serialize the
+// e2e suite's actual parallel work -- same scoping rationale as fatalMu above.
+var colorCobraMu sync.Mutex
+
 func initColorCobra(cmd *cobra.Command) {
+	colorCobraMu.Lock()
+	defer colorCobraMu.Unlock()
 	cc.Init(&cc.Config{
 		RootCmd:         cmd,
 		Headings:        cc.HiCyan + cc.Bold + cc.Underline,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -4,39 +4,49 @@ import (
 	"testing"
 )
 
-// TestE2EParallel is a dedicated home for e2e subtests that are independent of each other and can
-// therefore run concurrently. RootCmd (cmd/main.go) and pkg/plugin no longer read a process-global
-// viper singleton or package-level Now/DurationRound/StartedAfterClause overrides -- each RootCmd()
-// call owns its own *viper.Viper and plugin.RenderConfig (see #694), and testHackOpts/
+// TestE2EParallel runs the pool: the e2e subtests that share one cluster and run concurrently on
+// it, which is nearly all of them, and which is where a new subtest goes by default (see
+// CONTRIBUTING.md). RootCmd (cmd/main.go) and pkg/plugin no longer read a process-global viper
+// singleton or package-level Now/DurationRound/StartedAfterClause overrides -- each RootCmd() call
+// owns its own *viper.Viper and plugin.RenderConfig (see #694), and testHackOpts/
 // viperTestHackOpts just build option values rather than mutating shared state, so calling them
 // from concurrent subtests is safe. The two remaining process-global sinks on the render path --
 // cmdutil.BehaviorOnFatal in RootCmd's RunE and slog.SetDefault in newRenderEngine's
 // setupDeprecationFilter -- are also now safe under concurrent RootCmd().Execute() calls: the
 // former is guarded by cmd/main.go's fatalMu, held only around installing/consuming the handler
 // rather than around the render itself; the latter installs its filtering handler once per
-// process (sync.Once) instead of rebinding it on every render (see #701). A subtest qualifies for
-// t.Parallel() once it:
+// process (sync.Once) instead of rebinding it on every render (see #701).
+//
+// A subtest is safe to run here once it:
 //   - needs no namespace, or creates/uses a namespace dedicated to that subtest (never `default`,
 //     and never a namespace another subtest might also touch)
 //   - never relies on a fixed cluster-scoped resource name (Node, CustomResourceDefinition,
 //     ClusterRole, ...) another subtest could also use -- generate one instead, e.g. with
 //     GenerateName (see createBadNode)
 //
-// Add a qualifying subtest with t.Run(name, func(t *testing.T) { t.Parallel(); ... }) so it
-// actually runs alongside its siblings instead of just living next to them; that subtest-level
-// t.Parallel() is what makes siblings run concurrently, regardless of this function's own.
+// Those are properties of the subtest itself, and a subtest that can't have them (because it
+// mutates cluster-wide state its neighbours read, or because its own fixtures pin cluster-wide
+// state its neighbours move) isn't a serial subtest -- it belongs on the other cluster, in
+// TestE2EClusterWide (cmd/e2e_clusterwide_test.go). Nothing in this suite is exempt from
+// t.Parallel() any more (#867).
 //
-// This function itself must NOT call t.Parallel(): e2eClusterTest below falls back to
-// startCluster, which calls t.Setenv("KUBECONFIG", ...) for ad hoc `go test -run TestE2E...` runs
-// that don't set ASSUME_CLUSTER_IS_CONFIGURED=true -- and t.Setenv panics if called on a test
-// already marked parallel.
+// Add a subtest with t.Run(name, func(t *testing.T) { t.Parallel(); ... }) so it actually runs
+// alongside its siblings instead of just living next to them; that subtest-level t.Parallel() is
+// what makes siblings run concurrently, regardless of this function's own.
+//
+// This function's own t.Parallel() overlaps the whole pool with TestE2EClusterWide, which runs on
+// a different cluster -- worth real minutes, since much of the e2e wall clock is latency (image
+// pulls, rollout waits, metrics scrape intervals, the 15s ScheduleWindow, CrashLoopBackOff
+// backoffs) rather than CPU. It became possible once the startCluster fallback stopped calling
+// t.Setenv (which panics on an already-parallel test) in favour of a per-test kubeconfig path.
 //
 // Subtests are grouped topically into runXSubtests functions in cmd/e2e_*_test.go, each called
 // once below -- see #719 for why they can't be split into separate top-level Test* functions
 // instead: that would break the single e2eClients() setup / shared parallel pool this function
 // provides them.
 func TestE2EParallel(t *testing.T) {
-	e2eClusterTest(t)
+	t.Parallel()
+	e2eClusterTest(t, poolCluster)
 	hackOpts, clientset, dynamicClient := e2eClients(t)
 	runOwnersSubtests(t, hackOpts, clientset)
 	runPodSchedulingSubtests(t, hackOpts, clientset)

--- a/tests/e2e-artifacts/README.md
+++ b/tests/e2e-artifacts/README.md
@@ -286,7 +286,8 @@ section calls `KubeGet "" "flowschemas"` to cross-reference which FlowSchemas ro
 unconditionally suppressed under `--shallow`, so no static fixture can exercise it. These are
 built-in cluster resources (1.29+ uses `flowcontrol.apiserver.k8s.io/v1`) — no manifests to apply.
 
-**Target e2e test:** `t.Run("prioritylevelconfiguration-flowschemas", ...)` under
-`TestE2EDynamicManifests` — no `applyManifest`/`waitFor` needed. `cmdTest{args: []string{"prioritylevelconfiguration/workload-high", "--v", "5"}}`
+**Target e2e test:** `t.Run("prioritylevelconfiguration-flowschemas", ...)` in `TestE2EParallel`'s
+pool (it only reads built-in cluster resources, so it perturbs nothing) — no
+`applyManifest`/`waitFor` needed. `cmdTest{args: []string{"prioritylevelconfiguration/workload-high", "--v", "5"}}`
 (non-`--shallow`) asserting the `FlowSchemas` section lists the expected cross-referenced
 FlowSchemas, plus a `--shallow` variant asserting the section is absent.


### PR DESCRIPTION
## Summary

Part 3/4 of #864 (replacing minikube with kind), closes #867.

Stacked on #870 (which stacks on #869) — same shape as that pair. The pool
(`TestE2EParallel`) and the subtests that used to be exempted into a serial
bucket (`TestE2EDynamicManifests`) only interfered through cluster-scoped state
(the metrics-server `APIService`, node count) that no namespace could isolate.
kind makes a second cluster cheap enough to just give them one:

- `TestE2EDynamicManifests` is dissolved into `TestE2EClusterWide`, which runs
  with `t.Parallel()` on its own kind cluster instead of earning a serial-bucket
  exemption.
- All three entry points (`TestE2EParallel`, `TestE2EClusterWide`,
  `TestE2EAgainstVanillaCluster`) thread an explicit `--context` through the
  ~15 `kubectl`/`helm` shell-outs in `cmd/e2e_helpers_test.go` via a new
  `e2eTarget`/`e2eClusterRole` pair, instead of relying on the ambient
  kubeconfig context.
- `startCluster`'s ad hoc-run fallback moved off `t.Setenv` (which panics on an
  already-parallel test) onto a per-test kubeconfig path — that's what lets
  `TestE2EParallel` and `TestE2EClusterWide` both call `t.Parallel()` on
  themselves, overlapping the two clusters' wall clock.
- CI and the Makefile's shared-cluster scheme both stand up a second kind
  cluster (`kstat-e2e-shared-clusterwide` locally); `install-e2e-deps` installs
  metrics-server on both but keeps every heavy dependency on the pool's
  cluster only, so the second cluster is nearly free rather than a 2x install
  tax.
- CONTRIBUTING.md's "which bucket does my subtest go in" guidance is rewritten
  to match: there's no more serial-bucket exemption to earn, just the question
  of what a subtest does *to*, or has done *to it by*, its neighbours on the
  same cluster.

`-parallel=4` is deliberately left as-is rather than retuned — see the
Makefile comment on `test-e2e` for how to measure whether it still fits now
that it's a budget shared across both clusters' subtests, per the issue's own
open question.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] Offline unit/artifact tests pass (`go test ./cmd/... -run 'TestAllArtifactsLocal|TestE2ERegexFixturesAreAnchored'`)
- [ ] `make test-e2e` green against two live kind clusters (needs a runner with
      the capacity for two clusters; not run in this environment)