### PR TITLE
Resolve resource references in the API group they name, not by Kind alone

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -152,10 +152,21 @@ Either shape is fine; the requirement is that the ref itself stays on screen in 
 For a **list of resources another object manages** — a Kustomization's `status.inventory`, a Crossplane XR's `resourceRefs`, the objects in a Helm release manifest — use `managed_resource_line`, which implements all three modes plus the not-found case in one call:
 
 ```
-{{- $.Include "managed_resource_line" (dict "ctx" $ "kind" $kind "name" $name "namespace" $ns) | nindent 4 }}
+{{- $.Include "managed_resource_line" (dict "ctx" $ "kind" $kind "name" $name "namespace" $ns "group" $group) | nindent 4 }}
 ```
 
 It renders the full inline object under `--deep`, a per-kind health summary by default (via `resource_health_summary`, so a mixed-kind list needs no dispatch of its own), and a bare `resource_ref` when the object can't be fetched. A reference with nothing behind it is additionally marked `missing`, since naming a resource you manage is a claim that it exists; that marking is suppressed when live queries are off, where *every* lookup comes back empty for an unrelated reason. Callers apply their own `nindent` — the helper emits no leading indentation, so the same call works at any depth.
+
+### Always pass the API group with a reference
+
+A `Kind` is not a unique name: `Secret` exists in the core group *and* in `keyvault.azure.m.upbound.io`, `Gateway` in both `gateway.networking.k8s.io` and `networking.istio.io`. `KubeGet`/`KubeGetFirst` resolve an unqualified kind through discovery across every group and silently pick whichever wins the tie — which is how a Crossplane XR composing a provider `Secret` ended up rendering an unrelated core Secret's contents under the right name.
+
+So wherever a reference carries an `apiVersion` or a `group` (an `ownerReference`, a Crossplane `resourceRefs` entry, a Flux inventory id's third segment, a Gateway API `backendRef`, a Helm release manifest document), pass it on:
+
+- to the **lookup**, via `qualifyKind` — `$.KubeGetFirst $ns (qualifyKind .kind .apiVersion) .name` — or the `"group"` key of `managed_resource_line`/`deep_render_ref`.
+- to the **display**, via the `"group"` key of `resource_ref`. Only a group Kubernetes doesn't serve itself is actually printed (`Secret.keyvault.azure.m.upbound.io/creds`); `Deployment.apps` is noise and is suppressed, so passing the group is always safe.
+
+Where the group is a fixed constant the template already knows (Gatekeeper's `constraints.gatekeeper.sh`, Istio's `networking.istio.io`), pass the literal. The two places that deliberately stay unqualified are an object's own header line in `status_summary_line` (nothing to disambiguate it against — the user asked for it by name) and a Flux `spec.dependsOn` ref (always the same Kind as the object declaring it, which the header line just showed).
 
 ### Go template `and`/`or` do not short-circuit
 

--- a/TEMPLATE-API.md
+++ b/TEMPLATE-API.md
@@ -126,18 +126,22 @@ rendered as `.` (no `dict`).
 The building blocks [CONVENTIONS.md § Rendering depth](CONVENTIONS.md#rendering-depth) documents for
 implementing the `--shallow`/default/`--deep` pattern.
 
-- **`resource_ref`** — `dict "kind" "name" "namespace"(opt) "callerNamespace"(opt) "nameSuffix"(opt)`.
+- **`resource_ref`** — `dict "kind" "name" "namespace"(opt) "callerNamespace"(opt) "nameSuffix"(opt) "group"(opt)`.
   Renders `Kind/name`, `-n namespace` appended unless `namespace == callerNamespace`, an optional
   suffix glued onto `name` (e.g. a port) so it can't be misread as qualifying the namespace instead.
+  `group` is the referenced object's `apiVersion` or bare API group; a group Kubernetes doesn't serve
+  itself renders as `Kind.group/name` (`Secret.keyvault.azure.m.upbound.io/creds`), while built-in
+  groups stay off screen — see `displayKind`. Pass it whenever the reference carries one: `Kind` alone
+  is not a unique name across API groups.
   `kind`/`name` are defended with `default ""` so a nil ref field degrades to an empty segment instead
   of aborting the whole object's render.
-- **`deep_render_ref`** — `dict "ctx" "kind" "name" "namespace"(opt, defaults to ctx's) "indent"(opt, default 4)`.
+- **`deep_render_ref`** — `dict "ctx" "kind" "name" "namespace"(opt, defaults to ctx's) "group"(opt, the referenced object's apiVersion or bare API group, so the fetch resolves the right Kind) "indent"(opt, default 4)`.
   Renders nothing unless `--deep`; when `--deep`, fetches the referenced object and inlines it,
   indented. Pairs with a `resource_ref` call on the line above so the reference itself survives in
   every mode — see the worked example in
   [CONVENTIONS.md](CONVENTIONS.md#rendering-depth). Silent (no fetch attempted) whenever the object
   can't be found, which covers `--shallow`/`--local` without an extra check.
-- **`managed_resource_line`** — `dict "ctx" "kind" "name" "namespace"(opt, defaults to ctx's)`. One
+- **`managed_resource_line`** — `dict "ctx" "kind" "name" "namespace"(opt, defaults to ctx's) "group"(opt, the managed object's apiVersion or bare API group — used both for the lookup and for the printed ref)`. One
   line for one object some other object claims to manage (a Kustomization's `status.inventory`, a
   Crossplane XR's `resourceRefs`, a Helm release manifest entry): the full inline render under
   `--deep`, a compact per-kind health summary by default (via `resource_health_summary`), or a bare
@@ -357,7 +361,8 @@ a third-party contract, not this project's — see the
 | `karpenterDisqualifyingKey` | `(nodePoolRequirements, podRequirements []interface{}) string` | The specific key that disqualifies one NodePool from a Pod's requirements. |
 | `networkPolicyPolicyTypes`, `calicoPolicyTypes` | `(spec map[string]interface{}) []string` | Effective `Ingress`/`Egress` policy types, applying each API's own default-when-absent rule. |
 | `ciliumPolicyDirections` (func `ciliumPolicyDirectionsForTemplate`) | `(obj map[string]interface{}, podLabels map[string]interface{}) []string` | Ingress/egress directions a CiliumNetworkPolicy's rules actually restrict for the given Pod labels. |
-| `qualifyKind` | `(kind, group string) string` | `"Kind.group"` (empty group renders as bare `Kind`) — the same qualification scheme `findTemplateName` uses to disambiguate a Kind that exists in more than one API group. |
+| `qualifyKind` | `(kind, apiVersionOrGroup interface{}) string` | The group-qualified `TYPE` argument for `KubeGet`/`KubeGetFirst`: `"Kind.group"`, or a bare `Kind` for the core group. Accepts a full `apiVersion` (`"cert-manager.io/v1"`), a bare group, a bare version (`"v1"`, i.e. no group) or nil. The version is deliberately dropped, so the lookup follows the CRD's currently-preferred version. Same qualification scheme `findTemplateName` uses to disambiguate a Kind that exists in more than one API group — **always pass the group when the reference carries one**, since a bare Kind lets the RESTMapper pick whichever group wins the tie. |
+| `displayKind` | `(kind, apiVersionOrGroup interface{}) string` | The on-screen counterpart of `qualifyKind`: `"Kind.group"` only when the group is one Kubernetes doesn't serve itself, a bare `Kind` for the core and built-in groups (`apps`, `batch`, `policy`, `autoscaling`, `extensions`, anything under `k8s.io`). `resource_ref` applies this to its `group` key; templates printing a bare kind (e.g. a Flux `Kustomization`'s per-kind inventory counts) call it directly. |
 | `hostnameIntersections` | `(listenerHostname string, routeHostnames interface{}) []string` | Gateway API hostname-matching between a Listener and a Route. |
 | `istioHost` | `(host, namespace string) IstioHostRef` | Resolves an Istio host reference. Returns `{Key, Name, Namespace string; InCluster bool}`. |
 

--- a/cmd/e2e_crossplane_test.go
+++ b/cmd/e2e_crossplane_test.go
@@ -64,4 +64,35 @@ func runCrossplaneSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), 
 			stdoutRegexPath: "e2e-artifacts/crossplane-xr-deep.regex",
 		}.assert(t, nil, opts...)
 	})
+
+	t.Run("a composed resource is resolved in the API group its reference names", func(t *testing.T) {
+		t.Parallel()
+		// No ensureCrossplane: detectCrossplaneResource (default_resource_detectors.go) keys off a
+		// bare spec.resourceRefs, so a plain CRD carrying that field exercises the composed-resource
+		// rendering path without a Crossplane installation -- and this scenario is about reference
+		// resolution, not about anything Crossplane's controllers do.
+		//
+		// The reference names Kind=Secret in keyvault.azure.m.upbound.io (a real Upbound Azure
+		// provider Kind), while a core v1 Secret of the *same name* exists in the same namespace.
+		// Resolving by Kind alone resolves to core/v1 through discovery, so before the group was
+		// passed through both composed lines rendered the core Secret: same name, same summary,
+		// twice. The two lines below have to stay distinguishable.
+		opts := combineOpts(hackOpts, viperTestHackOpts())
+		ns := "e2e-cross-group-kind"
+		_, err := clientset.CoreV1().Namespaces().Create(context.TODO(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+		t.Cleanup(func() { deleteNamespaceAndWait(t, clientset, ns) })
+		require.NoError(t, err)
+
+		applyManifest(t, "e2e-artifacts/cross-group-kind-crds.yaml")
+		require.NoError(t, kubectlCmd(t, "wait", "--for=condition=Established",
+			"crd/secrets.keyvault.azure.m.upbound.io", "crd/xsecretholders.tests.kubectl-status.io",
+			"--timeout=60s").Run())
+		applyManifestInNamespace(t, "e2e-artifacts/cross-group-kind.yaml", ns)
+
+		cmdTest{
+			args:            []string{"xsecretholder/holder-a", "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath: "e2e-artifacts/cross-group-kind.regex",
+		}.assert(t, nil, opts...)
+	})
 }

--- a/pkg/plugin/apigroup.go
+++ b/pkg/plugin/apigroup.go
@@ -1,0 +1,106 @@
+package plugin
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cast"
+)
+
+// versionOnlyPattern matches an apiVersion that carries no group at all -- the core group's "v1"
+// and the shape any group-less version takes ("v1beta1", "v2alpha1"). A reference field is
+// variously populated with a full "group/version" (ownerReferences, Crossplane resourceRefs), a
+// bare group (Gateway API backendRefs, cert-manager issuerRef, Flux inventory ids) or nothing, so
+// apiGroup has to tell "v1" (core) apart from "cert-manager.io" (a group) without a cluster.
+var versionOnlyPattern = regexp.MustCompile(`^v[0-9]+((alpha|beta)[0-9]+)?$`)
+
+// apiGroup extracts the API group from a value that may be a full apiVersion ("apps/v1"), a bare
+// group ("keyvault.azure.m.upbound.io"), a bare version ("v1"), or nothing. Returns "" for the core
+// group and for anything it can't make sense of, so every caller degrades to the group-less
+// behaviour that predates this rather than inventing a group.
+//
+// interface{} rather than string for the same reason resourceRef's parameters are: a ref field a
+// CRD marks required can still arrive nil from a hand-written manifest rendered with -f, and
+// cast.ToString degrades that to "" instead of erroring the call and aborting the object's render.
+func apiGroup(apiVersionOrGroup interface{}) string {
+	s := strings.TrimSpace(cast.ToString(apiVersionOrGroup))
+	if s == "" {
+		return ""
+	}
+	if group, _, found := strings.Cut(s, "/"); found {
+		return group
+	}
+	if versionOnlyPattern.MatchString(s) {
+		return ""
+	}
+	return s
+}
+
+// builtinAPIGroups are the non-core API groups the Kubernetes project itself serves that don't end
+// in "k8s.io". Every other built-in group does (networking.k8s.io, rbac.authorization.k8s.io,
+// storage.k8s.io, ...), which isBuiltinAPIGroup matches by suffix rather than by enumerating them.
+var builtinAPIGroups = map[string]bool{
+	"":            true,
+	"apps":        true,
+	"batch":       true,
+	"policy":      true,
+	"autoscaling": true,
+	"extensions":  true,
+}
+
+// isBuiltinAPIGroup reports whether group is one Kubernetes itself serves. Kinds in those groups
+// are the ones every operator already reads unqualified -- nobody needs to be told a Deployment is
+// "Deployment.apps" -- so their group is left off the screen, while a third-party group is always
+// shown: Kind alone is not a unique name, and a "Secret" from keyvault.azure.m.upbound.io rendered
+// as plain "Secret/foo" reads as the core Secret it isn't (issue behind this helper).
+//
+// A CRD group that merely looks Kubernetes-ish still ends up qualified unless it is exactly one of
+// the built-ins, since the check is on the whole group string and third-party groups don't end in
+// "k8s.io" except by deliberate squatting (sigs.k8s.io/gateway-api's gateway.networking.k8s.io
+// being the notable, and harmless, exception -- its Kinds don't collide with built-in ones).
+func isBuiltinAPIGroup(group string) bool {
+	return builtinAPIGroups[group] || group == "k8s.io" || strings.HasSuffix(group, ".k8s.io")
+}
+
+// qualifyKind builds the group-qualified TYPE argument for KubeGet/KubeGetFirst out of a
+// reference's kind plus whatever it says about its API group -- a full apiVersion
+// ("keyvault.azure.m.upbound.io/v1beta1"), a bare group ("gateway.networking.k8s.io"), a bare
+// version ("v1"), or nothing. Returns kind unchanged for the core group, "Kind.group" otherwise.
+//
+// Templates resolving a reference whose API group they know should always qualify it, since a bare
+// kind lets the RESTMapper resolve across every group sharing that Kind name and silently pick
+// whichever wins the tie -- Gateway API's Gateway vs. Istio's (issue #789), or a Crossplane XR
+// composing a "Secret" from keyvault.azure.m.upbound.io, whose lookup landed on the core Secret of
+// the same name and rendered an unrelated object's contents.
+//
+// The version is deliberately dropped even when the reference carries one (resource.Builder would
+// honour it, see input.mappingFor), so the lookup follows the CRD's currently-preferred version
+// instead of failing once the version recorded in an old reference stops being served.
+//
+// The parameters are interface{} rather than string for the same reason resourceRef's are: a ref
+// field a CRD marks required can still arrive nil from a hand-written manifest rendered with -f,
+// and cast.ToString degrades that to "" instead of erroring the call and aborting the render.
+func qualifyKind(kind, apiVersionOrGroup interface{}) string {
+	kindStr := cast.ToString(kind)
+	group := apiGroup(apiVersionOrGroup)
+	if kindStr == "" || group == "" {
+		return kindStr
+	}
+	return kindStr + "." + group
+}
+
+// displayKind renders a Kind for the screen, qualified as "Kind.group" only when the group is one
+// Kubernetes doesn't serve itself. This is the display counterpart of qualifyKind: the lookup
+// form always carries the group (the apiserver needs it to resolve the right resource), while the
+// printed form carries it only when it tells the reader something -- "Deployment.apps" is noise,
+// "Secret.keyvault.azure.m.upbound.io" is the whole point. Used by resourceRef for every reference
+// on screen, and directly by templates that print a bare kind (e.g. a Flux Kustomization's
+// per-kind inventory counts).
+func displayKind(kind, apiVersionOrGroup interface{}) string {
+	kindStr := cast.ToString(kind)
+	group := apiGroup(apiVersionOrGroup)
+	if kindStr == "" || group == "" || isBuiltinAPIGroup(group) {
+		return kindStr
+	}
+	return kindStr + "." + group
+}

--- a/pkg/plugin/apigroup_test.go
+++ b/pkg/plugin/apigroup_test.go
@@ -1,0 +1,94 @@
+package plugin
+
+import "testing"
+
+func TestAPIGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{name: "full apiVersion", in: "keyvault.azure.m.upbound.io/v1beta1", want: "keyvault.azure.m.upbound.io"},
+		{name: "built-in group apiVersion", in: "apps/v1", want: "apps"},
+		{name: "core apiVersion", in: "v1", want: ""},
+		{name: "bare group", in: "cert-manager.io", want: "cert-manager.io"},
+		{name: "bare version without a group", in: "v2beta1", want: ""},
+		{name: "empty string", in: "", want: ""},
+		{name: "nil", in: nil, want: ""},
+		{name: "whitespace only", in: "   ", want: ""},
+		{name: "empty group from a Flux inventory id", in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiGroup(tt.in); got != tt.want {
+				t.Errorf("apiGroup(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBuiltinAPIGroup(t *testing.T) {
+	builtin := []string{"", "apps", "batch", "policy", "autoscaling", "extensions",
+		"networking.k8s.io", "rbac.authorization.k8s.io", "resource.k8s.io", "flowcontrol.apiserver.k8s.io"}
+	for _, group := range builtin {
+		if !isBuiltinAPIGroup(group) {
+			t.Errorf("isBuiltinAPIGroup(%q) = false, want true", group)
+		}
+	}
+	thirdParty := []string{"keyvault.azure.m.upbound.io", "cert-manager.io", "karpenter.sh",
+		"monitoring.coreos.com", "kustomize.toolkit.fluxcd.io", "networking.istio.io", "appsx"}
+	for _, group := range thirdParty {
+		if isBuiltinAPIGroup(group) {
+			t.Errorf("isBuiltinAPIGroup(%q) = true, want false", group)
+		}
+	}
+}
+
+func TestQualifyKind(t *testing.T) {
+	tests := []struct {
+		name              string
+		kind              interface{}
+		apiVersionOrGroup interface{}
+		want              string
+	}{
+		{name: "third-party apiVersion", kind: "Secret", apiVersionOrGroup: "keyvault.azure.m.upbound.io/v1beta1", want: "Secret.keyvault.azure.m.upbound.io"},
+		{name: "version is dropped so the preferred one is used", kind: "Gateway", apiVersionOrGroup: "gateway.networking.k8s.io/v1beta1", want: "Gateway.gateway.networking.k8s.io"},
+		{name: "bare group", kind: "Gateway", apiVersionOrGroup: "gateway.networking.k8s.io", want: "Gateway.gateway.networking.k8s.io"},
+		{name: "built-in groups are qualified too, the lookup wants them", kind: "Deployment", apiVersionOrGroup: "apps/v1", want: "Deployment.apps"},
+		{name: "core group stays bare", kind: "Secret", apiVersionOrGroup: "v1", want: "Secret"},
+		{name: "no group at all stays bare", kind: "Secret", apiVersionOrGroup: "", want: "Secret"},
+		{name: "nil group stays bare", kind: "Secret", apiVersionOrGroup: nil, want: "Secret"},
+		{name: "empty kind stays empty", kind: "", apiVersionOrGroup: "cert-manager.io", want: ""},
+		{name: "nil kind stays empty", kind: nil, apiVersionOrGroup: "cert-manager.io", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qualifyKind(tt.kind, tt.apiVersionOrGroup); got != tt.want {
+				t.Errorf("qualifyKind(%v, %v) = %q, want %q", tt.kind, tt.apiVersionOrGroup, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplayKind(t *testing.T) {
+	tests := []struct {
+		name              string
+		kind              interface{}
+		apiVersionOrGroup interface{}
+		want              string
+	}{
+		{name: "third-party group is shown", kind: "Secret", apiVersionOrGroup: "keyvault.azure.m.upbound.io/v1beta1", want: "Secret.keyvault.azure.m.upbound.io"},
+		{name: "built-in group is hidden", kind: "Deployment", apiVersionOrGroup: "apps/v1", want: "Deployment"},
+		{name: "k8s.io group is hidden", kind: "NetworkPolicy", apiVersionOrGroup: "networking.k8s.io/v1", want: "NetworkPolicy"},
+		{name: "core group is hidden", kind: "Secret", apiVersionOrGroup: "v1", want: "Secret"},
+		{name: "no group at all", kind: "Secret", apiVersionOrGroup: nil, want: "Secret"},
+		{name: "empty kind stays empty", kind: nil, apiVersionOrGroup: "cert-manager.io", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := displayKind(tt.kind, tt.apiVersionOrGroup); got != tt.want {
+				t.Errorf("displayKind(%v, %v) = %q, want %q", tt.kind, tt.apiVersionOrGroup, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/color.go
+++ b/pkg/plugin/color.go
@@ -18,12 +18,19 @@ import (
 // existing/external user template calling `{{template "resource_ref" (dict ...)}}` keeps working
 // unchanged against that thin wrapper.
 //
-// kind/name/namespace/callerNamespace/nameSuffix are interface{} rather than string: a ref field a
-// CRD marks required can still arrive nil from a hand-written manifest rendered with -f (a missing
-// dict key resolves to an untyped nil the same way), and cast.ToString degrades that to "" instead
-// of erroring the call and aborting the whole object's render.
-func resourceRef(kind, name, namespace, callerNamespace, nameSuffix interface{}) string {
-	kindStr := cast.ToString(kind)
+// apiVersionOrGroup is whatever the reference says about its API group -- a full apiVersion
+// ("keyvault.azure.m.upbound.io/v1beta1"), a bare group, or nothing. A group Kubernetes doesn't
+// serve itself is rendered into the Kind as "Kind.group/name": Kind alone is not a unique name
+// across groups, and a Crossplane/Flux-managed "Secret" from keyvault.azure.m.upbound.io shown as
+// plain "Secret/foo" reads as the core Secret it isn't. Built-in groups stay off screen (see
+// isBuiltinAPIGroup) -- "Deployment.apps/foo" is noise nobody asked for.
+//
+// kind/name/namespace/callerNamespace/nameSuffix/apiVersionOrGroup are interface{} rather than
+// string: a ref field a CRD marks required can still arrive nil from a hand-written manifest
+// rendered with -f (a missing dict key resolves to an untyped nil the same way), and cast.ToString
+// degrades that to "" instead of erroring the call and aborting the whole object's render.
+func resourceRef(kind, name, namespace, callerNamespace, nameSuffix, apiVersionOrGroup interface{}) string {
+	kindStr := displayKind(kind, apiVersionOrGroup)
 	nameStr := cast.ToString(name)
 	namespaceStr := cast.ToString(namespace)
 	callerNamespaceStr := cast.ToString(callerNamespace)

--- a/pkg/plugin/color_test.go
+++ b/pkg/plugin/color_test.go
@@ -24,6 +24,7 @@ func TestResourceRef(t *testing.T) {
 		namespace       interface{}
 		callerNamespace interface{}
 		nameSuffix      interface{}
+		group           interface{}
 		want            string
 	}{
 		{
@@ -76,10 +77,47 @@ func TestResourceRef(t *testing.T) {
 			refName: nil,
 			want:    "/",
 		},
+		{
+			name:    "third-party group qualifies the kind",
+			kind:    "Secret",
+			refName: "my-secret",
+			group:   "keyvault.azure.m.upbound.io/v1beta1",
+			want:    "Secret.keyvault.azure.m.upbound.io/my-secret",
+		},
+		{
+			name:    "bare group (no version) qualifies the kind too",
+			kind:    "Issuer",
+			refName: "ca",
+			group:   "cert-manager.io",
+			want:    "Issuer.cert-manager.io/ca",
+		},
+		{
+			name:    "built-in group is left off screen",
+			kind:    "Deployment",
+			refName: "web",
+			group:   "apps/v1",
+			want:    "Deployment/web",
+		},
+		{
+			name:    "core group apiVersion is left off screen",
+			kind:    "Secret",
+			refName: "my-secret",
+			group:   "v1",
+			want:    "Secret/my-secret",
+		},
+		{
+			name:            "group is rendered before the namespace suffix",
+			kind:            "Secret",
+			refName:         "my-secret",
+			namespace:       "ns1",
+			callerNamespace: "ns2",
+			group:           "keyvault.azure.m.upbound.io/v1beta1",
+			want:            "Secret.keyvault.azure.m.upbound.io/my-secret -n ns1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resourceRef(tt.kind, tt.refName, tt.namespace, tt.callerNamespace, tt.nameSuffix)
+			got := resourceRef(tt.kind, tt.refName, tt.namespace, tt.callerNamespace, tt.nameSuffix, tt.group)
 			if got != tt.want {
 				t.Fatalf("resourceRef() = %q, want %q", got, tt.want)
 			}

--- a/pkg/plugin/hostname.go
+++ b/pkg/plugin/hostname.go
@@ -28,20 +28,6 @@ func expectedHostnames(hostnames interface{}) []string {
 	return out
 }
 
-// qualifyKind builds the group-qualified TYPE argument for KubeGet/KubeGetFirst: kind unchanged
-// when group is empty (the core API group), "kind.group" otherwise. Templates resolving a
-// reference whose API group they know -- e.g. a Gateway API ParentReference, which defaults to
-// group "gateway.networking.k8s.io" -- should always qualify it, since a bare kind lets the
-// RESTMapper resolve across every group sharing that Kind name (e.g. Gateway API's Gateway vs.
-// Istio's) and silently pick whichever wins the tie.
-// See https://github.com/bergerx/kubectl-status/issues/789.
-func qualifyKind(kind, group string) string {
-	if group == "" {
-		return kind
-	}
-	return kind + "." + group
-}
-
 // hostnameIntersections narrows a Gateway listener's hostname against a route's hostnames the
 // way the Gateway API attaches routes to listeners, returning the hostnames the pair actually
 // serves together -- which is what a listener's certificate has to cover.

--- a/pkg/plugin/hostname_test.go
+++ b/pkg/plugin/hostname_test.go
@@ -5,26 +5,6 @@ import (
 	"testing"
 )
 
-func TestQualifyKind(t *testing.T) {
-	tests := []struct {
-		name  string
-		kind  string
-		group string
-		want  string
-	}{
-		{"empty group returns kind unchanged", "Gateway", "", "Gateway"},
-		{"non-empty group qualifies the kind", "Gateway", "gateway.networking.k8s.io", "Gateway.gateway.networking.k8s.io"},
-		{"a different group produces a different qualified kind", "Gateway", "networking.istio.io", "Gateway.networking.istio.io"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := qualifyKind(tt.kind, tt.group); got != tt.want {
-				t.Errorf("qualifyKind(%q, %q) = %q, want %q", tt.kind, tt.group, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestHostnameIntersections(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/plugin/renderable.go
+++ b/pkg/plugin/renderable.go
@@ -68,7 +68,10 @@ func (r RenderableObject) newRenderableObject(obj map[string]interface{}) Render
 }
 
 func (r RenderableObject) String() string {
-	kindAndName := fmt.Sprintf("%s/%s", r.Kind(), r.Name())
+	// Group-qualified for a non-built-in group, the same way every reference on screen is (see
+	// displayKind): this string is user-visible through the "already printed" line, where a bare
+	// Kind can name an object from a different group than the one actually printed.
+	kindAndName := fmt.Sprintf("%s/%s", displayKind(r.Kind(), r.APIVersion()), r.Name())
 	if namespace := r.Namespace(); namespace != "" {
 		kindAndName = fmt.Sprintf("%s[%s]", kindAndName, namespace)
 	}
@@ -203,7 +206,11 @@ func (r RenderableObject) renderTemplate(templateName string, data interface{}) 
 
 func (r RenderableObject) executeTemplate(wr io.Writer, name string, data any) error {
 	target, ok := data.(RenderableObject)
-	if ok && target.Kind() == name && r.engine.renderedUIDs.checkAdd(target.GetUID()) && !r.Config.GetBool("watching") {
+	// A Kind that exists in more than one API group is dispatched through a group-qualified
+	// template name ("Kind.group", see templateSet.findTemplateName), so comparing against the bare
+	// Kind alone would miss exactly those objects and re-render them in full instead of collapsing
+	// the repeat into "already printed".
+	if ok && isWholeObjectTemplate(name, target) && r.engine.renderedUIDs.checkAdd(target.GetUID()) && !r.Config.GetBool("watching") {
 		klog.V(3).InfoS("skip rendering of the RenderableObject as its already rendered",
 			"r", r, "templateName", name)
 		_, _ = color.New(color.FgWhite).Fprintf(wr, "%s is already printed", target.String())
@@ -211,6 +218,15 @@ func (r RenderableObject) executeTemplate(wr io.Writer, name string, data any) e
 	}
 	tree := r.engine.templateSet.resolveIncludeTree(name, r.currentTree)
 	return tree.ExecuteTemplate(wr, name, data)
+}
+
+// isWholeObjectTemplate reports whether templateName is the entry point that renders target in
+// full -- its Kind, or the "Kind.group" form findTemplateName uses when that Kind name is shared
+// across API groups -- as opposed to one of the many partials that also execute against a
+// RenderableObject and must never be deduplicated.
+func isWholeObjectTemplate(templateName string, target RenderableObject) bool {
+	kind := target.Kind()
+	return kind != "" && (templateName == kind || templateName == qualifyKind(kind, target.APIVersion()))
 }
 
 type uidSet map[types.UID]struct{}

--- a/pkg/plugin/template_functions_dynamic.go
+++ b/pkg/plugin/template_functions_dynamic.go
@@ -412,6 +412,10 @@ func (r RenderableObject) KubeGetNetworkPoliciesMatchingPod(namespace string, po
 // first and then listed in turn. Called on the Namespace RenderableObject itself (like
 // KubeGetEvents), not given one as a parameter, since it only ever makes sense for the object
 // being rendered.
+// gatekeeperConstraintsGroup is the API group Gatekeeper serves every generated Constraint CRD
+// under, regardless of which ConstraintTemplate declared it.
+const gatekeeperConstraintsGroup = "constraints.gatekeeper.sh"
+
 func (r RenderableObject) KubeGetGatekeeperConstraintsMatchingNamespace() (out []RenderableObject) {
 	out = make([]RenderableObject, 0)
 	if r.LiveQueriesDisabled() {
@@ -421,13 +425,18 @@ func (r RenderableObject) KubeGetGatekeeperConstraintsMatchingNamespace() (out [
 	namespaceName := r.Name()
 	namespaceLabels := stringifyLabels(r.Labels())
 	seenKinds := map[string]bool{}
-	for _, ct := range r.KubeGet("", "ConstraintTemplate") {
+	for _, ct := range r.KubeGet("", qualifyKind("ConstraintTemplate", "templates.gatekeeper.sh")) {
 		kind, _, _ := unstructured.NestedString(ct.Object, "spec", "crd", "spec", "names", "kind")
 		if kind == "" || seenKinds[kind] {
 			continue
 		}
 		seenKinds[kind] = true
-		for _, constraint := range r.KubeGet("", kind) {
+		// Qualified with Gatekeeper's own group: a ConstraintTemplate is free to declare a Kind
+		// name that also exists elsewhere in the cluster (a CRD called "Deployment" or "Secret" is
+		// nothing unusual for a policy set), and a bare Kind lets the RESTMapper resolve to
+		// whichever group wins the tie -- listing unrelated objects and matching them against
+		// namespace selectors they never had.
+		for _, constraint := range r.KubeGet("", qualifyKind(kind, gatekeeperConstraintsGroup)) {
 			matchSpec, _, _ := unstructured.NestedMap(constraint.Object, "spec", "match")
 			if gatekeeperConstraintMatchesNamespace(matchSpec, namespaceName, namespaceLabels) {
 				out = append(out, constraint)

--- a/pkg/plugin/template_functions_static.go
+++ b/pkg/plugin/template_functions_static.go
@@ -86,6 +86,7 @@ func (cfg *RenderConfig) funcMap() template.FuncMap {
 		"percent":                         percent,
 		"colorPercent":                    colorPercent,
 		"resourceRef":                     resourceRef,
+		"displayKind":                     displayKind,
 		"evictionHeadroom":                evictionHeadroom,
 		"evictionAnnotation":              evictionAnnotation,
 		"quotaRolloutHeadroom":            quotaRolloutHeadroom,

--- a/pkg/plugin/templates/common.tmpl
+++ b/pkg/plugin/templates/common.tmpl
@@ -30,17 +30,21 @@
            object doing the referencing; when it matches "namespace" the namespace is redundant on
            screen and is dropped) "nameSuffix" (optional -- a qualifier of the name itself, such
            as a port, placed against the name so it can't be misread as qualifying the trailing
-           " -n namespace" instead)), so every existing/external user template calling
-           template "resource_ref" (dict ...) directly keeps working unchanged. The actual
-           formatting logic lives in the resourceRef Go function (color.go), which gets a
-           compiler-checked parameter list and unit test coverage instead of an unchecked dict;
+           " -n namespace" instead) "group" (optional -- the referenced object's apiVersion or bare
+           API group; a group Kubernetes doesn't serve itself is rendered as "Kind.group/name",
+           since Kind alone is not a unique name across groups)), so every existing/external user
+           template calling template "resource_ref" (dict ...) directly keeps working unchanged.
+           The actual formatting logic lives in the resourceRef Go function (color.go), which gets
+           a compiler-checked parameter list and unit test coverage instead of an unchecked dict;
            see issue #810. */ -}}
-    {{- resourceRef .kind .name .namespace .callerNamespace .nameSuffix -}}
+    {{- resourceRef .kind .name .namespace .callerNamespace .nameSuffix .group -}}
 {{- end -}}
 
 {{- define "deep_render_ref" }}
     {{- /* Expects dict "ctx" (the RenderableObject doing the referencing) "kind" "name"
-           "namespace" (optional, defaults to the caller's) "indent" (optional, defaults to 4).
+           "namespace" (optional, defaults to the caller's) "group" (optional -- the referenced
+           object's apiVersion or bare API group, so the fetch resolves the right Kind when the
+           same Kind name exists in more than one group) "indent" (optional, defaults to 4).
            Renders the referenced object inline under the caller's line when --deep is set, and
            nothing at all otherwise -- so a caller pairs it with a resource_ref line, which stays
            on screen in every mode:
@@ -56,7 +60,7 @@
            either needing an explicit check here. */ -}}
     {{- $ctx := .ctx }}
     {{- if $ctx.Config.GetBool "deep" }}
-        {{- $obj := $ctx.KubeGetFirst (.namespace | default $ctx.Namespace) .kind .name }}
+        {{- $obj := $ctx.KubeGetFirst (.namespace | default $ctx.Namespace) (qualifyKind .kind .group) .name }}
         {{- if $obj.Object }}
             {{- $ctx.IncludeRenderableObject $obj | nindent (int (.indent | default 4)) }}
         {{- end }}
@@ -65,7 +69,8 @@
 
 {{- define "managed_resource_line" }}
     {{- /* Expects dict "ctx" (the RenderableObject doing the managing) "kind" "name" "namespace"
-           (optional, defaults to the caller's).
+           (optional, defaults to the caller's) "group" (optional -- the managed object's
+           apiVersion or bare API group).
 
            One line for one object that some other object claims to manage, in whichever of the
            three rendering modes is active: the full inline render under --deep, a compact per-kind
@@ -86,9 +91,13 @@
            would be a lie. */ -}}
     {{- $ctx := .ctx }}
     {{- $namespace := .namespace | default $ctx.Namespace }}
-    {{- $obj := $ctx.KubeGetFirst $namespace .kind .name }}
+    {{- /* The group is what makes the lookup land on the object the managing resource actually
+           named: a bare "Secret" resolves to core/v1 through discovery whichever group the
+           reference meant, so a Crossplane XR composing a secret.keyvault.azure.m.upbound.io used
+           to render an unrelated core Secret's contents under the right name. */ -}}
+    {{- $obj := $ctx.KubeGetFirst $namespace (qualifyKind .kind .group) .name }}
     {{- if not $obj.Object }}
-        {{- $ctx.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $namespace "callerNamespace" $ctx.Namespace) }}
+        {{- $ctx.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" $namespace "callerNamespace" $ctx.Namespace "group" .group) }}
         {{- if not $ctx.LiveQueriesDisabled }} {{ "missing" | red | bold }}: no such object in the cluster{{ end }}
     {{- else if $ctx.Config.GetBool "deep" }}
         {{- $ctx.IncludeRenderableObject $obj }}
@@ -112,6 +121,10 @@
 
 {{- define "status_summary_line" }}
     {{- /*gotype: github.com/bergerx/kubectl-status/pkg/plugin.RenderableObject*/ -}}
+    {{- /* Deliberately unqualified by API group, unlike the references below: this is the header
+           of the object the user asked for by name, where there is nothing to disambiguate it
+           against, and "PrometheusRule.monitoring.coreos.com/foo" would buy nothing for the length.
+           A reference to some *other* object is the case where the group is load-bearing. */ -}}
     {{- if (.Object | default dict).inline }}
         {{- template "resource_ref" (dict "kind" .Kind "name" .Name) }}
     {{- else }}
@@ -119,7 +132,7 @@
     {{- end }}
     {{- with .Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- if .Metadata.ownerReferences }} by {{ range $index, $ownerReference := .Metadata.ownerReferences }}
-        {{- if $index }},{{ end }}{{ template "resource_ref" (dict "kind" $ownerReference.kind "name" $ownerReference.name) }}
+        {{- if $index }},{{ end }}{{ template "resource_ref" (dict "kind" $ownerReference.kind "name" $ownerReference.name "group" $ownerReference.apiVersion) }}
     {{- end }}{{ end }}
     {{- with .Metadata.generation }}, gen:{{ . }}{{ end }}
     {{- if and .Status.startTime (ne .Kind "Job") }}
@@ -237,7 +250,7 @@
             {{- end }}{{ end }}
         {{- end }}
         {{- range .Orphans }}
-            {{- "Orphan" | red | bold | nindent 2 }}: owner {{ template "resource_ref" (dict "kind" .Kind "name" .Name) }} referenced in ownerReferences no longer exists
+            {{- "Orphan" | red | bold | nindent 2 }}: owner {{ template "resource_ref" (dict "kind" .Kind "name" .Name "group" .APIVersion) }} referenced in ownerReferences no longer exists
         {{- end }}
     {{- end }}
 {{- end }}
@@ -300,7 +313,7 @@
            itself rather than at status.observedGeneration (controller-runtime's metav1.Condition
            carries its own per-condition observedGeneration; some operators only set it there). */ -}}
     {{- $obj := .obj }}
-    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace) }}
+    {{- template "resource_ref" (dict "kind" $obj.Kind "name" $obj.Name "namespace" $obj.Namespace "callerNamespace" .callerNamespace "group" $obj.APIVersion) }}
     {{- with $obj.Metadata.creationTimestamp }}, created {{ . | colorAgo }}{{ agoSuffix }}{{ end }}
     {{- with $obj.KStatus }}, {{ .Status.String | colorKeyword }}{{ with .Message }}: {{ . }}{{ end }}{{ end }}
     {{- if $obj.Status | hasKey "ready" }}

--- a/pkg/plugin/templates/core/PersistentVolume.tmpl
+++ b/pkg/plugin/templates/core/PersistentVolume.tmpl
@@ -24,8 +24,8 @@
            original PV status line. */ -}}
     {{- with .Spec.storageClassName }}{{ $.Include "storageclass_summary" (dict "ctx" $ "name" . "provisionerShown" ($.Annotations | hasKey "pv.kubernetes.io/provisioned-by")) }}{{ end }}
     {{- with .Spec.claimRef }}
-        {{- "Created" | nindent 2 }} for {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace) }}
-        {{- $pvc := $.KubeGetFirst .namespace .kind .name }}
+        {{- "Created" | nindent 2 }} for {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace "group" .apiVersion) }}
+        {{- $pvc := $.KubeGetFirst .namespace (qualifyKind .kind .apiVersion) .name }}
         {{- if $pvc.Object }}
             {{- if ne $pvc.Metadata.uid .uid }}
                 {{- "Dangling" | red | bold | nindent 4 }}: The PVC referenced in this PV is replaced by a new one. And a new PV is created for the replacement PVC.

--- a/pkg/plugin/templates/core/Secret.tmpl
+++ b/pkg/plugin/templates/core/Secret.tmpl
@@ -259,5 +259,5 @@
            scope. */ -}}
     {{- $ctx := .ctx }}
     {{- $entry := .entry }}
-    {{- $ctx.Include "managed_resource_line" (dict "ctx" $ctx "kind" $entry.kind "name" $entry.name "namespace" ($entry.namespace | default $ctx.Namespace)) }}
+    {{- $ctx.Include "managed_resource_line" (dict "ctx" $ctx "kind" $entry.kind "name" $entry.name "namespace" ($entry.namespace | default $ctx.Namespace) "group" $entry.apiVersion) }}
 {{- end }}

--- a/pkg/plugin/templates/crossplane/crossplane_common.tmpl
+++ b/pkg/plugin/templates/crossplane/crossplane_common.tmpl
@@ -51,7 +51,10 @@
            from crossplane_default_resource. Since this now runs for every CRD kind that has no dedicated
            template, a coincidentally-named but differently-shaped spec.resourceRefs/spec.crossplane
            field (e.g. not a list of {kind,name} objects) must be ignored rather than treated as a
-           template error that would blank out that resource's whole render. */ -}}
+           template error that would blank out that resource's whole render.
+           Each entry's apiVersion is forwarded as the ref's group: composed resources routinely use
+           a provider Kind whose name is also a core one (Secret in keyvault.azure.m.upbound.io),
+           and without the group both the lookup and the printed ref land on the core Kind. */ -}}
     {{- $refs := .Spec.resourceRefs }}
     {{- $crossplane := .Spec.crossplane }}
     {{- if kindIs "map" $crossplane }}
@@ -70,7 +73,7 @@
         {{- range . }}
             {{- $ns := $.Namespace }}
             {{- with .namespace }}{{ $ns = . }}{{ end }}
-            {{- $.Include "managed_resource_line" (dict "ctx" $ "kind" .kind "name" .name "namespace" $ns) | nindent 4 }}
+            {{- $.Include "managed_resource_line" (dict "ctx" $ "kind" .kind "name" .name "namespace" $ns "group" .apiVersion) | nindent 4 }}
         {{- end }}
     {{- end }}
 {{- end }}
@@ -143,7 +146,7 @@
             {{- end }}
         {{- end }}
         {{- with .Spec.providerConfigRef }}
-            {{- $.Include "resource_ref" (dict "kind" (.kind | default "ProviderConfig") "name" .name) | nindent 2 }}
+            {{- $.Include "resource_ref" (dict "kind" (.kind | default "ProviderConfig") "name" .name "group" .apiVersion) | nindent 2 }}
         {{- end }}
         {{- $policies := .Spec.managementPolicies }}
         {{- if kindIs "slice" $policies }}

--- a/pkg/plugin/templates/dra/ResourceClaim.tmpl
+++ b/pkg/plugin/templates/dra/ResourceClaim.tmpl
@@ -59,7 +59,7 @@
            managed_resource_line, the same way PersistentVolumeClaim relies on being resolvable
            through resource_health_summary wherever a PVC is named rather than fully rendered. */ -}}
     {{- $claim := .obj }}
-    {{- template "resource_ref" (dict "kind" $claim.Kind "name" $claim.Name "namespace" $claim.Namespace "callerNamespace" .callerNamespace) }}
+    {{- template "resource_ref" (dict "kind" $claim.Kind "name" $claim.Name "namespace" $claim.Namespace "callerNamespace" .callerNamespace "group" $claim.APIVersion) }}
     {{- $status := $claim.Status | default dict }}
     {{- $allocation := $status.allocation }}
     {{- if not $allocation }}

--- a/pkg/plugin/templates/externalsecrets/ExternalSecret.tmpl
+++ b/pkg/plugin/templates/externalsecrets/ExternalSecret.tmpl
@@ -10,7 +10,7 @@
     {{- with .Spec.secretStoreRef }}
         {{- $storeKind := .kind | default "SecretStore" }}
         {{- if $.Config.GetBool "deep" }}
-            {{- $obj := $.KubeGetFirst $.Namespace $storeKind .name }}
+            {{- $obj := $.KubeGetFirst $.Namespace (qualifyKind $storeKind "external-secrets.io") .name }}
             {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
         {{- else }}
             {{- "Store" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" $storeKind "name" .name) }}

--- a/pkg/plugin/templates/flux/Kustomization.tmpl
+++ b/pkg/plugin/templates/flux/Kustomization.tmpl
@@ -51,7 +51,12 @@
             {{- $parts := splitList "_" (.id | default "" | toString) }}
             {{- /* An id that doesn't split into four is bucketed rather than counted under its own
                    text, which would otherwise put the whole malformed id in the kind summary. */ -}}
-            {{- $kind := ternary (last $parts) "unparsable" (eq (len $parts) 4) }}
+            {{- /* Counted under the same group-qualified kind the entries themselves are printed
+                   as below, so two same-named Kinds from different groups aren't summed into one
+                   bogus count. Written as an if rather than a ternary because both branches of a
+                   ternary are evaluated, and "index $parts 2" errors on a malformed id. */ -}}
+            {{- $kind := "unparsable" }}
+            {{- if eq (len $parts) 4 }}{{ $kind = displayKind (index $parts 3) (index $parts 2) }}{{ end }}
             {{- $_ := $countsByKind | set $kind (add1 (int ($countsByKind | get $kind))) }}
             {{- $ids = $ids | append (.id | default "" | toString) }}
         {{- end }}
@@ -67,12 +72,16 @@
             {{- if eq (len $parts) 4 }}
                 {{- $entryNamespace := index $parts 0 }}
                 {{- $entryName := index $parts 1 }}
+                {{- /* Empty for the core group ("ns_name__Secret"), which is exactly what the ref
+                       and the lookup want -- an id naming a non-core group is the case that used
+                       to resolve to the wrong Kind of the same name. */ -}}
+                {{- $entryGroup := index $parts 2 }}
                 {{- $entryKind := index $parts 3 }}
                 {{- /* An inventory entry is a record of an apply that already succeeded, so an
                        object missing from underneath one was deleted out-of-band or left behind by
                        a prune that couldn't finish -- and the Kustomization reports Ready either
                        way. managed_resource_line flags that for us. */ -}}
-                {{- $.Include "managed_resource_line" (dict "ctx" $ "kind" $entryKind "name" $entryName "namespace" $entryNamespace) | nindent 4 }}
+                {{- $.Include "managed_resource_line" (dict "ctx" $ "kind" $entryKind "name" $entryName "namespace" $entryNamespace "group" $entryGroup) | nindent 4 }}
             {{- else }}
                 {{- $entry | toString | cyan | nindent 4 }}
             {{- end }}

--- a/pkg/plugin/templates/flux/flux_common.tmpl
+++ b/pkg/plugin/templates/flux/flux_common.tmpl
@@ -37,7 +37,9 @@
     {{- /* Flux gates reconciliation on spec.dependsOn: while any listed object is not Ready this
            one isn't reconciled at all, which is the usual explanation for an object that just
            sits there with a stale revision. Entries carry only name/namespace -- they always
-           refer to the same kind as the object declaring them. */ -}}
+           refer to the same kind as the object declaring them -- which is why the refs are printed
+           unqualified (the reader just read that Kind on the header line) while the --deep fetch
+           passes the group anyway, so a same-named Kind in another group can't win the lookup. */ -}}
     {{- with .Spec.dependsOn }}
         {{- "Depends on" | bold | nindent 2 }}
         {{- range $index, $dep := . }}
@@ -46,7 +48,7 @@
         {{- /* Deep renders each dependency below the list rather than inline in it, so the
                one-line "who is blocking me" summary survives in every mode. */ -}}
         {{- range $dep := . }}
-            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" ($dep.kind | default $.Kind) "name" $dep.name "namespace" ($dep.namespace | default $.Namespace)) }}
+            {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" ($dep.kind | default $.Kind) "name" $dep.name "namespace" ($dep.namespace | default $.Namespace) "group" (ternary ($.APIVersion | toString) "" (not $dep.kind))) }}
         {{- end }}
     {{- end }}
 {{- end -}}

--- a/pkg/plugin/templates/gatewayapi/BackendTLSPolicy.tmpl
+++ b/pkg/plugin/templates/gatewayapi/BackendTLSPolicy.tmpl
@@ -13,7 +13,7 @@
                 {{- $obj := $.KubeGetFirst $.Namespace (qualifyKind .kind .group) .name }}
                 {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 4 }}{{ end }}
             {{- else }}
-                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name) | nindent 4 }}
+                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "group" .group) | nindent 4 }}
                 {{- with .sectionName }} [{{ . | cyan }}]{{ end }}
             {{- end }}
         {{- end }}
@@ -24,7 +24,7 @@
         {{- with .caCertificateRefs }}
             {{- "CA certs" | bold | nindent 4 }}:
             {{- range . }}
-                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name) | nindent 6 }}
+                {{- $.Include "resource_ref" (dict "kind" .kind "name" .name "group" .group) | nindent 6 }}
             {{- end }}
         {{- end }}
         {{- with .subjectAltNames }}
@@ -37,7 +37,7 @@
     {{- with .Status.ancestors }}
         {{- "Status" | bold | nindent 2 }}:
         {{- range . }}
-            {{- $.Include "resource_ref" (dict "kind" (.ancestorRef.kind | default "Gateway") "name" .ancestorRef.name "namespace" .ancestorRef.namespace "callerNamespace" $.Namespace) | nindent 4 }}
+            {{- $.Include "resource_ref" (dict "kind" (.ancestorRef.kind | default "Gateway") "name" .ancestorRef.name "namespace" .ancestorRef.namespace "callerNamespace" $.Namespace "group" .ancestorRef.group) | nindent 4 }}
             {{- with .controllerName }} ({{ . }}){{ end }}
             {{- range .conditions | sortMapListByKeysValue "type" }}
                 {{- $.Include "condition_summary" . | nindent 6 }}

--- a/pkg/plugin/templates/gatewayapi/GatewayClass.tmpl
+++ b/pkg/plugin/templates/gatewayapi/GatewayClass.tmpl
@@ -10,10 +10,10 @@
     {{- with .Spec.parametersRef }}
         {{- if $.Config.GetBool "deep" }}
             {{- $ns := coalesce .namespace $.Namespace }}
-            {{- $obj := $.KubeGetFirst $ns .kind .name }}
+            {{- $obj := $.KubeGetFirst $ns (qualifyKind .kind .group) .name }}
             {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 4 }}{{ end }}
         {{- else }}
-            {{- "Parameters" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace) }}
+            {{- "Parameters" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" .kind "name" .name "namespace" .namespace "group" .group) }}
         {{- end }}
     {{- end }}
     {{- with .Spec.description }}

--- a/pkg/plugin/templates/istio/VirtualService.tmpl
+++ b/pkg/plugin/templates/istio/VirtualService.tmpl
@@ -25,7 +25,8 @@
            silently picks one -- on a cluster running both, the Gateway API's wins, so a
            "no such Gateway" check here would report every healthy Istio Gateway as missing.
            See #789; naming the ref without claiming anything about it is correct under either
-           resolution. */ -}}
+           resolution. The ref is printed group-qualified for the same reason: on such a cluster
+           a bare "Gateway/foo" is genuinely ambiguous to the reader too. */ -}}
     {{- with .Spec.gateways }}
         {{- "Gateways" | bold | nindent 2 }}:
         {{- $single := eq (len .) 1 }}
@@ -38,7 +39,7 @@
                 {{- $parts := . | toString | splitList "/" }}
                 {{- $gwNs := $.Namespace }}{{ $gwName := . | toString }}
                 {{- if eq (len $parts) 2 }}{{ $gwNs = index $parts 0 }}{{ $gwName = index $parts 1 }}{{ end }}
-                {{- $entry = $.Include "resource_ref" (dict "kind" "Gateway" "name" $gwName "namespace" $gwNs "callerNamespace" $.Namespace) }}
+                {{- $entry = $.Include "resource_ref" (dict "kind" "Gateway" "name" $gwName "namespace" $gwNs "callerNamespace" $.Namespace "group" "networking.istio.io") }}
             {{- end }}
             {{- if $single }} {{ $entry }}{{ else }}{{ $entry | nindent 4 }}{{ end }}
         {{- end }}

--- a/pkg/plugin/templates/policy/gatekeeper_constraint_common.tmpl
+++ b/pkg/plugin/templates/policy/gatekeeper_constraint_common.tmpl
@@ -37,7 +37,7 @@
                -- no lookup needed to know the name, only to fetch the object itself in --deep. */ -}}
         {{- $ctName := . | lower }}
         {{- $.Include "resource_ref" (dict "kind" "ConstraintTemplate" "name" $ctName) | nindent 2 }}
-        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ConstraintTemplate" "name" $ctName) }}
+        {{- $.Include "deep_render_ref" (dict "ctx" $ "kind" "ConstraintTemplate" "name" $ctName "group" "templates.gatekeeper.sh") }}
     {{- end }}
     {{- with .Spec.match }}
         {{- /* .kinds is optional -- matching by namespaces/namespaceSelector alone is valid, and

--- a/pkg/plugin/templates/prometheus/PrometheusRule.tmpl
+++ b/pkg/plugin/templates/prometheus/PrometheusRule.tmpl
@@ -70,10 +70,10 @@
                 {{- else if eq .resource "thanosrulers" }}{{ $kind = "ThanosRuler" }}
                 {{- else if eq .resource "alertmanagers" }}{{ $kind = "Alertmanager" }}
                 {{- end }}
-                {{- $obj := $.KubeGetFirst .namespace $kind .name }}
+                {{- $obj := $.KubeGetFirst .namespace (qualifyKind $kind .group) .name }}
                 {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 4 }}{{ end }}
             {{- else }}
-                {{- $.Include "resource_ref" (dict "kind" .resource "name" .name "namespace" .namespace "callerNamespace" $.Namespace) | nindent 4 }}
+                {{- $.Include "resource_ref" (dict "kind" .resource "name" .name "namespace" .namespace "callerNamespace" $.Namespace "group" .group) | nindent 4 }}
             {{- end }}
         {{- end }}
     {{- end }}

--- a/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/HorizontalPodAutoscaler.tmpl
@@ -7,10 +7,10 @@
     {{- template "observed_generation_summary" . }}
     {{- with .Spec.scaleTargetRef }}
         {{- if $.Config.GetBool "deep" }}
-            {{- $obj := $.KubeGetFirst $.Namespace (.kind | default "Deployment") .name }}
+            {{- $obj := $.KubeGetFirst $.Namespace (qualifyKind (.kind | default "Deployment") .apiVersion) .name }}
             {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
         {{- else }}
-            {{- "Scales" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name) }}
+            {{- "Scales" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "group" .apiVersion) }}
         {{- end }}
     {{- end }}
     {{- $minReplicas := 1 }}{{- if .Spec | hasKey "minReplicas" }}{{- $minReplicas = .Spec.minReplicas | int }}{{- end }}

--- a/pkg/plugin/templates/workloads/Pod.tmpl
+++ b/pkg/plugin/templates/workloads/Pod.tmpl
@@ -678,7 +678,7 @@
             {{- if not $claimName }}
                 {{- $line = printf "%s: %s" ($podClaim.name | bold) ("not yet generated" | yellow) }}
             {{- else }}
-                {{- $line = printf "%s: %s" ($podClaim.name | bold) ($pod.Include "managed_resource_line" (dict "ctx" $pod "kind" "ResourceClaim" "name" $claimName "namespace" $pod.Namespace)) }}
+                {{- $line = printf "%s: %s" ($podClaim.name | bold) ($pod.Include "managed_resource_line" (dict "ctx" $pod "kind" "ResourceClaim" "name" $claimName "namespace" $pod.Namespace "group" "resource.k8s.io")) }}
             {{- end }}
             {{- $entries = $entries | append $line }}
         {{- end }}

--- a/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
+++ b/pkg/plugin/templates/workloads/VerticalPodAutoscaler.tmpl
@@ -7,10 +7,10 @@
     {{- template "observed_generation_summary" . }}
     {{- with .Spec.targetRef }}
         {{- if $.Config.GetBool "deep" }}
-            {{- $obj := $.KubeGetFirst $.Namespace (.kind | default "Deployment") .name }}
+            {{- $obj := $.KubeGetFirst $.Namespace (qualifyKind (.kind | default "Deployment") .apiVersion) .name }}
             {{- if $obj.Object }}{{ $.IncludeRenderableObject $obj | nindent 2 }}{{ end }}
         {{- else }}
-            {{- "Targets" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name) }}
+            {{- "Targets" | bold | nindent 2 }}: {{ $.Include "resource_ref" (dict "kind" (.kind | default "Deployment") "name" .name "group" .apiVersion) }}
         {{- end }}
     {{- end }}
     {{- $updateMode := (.Spec.updatePolicy | default dict).updateMode | default "Auto" }}

--- a/tests/artifacts/certificaterequest-ca-signed.out
+++ b/tests/artifacts/certificaterequest-ca-signed.out
@@ -1,5 +1,5 @@
 
-CertificateRequest/kubectl-status-server-1 -n default, created 1m ago by Certificate/kubectl-status-server, gen:1
+CertificateRequest/kubectl-status-server-1 -n default, created 1m ago by Certificate.cert-manager.io/kubectl-status-server, gen:1
   Current: Resource is Ready
   Requested by system:serviceaccount:cert-manager:cert-manager for Certificate/kubectl-status-server (rev 1)
     Via: Issuer/kubectl-status-ca-issuer (cert-manager.io)

--- a/tests/artifacts/certificaterequest-ca.out
+++ b/tests/artifacts/certificaterequest-ca.out
@@ -1,5 +1,5 @@
 
-CertificateRequest/kubectl-status-ca-1 -n default, created 1m ago by Certificate/kubectl-status-ca, gen:1
+CertificateRequest/kubectl-status-ca-1 -n default, created 1m ago by Certificate.cert-manager.io/kubectl-status-ca, gen:1
   Current: Resource is Ready
   Requested by system:serviceaccount:cert-manager:cert-manager for Certificate/kubectl-status-ca (rev 1)
     Via: Issuer/selfsigned-bootstrap (cert-manager.io)

--- a/tests/artifacts/certificaterequest-selfsigned.out
+++ b/tests/artifacts/certificaterequest-selfsigned.out
@@ -1,5 +1,5 @@
 
-CertificateRequest/kubectl-status-selfsigned-1 -n default, created 1m ago by Certificate/kubectl-status-selfsigned, gen:1
+CertificateRequest/kubectl-status-selfsigned-1 -n default, created 1m ago by Certificate.cert-manager.io/kubectl-status-selfsigned, gen:1
   Current: Resource is Ready
   Requested by system:serviceaccount:cert-manager:cert-manager for Certificate/kubectl-status-selfsigned (rev 1)
     Via: Issuer/kubectl-status-selfsigned-issuer (cert-manager.io)

--- a/tests/artifacts/crossplane-xr-composed-cross-group.out
+++ b/tests/artifacts/crossplane-xr-composed-cross-group.out
@@ -1,0 +1,6 @@
+
+XSecretHolder/holder-a -n e2e-cross-group-kind, created 1m ago, gen:1
+  Current: Resource is current
+  Composed resources:
+    Secret.keyvault.azure.m.upbound.io/shared-name
+    Secret/shared-name

--- a/tests/artifacts/crossplane-xr-composed-cross-group.yaml
+++ b/tests/artifacts/crossplane-xr-composed-cross-group.yaml
@@ -1,0 +1,17 @@
+apiVersion: tests.kubectl-status.io/v1alpha1
+kind: XSecretHolder
+metadata:
+  creationTimestamp: "2026-07-19T20:11:10Z"
+  generation: 1
+  name: holder-a
+  namespace: e2e-cross-group-kind
+  resourceVersion: "1144"
+  uid: 8f1c6a20-5d7e-4c1a-9f42-2b0d6e7a1c33
+spec:
+  resourceRefs:
+  - apiVersion: keyvault.azure.m.upbound.io/v1beta1
+    kind: Secret
+    name: shared-name
+  - apiVersion: v1
+    kind: Secret
+    name: shared-name

--- a/tests/artifacts/nodeclaim-healthy.out
+++ b/tests/artifacts/nodeclaim-healthy.out
@@ -1,5 +1,5 @@
 
-NodeClaim/default-abcde, created 1m ago by NodePool/default, gen:1
+NodeClaim/default-abcde, created 1m ago by NodePool.karpenter.sh/default, gen:1
   Current: Resource is Ready
   NodeClass: EC2NodeClass/default
   Capacity: m5.large (spot) in us-east-1a

--- a/tests/artifacts/nodeclaim-launch-failed.out
+++ b/tests/artifacts/nodeclaim-launch-failed.out
@@ -1,5 +1,5 @@
 
-NodeClaim/default-fghij, created 1m ago by NodePool/default, gen:1
+NodeClaim/default-fghij, created 1m ago by NodePool.karpenter.sh/default, gen:1
   InProgress: NodeClaim is not initialized
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default

--- a/tests/artifacts/nodeclaim-registration-failed.out
+++ b/tests/artifacts/nodeclaim-registration-failed.out
@@ -1,5 +1,5 @@
 
-NodeClaim/default-klmno, created 1m ago by NodePool/default, gen:1
+NodeClaim/default-klmno, created 1m ago by NodePool.karpenter.sh/default, gen:1
   InProgress: NodeClaim is not initialized
     Reconciling: NodeClaimNotInitialized, NodeClaim is not initialized
   NodeClass: EC2NodeClass/default

--- a/tests/artifacts/prometheusrule-with-bindings.out
+++ b/tests/artifacts/prometheusrule-with-bindings.out
@@ -4,5 +4,5 @@ PrometheusRule/platform-alerts -n monitoring, created 1m ago, gen:1
   Groups:
     platform.alerts: 2 alerts · 1 critical · 1 warning
   Bound to:
-    prometheuses/kube-prometheus
-    thanosrulers/thanos-ruler
+    prometheuses.monitoring.coreos.com/kube-prometheus
+    thanosrulers.monitoring.coreos.com/thanos-ruler

--- a/tests/artifacts/virtualservice-routing-problems.out
+++ b/tests/artifacts/virtualservice-routing-problems.out
@@ -3,8 +3,8 @@ VirtualService/productpage -n bookinfo, created 1m ago, gen:11
   Current: Resource is current
   Hosts: bookinfo.example.com
   Gateways:
-    Gateway/bookinfo-gateway
-    Gateway/shared-gateway -n istio-system
+    Gateway.networking.istio.io/bookinfo-gateway
+    Gateway.networking.istio.io/shared-gateway -n istio-system
     mesh (sidecars)
   HTTP:
     retired when (uri=/legacy) or (uri prefix /v0/)

--- a/tests/e2e-artifacts/cross-group-kind-crds.yaml
+++ b/tests/e2e-artifacts/cross-group-kind-crds.yaml
@@ -1,0 +1,66 @@
+# Two CRDs whose only purpose is to reproduce a Kind name that exists in more than one API group:
+# "Secret" is the core Kubernetes Kind, and it is also a real provider Kind in Upbound's Azure
+# provider (secret.keyvault.azure.m.upbound.io). A reference naming just the Kind resolves through
+# discovery to the core one, which is how a Crossplane XR composing a provider Secret used to
+# render an unrelated core Secret's contents under the right name.
+#
+# XSecretHolder stands in for the XR: it needs no Crossplane installation at all, since
+# detectCrossplaneResource (pkg/plugin/default_resource_detectors.go) keys off a bare
+# spec.resourceRefs, which is exactly the field carrying the ambiguous reference.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: secrets.keyvault.azure.m.upbound.io
+spec:
+  group: keyvault.azure.m.upbound.io
+  names:
+    kind: Secret
+    listKind: SecretList
+    plural: secrets
+    singular: secret
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xsecretholders.tests.kubectl-status.io
+spec:
+  group: tests.kubectl-status.io
+  names:
+    kind: XSecretHolder
+    listKind: XSecretHolderList
+    plural: xsecretholders
+    singular: xsecretholder
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/tests/e2e-artifacts/cross-group-kind.regex
+++ b/tests/e2e-artifacts/cross-group-kind.regex
@@ -1,0 +1,7 @@
+\A
+XSecretHolder/holder-a -n e2e-cross-group-kind, created 1m ago, gen:1
+  Current: Resource is current
+  Composed resources:
+    Secret\.keyvault\.azure\.m\.upbound\.io/shared-name, created 1m ago, Current: Resource is current
+    Secret/shared-name, created 1m ago, Current: Resource is always ready
+\z

--- a/tests/e2e-artifacts/cross-group-kind.yaml
+++ b/tests/e2e-artifacts/cross-group-kind.yaml
@@ -1,0 +1,33 @@
+# Both objects deliberately share the name "shared-name" in the same namespace, so that resolving
+# the reference by Kind alone silently returns the wrong one instead of reporting it missing --
+# without the core Secret here, a regression back to the bare-Kind lookup would still make the
+# test pass, just for the wrong reason.
+# No metadata.namespace: applyManifestInNamespace supplies it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shared-name
+type: Opaque
+stringData:
+  core-only-key: core-value
+---
+apiVersion: keyvault.azure.m.upbound.io/v1beta1
+kind: Secret
+metadata:
+  name: shared-name
+spec:
+  forProvider:
+    name: shared-name
+---
+apiVersion: tests.kubectl-status.io/v1alpha1
+kind: XSecretHolder
+metadata:
+  name: holder-a
+spec:
+  resourceRefs:
+  - apiVersion: keyvault.azure.m.upbound.io/v1beta1
+    kind: Secret
+    name: shared-name
+  - apiVersion: v1
+    kind: Secret
+    name: shared-name

--- a/tests/e2e-artifacts/crossplane-xr-deep.regex
+++ b/tests/e2e-artifacts/crossplane-xr-deep.regex
@@ -4,7 +4,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
     Reconciling: Creating, Unready resources: blocked-workload, config
   Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
   Composed resources:
-    Deployment/probe-a-blocked -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a, gen:1 rev:1
+    Deployment/probe-a-blocked -n e2e-crossplane-xr, created 1m ago by XStatusProbe\.tests\.kubectl-status\.io/probe-a, gen:1 rev:1
       InProgress: Available: 0/1
         Reconciling: LessAvailable, Available: 0/1
       desired:1, existing:1, ready:0, updated:1, available:0, unavailable:1
@@ -42,7 +42,7 @@ XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
           Composition/status-probe, revision CompositionRevision/status-probe-[a-z0-9]+, update policy Automatic
           Composed resources:
             Deployment/probe-a-blocked\[e2e-crossplane-xr\] is already printed
-            ConfigMap/probe-a-config -n e2e-crossplane-xr, created 1m ago by XStatusProbe/probe-a
+            ConfigMap/probe-a-config -n e2e-crossplane-xr, created 1m ago by XStatusProbe\.tests\.kubectl-status\.io/probe-a
               Owners:
                 XStatusProbe/probe-a -n e2e-crossplane-xr, created 1m ago, gen:3
                   InProgress: Unready resources: blocked-workload, config


### PR DESCRIPTION
## The bug

A `Kind` is not a unique name. `Secret` exists in the core group **and** in `keyvault.azure.m.upbound.io` (Upbound's Azure provider); `Gateway` in both `gateway.networking.k8s.io` and `networking.istio.io`.

`KubeGet`/`KubeGetFirst` hand the type argument to `resource.Builder`, which resolves an unqualified Kind through discovery across every group and silently picks whichever wins the tie. Every reference site that already had the group was throwing it away — so a Crossplane XR composing a provider `Secret` rendered an unrelated **core** Secret's contents under the right name:

```
Composed resources:
  Secret/shared-name, created 17s ago, Current: Resource is always ready
  Secret/shared-name, created 17s ago, Current: Resource is always ready
```

Both lines are the same core Secret. After this change:

```
Composed resources:
  Secret.keyvault.azure.m.upbound.io/shared-name, created 17s ago, Current: Resource is current
  Secret/shared-name, created 17s ago, Current: Resource is always ready
```

The same drop happens in a Flux `Kustomization`'s `status.inventory` (the group is literally parsed out of the entry id and then discarded), a Helm release manifest's documents, Gateway API refs, HPA/VPA `scaleTargetRef`, a PV's `claimRef`, and Gatekeeper's generated Constraint kinds.

## The change

Two paired helpers in the new `pkg/plugin/apigroup.go`, both accepting a full `apiVersion`, a bare group, a bare version or nil:

- **`qualifyKind`** — the lookup form, always `Kind.group`. Absorbs the existing `qualifyKind` from `hostname.go`, which did the same job for Gateway API refs (#789) but only took an already-extracted group. The version is dropped even when the reference carries one, so a lookup follows the CRD's currently-preferred version rather than failing once the version recorded in an old reference stops being served.
- **`displayKind`** — the on-screen form, `Kind.group` only for a group Kubernetes doesn't serve itself. `Secret.keyvault.azure.m.upbound.io` is the whole point; `Deployment.apps` is noise, so built-in groups stay off screen and passing the group is always safe at every call site.

`resource_ref`, `managed_resource_line` and `deep_render_ref` gain an optional `"group"` dict key, so the TEMPLATE-API.md stable-name promise holds for external templates that don't pass it.

Also fixes two Kind-only comparisons this uncovered: the "already printed" dedup guard never fired for a Kind dispatched through a group-qualified template name, and `RenderableObject.String()` could name an object from a different group than the one printed.

## Deliberately left unqualified on screen

Documented in CONVENTIONS.md so they read as choices rather than misses:

- **An object's own header line** (`status_summary_line`) — nothing to disambiguate it against, the user asked for it by name. Qualifying it turned 57 artifacts into `Kustomization.kustomize.toolkit.fluxcd.io/podinfo` for no gain.
- **A Flux `spec.dependsOn` entry** — always the same Kind as the object whose header just printed it. Its `--deep` fetch is still group-qualified.
- **Flux's "Applied by" `Kustomization` ref** — `kustomize.config.k8s.io/Kustomization` is never a cluster object, so there is no real collision.

## Testing

- `pkg/plugin/apigroup_test.go`, plus new cases in `color_test.go`.
- New live e2e subtest (`cmd/e2e_crossplane_test.go`). It needs no Crossplane installation — `detectCrossplaneResource` keys off a bare `spec.resourceRefs` — and creates **both** same-named objects, so a regression back to the bare-Kind lookup fails it rather than passing for the wrong reason. Verified by reverting the fix and watching it fail.
- New offline artifact `tests/artifacts/crossplane-xr-composed-cross-group.{yaml,out}`, captured from live cluster objects, covering the display half.
- 8 existing `.out` files updated. Every diff is a reference that was previously ambiguous: `by NodePool.karpenter.sh/default`, `by Certificate.cert-manager.io/...`, `Gateway.networking.istio.io/bookinfo-gateway`, `prometheuses.monitoring.coreos.com/kube-prometheus`.

## Known follow-up

Under `--deep`, two composed Secrets from different groups still both render with the header `Secret/shared-name` — a consequence of the `status_summary_line` exclusion above. Default (non-`--deep`) rendering, which is the common path, is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fHVoW5Hw1yNmQc4HqTeTq
