### PR TITLE
fix: add retry to flaky e2e tests

### DIFF
--- a/cmd/e2e_clusterwide_test.go
+++ b/cmd/e2e_clusterwide_test.go
@@ -465,8 +465,9 @@ func TestE2EClusterWide(t *testing.T) {
 		waitForPodScheduleWindow(t, ns, "app="+podName)
 
 		cmdTest{
-			args:            []string{"pod/" + podName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/pod-wfc-topologies-unbound.regex",
+			args:                    []string{"pod/" + podName, "-n", ns, "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath:         "e2e-artifacts/pod-wfc-topologies-unbound.regex",
+			retryStdoutRegexFor:     30 * time.Second,
 		}.assert(t, nil, opts...)
 	})
 	t.Run("pod nodeSelector key no NodePool declares surfaces a Karpenter incompatibility, a satisfiable one stays silent", func(t *testing.T) {

--- a/cmd/e2e_clusterwide_test.go
+++ b/cmd/e2e_clusterwide_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"

--- a/cmd/e2e_rollout_test.go
+++ b/cmd/e2e_rollout_test.go
@@ -61,8 +61,9 @@ func runRolloutSubtests(t *testing.T, hackOpts []func(*plugin.RenderConfig), cli
 		// The order in which the two ReplicaSet revisions are diffed (and so which side
 		// gets "-" vs "+") isn't guaranteed, so the fixture alternates both directions.
 		cmdTest{
-			args:            []string{"deployment/" + name, "-n", ns, "--include-rollout-diffs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
-			stdoutRegexPath: "e2e-artifacts/rollout-diff.regex",
+			args:                    []string{"deployment/" + name, "-n", ns, "--include-rollout-diffs", "--include-events=false", "--include-managed-fields=false", "--v", "5"},
+			stdoutRegexPath:         "e2e-artifacts/rollout-diff.regex",
+			retryStdoutRegexFor:     30 * time.Second,
 		}.assert(t, nil, opts...)
 	})
 	t.Run("Rollouts section shows a single blocked rollout even without a second one to compare against", func(t *testing.T) {


### PR DESCRIPTION
Fixes two pre-existing flaky e2e tests by adding retryStdoutRegexFor (30s) to the cmdTest assertions:

1. **TestE2EClusterWide/Pod_hedges_on_an_unbound_WaitForFirstConsumer_PVC's_allowedTopologies** - WaitForFirstConsumer PVC provisioning timing variance; the test asserts output regex against a pod that may not be fully scheduled yet when the check runs

2. **TestE2EParallel/deployment_rollout_with_--include-rollout-diffs_shows_the_diff_between_revisions** - Rollout status check times out waiting for old replica termination; retry logic around the kubectl-status render

Both fixes use the existing  field in  (defined in ) which re-runs the command until its stdout matches the regex fixture.